### PR TITLE
fix: poll for gateway readiness after WhatsApp config.patch

### DIFF
--- a/apps/frontend/src/components/chat/ChannelSetupStep.tsx
+++ b/apps/frontend/src/components/chat/ChannelSetupStep.tsx
@@ -240,8 +240,19 @@ export function ChannelSetupStep({ onComplete }: { onComplete: () => void }) {
           raw: JSON.stringify({ channels: { whatsapp: { enabled: true, dmPolicy: "pairing" } } }),
           baseHash: snapshot.hash,
         });
-        // Wait for gateway to restart and load the WhatsApp plugin
-        await new Promise((r) => setTimeout(r, 4000));
+        // Poll until the gateway is back up after restarting (max 20s).
+        // A fixed sleep isn't reliable — ECS/EFS restarts can take 5–12s.
+        setWaMessage("Waiting for gateway to restart…");
+        const pollDeadline = Date.now() + 20_000;
+        while (Date.now() < pollDeadline) {
+          await new Promise((r) => setTimeout(r, 1500));
+          try {
+            await callRpc("config.get", undefined);
+            break; // Gateway responded — plugin is loaded
+          } catch {
+            // Still restarting, keep waiting
+          }
+        }
         setWaMessage(null);
       }
 


### PR DESCRIPTION
## Summary

- After `config.patch` enables WhatsApp, the OpenClaw gateway restarts. The previous 4s fixed wait was too short on ECS/EFS (restart takes 5–12s), causing `[Errno 111] Connect call failed` (ECONNREFUSED) when `web.login.start` fired too early.
- Replaced with a poll loop: calls `config.get` every 1.5s, proceeds as soon as the gateway responds, with a 20s hard timeout. The user sees "Waiting for gateway to restart…" while polling.

## Test plan
- [ ] Click "Show QR Code" in WhatsApp setup — should show status message then display QR (no more Errno 111 error)
- [ ] On subsequent clicks (WhatsApp already enabled), QR should appear immediately without the restart wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)