### PR TITLE
fix: enable WhatsApp plugin before QR login + re-apply ESLint fixes

### DIFF
--- a/apps/frontend/src/components/chat/ChannelCards.tsx
+++ b/apps/frontend/src/components/chat/ChannelCards.tsx
@@ -14,6 +14,7 @@ import {
   ArrowLeft,
   MessageCircle,
 } from "lucide-react";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { useGatewayRpc, useGatewayRpcMutation } from "@/hooks/useGatewayRpc";
 
@@ -582,10 +583,13 @@ export function ChannelCards({ onDismiss }: ChannelCardsProps) {
                 </div>
                 {qrDataUrl && (
                   <div className="flex justify-center">
-                    <img
+                    <Image
                       src={qrDataUrl}
                       alt="WhatsApp QR Code"
-                      className="w-48 h-48 rounded border border-border"
+                      width={192}
+                      height={192}
+                      unoptimized
+                      className="rounded border border-border"
                     />
                   </div>
                 )}

--- a/apps/frontend/src/components/chat/ChannelSetupStep.tsx
+++ b/apps/frontend/src/components/chat/ChannelSetupStep.tsx
@@ -14,6 +14,7 @@ import {
   RefreshCw,
   AlertTriangle,
 } from "lucide-react";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { useGatewayRpc, useGatewayRpcMutation } from "@/hooks/useGatewayRpc";
 
@@ -552,10 +553,13 @@ export function ChannelSetupStep({ onComplete }: { onComplete: () => void }) {
                       </div>
                       {qrDataUrl && (
                         <div className="flex justify-center">
-                          <img
+                          <Image
                             src={qrDataUrl}
                             alt="WhatsApp QR Code"
-                            className="w-48 h-48 rounded border border-border"
+                            width={192}
+                            height={192}
+                            unoptimized
+                            className="rounded border border-border"
                           />
                         </div>
                       )}

--- a/apps/frontend/src/components/chat/ProvisioningStepper.tsx
+++ b/apps/frontend/src/components/chat/ProvisioningStepper.tsx
@@ -96,7 +96,7 @@ export function ProvisioningStepper({
       }
     }, 5000);
     return () => clearInterval(interval);
-  }, [phase]);
+  }, [phase, startTime]);
 
   // Ready — render children
   if (phase === "ready") {

--- a/apps/frontend/src/components/control/panels/ActionsPanel.tsx
+++ b/apps/frontend/src/components/control/panels/ActionsPanel.tsx
@@ -50,7 +50,7 @@ const PAIRING_CHANNELS = [
     idLabel: "Phone Number",
     idPlaceholder: "+1234567890",
     help: "Enter the full phone number with country code.",
-    validate: (_v: string) => null,
+    validate: () => null,
   },
 ];
 

--- a/apps/frontend/src/components/control/panels/AgentsPanel.tsx
+++ b/apps/frontend/src/components/control/panels/AgentsPanel.tsx
@@ -693,7 +693,6 @@ function AgentToolsTab({ agentId }: { agentId: string }) {
     | undefined;
 
   // Resolve effective profile: agent override > global > "full"
-  const serverProfile = agentToolsConfig?.profile ?? globalToolsConfig?.profile ?? "full";
   const serverAlsoAllow = agentToolsConfig?.alsoAllow ?? [];
   const serverDeny = agentToolsConfig?.deny ?? [];
 

--- a/apps/frontend/src/components/control/panels/ChannelsPanel.tsx
+++ b/apps/frontend/src/components/control/panels/ChannelsPanel.tsx
@@ -18,6 +18,7 @@ import {
   Eye,
   EyeOff,
 } from "lucide-react";
+import Image from "next/image";
 import { useGatewayRpc, useGatewayRpcMutation } from "@/hooks/useGatewayRpc";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -783,10 +784,13 @@ function ChannelCard({
       {isWhatsApp && qrDataUrl && (
         <div className="px-4 pb-3">
           <div className="rounded-md border border-border/60 bg-background p-4 flex flex-col items-center gap-3">
-            <img
+            <Image
               src={qrDataUrl}
               alt="WhatsApp QR Code"
-              className="w-48 h-48 rounded"
+              width={192}
+              height={192}
+              unoptimized
+              className="rounded"
             />
             <p className="text-xs text-muted-foreground text-center">
               Scan this QR code with WhatsApp on your phone
@@ -903,7 +907,6 @@ function ChannelCard({
 // ---------------------------------------------------------------------------
 
 function ChannelConfigForm({
-  channelId,
   fields,
   currentConfig,
   busy,

--- a/apps/frontend/src/components/control/panels/McpServersTab.tsx
+++ b/apps/frontend/src/components/control/panels/McpServersTab.tsx
@@ -35,7 +35,8 @@ const PLACEHOLDER_CONFIG = `{
   }
 }`;
 
-export function McpServersTab({ agentId: _agentId }: { agentId?: string }) {
+export function McpServersTab(props: { agentId?: string }) {
+  void props;
   const api = useApi();
   const [servers, setServers] = useState<Record<string, McpServer>>({});
   const [loading, setLoading] = useState(true);

--- a/apps/frontend/src/components/control/panels/SessionsPanel.tsx
+++ b/apps/frontend/src/components/control/panels/SessionsPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Loader2, RefreshCw, Trash2, MessageSquare } from "lucide-react";
+import { Loader2, RefreshCw, Trash2 } from "lucide-react";
 import { useGatewayRpc, useGatewayRpcMutation } from "@/hooks/useGatewayRpc";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/apps/frontend/src/components/control/panels/UsagePanel.tsx
+++ b/apps/frontend/src/components/control/panels/UsagePanel.tsx
@@ -241,7 +241,7 @@ export function UsagePanel() {
   }, [sessionsData]);
 
   // --- Categorize REST API by_model into LLM vs Tool ---
-  const { llmModels, toolModels, totalToolCost } = useMemo(() => {
+  const { toolModels, totalToolCost } = useMemo(() => {
     const models = usage?.by_model ?? [];
     const llm: ModelUsage[] = [];
     const tools: ModelUsage[] = [];

--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -223,7 +223,7 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
         clearPingInterval();
 
         // Reject all pending RPCs
-        for (const [id, pending] of pendingRpcsRef.current) {
+        for (const [, pending] of pendingRpcsRef.current) {
           clearTimeout(pending.timeout);
           pending.reject(new Error("WebSocket closed"));
         }


### PR DESCRIPTION
## Summary

- **WhatsApp QR fix**: `web.login.start` was failing with "web login provider is not available" because the WhatsApp Baileys plugin only registers its gateway methods when `enabled: true` in `openclaw.json`. The default config has it disabled. Now `handleWhatsAppQr` patches the config to enable WhatsApp and waits for the gateway restart before calling `web.login.start`. Skips the restart wait if already enabled (subsequent retries are instant).
- **ESLint fixes**: Re-applies 11 lint warnings that were on the feature branch but missed by the #49 squash merge — `<img>` → `<Image>` in ChannelSetupStep/ChannelCards/ChannelsPanel, unused var/import cleanup across 5 panel files, missing `startTime` dep in ProvisioningStepper `useEffect`, unused `id` binding in `useGateway`.

## Test plan
- [ ] Click "Show QR Code" in WhatsApp channel setup — should show a QR (no more "web login provider is not available" error)
- [ ] Scan the QR in WhatsApp \u2192 Linked Devices, click "I scanned it" — should connect
- [ ] CI/CD lint check passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)