### PR TITLE
fix: increase RPC timeout for web.login.start and web.login.wait

### DIFF
--- a/apps/frontend/src/components/chat/ChannelSetupStep.tsx
+++ b/apps/frontend/src/components/chat/ChannelSetupStep.tsx
@@ -256,11 +256,13 @@ export function ChannelSetupStep({ onComplete }: { onComplete: () => void }) {
         setWaMessage(null);
       }
 
-      // Use force: true if a previous login failed (stale creds on disk)
+      // Use force: true if a previous login failed (stale creds on disk).
+      // Pass a 60s RPC timeout — the 30s OpenClaw-side timeout plus buffer
+      // for network latency so the frontend timer never races OpenClaw's.
       const res = await callRpc<WebLoginResult>("web.login.start", {
         force: waLoginFailed,
         timeoutMs: 30000,
-      });
+      }, 60000);
       setQrDataUrl(res.qrDataUrl ?? null);
       setWaMessage(res.message ?? null);
     } catch (err) {
@@ -283,9 +285,10 @@ export function ChannelSetupStep({ onComplete }: { onComplete: () => void }) {
       return next;
     });
     try {
+      // 130s RPC timeout = 120s OpenClaw wait + 10s network buffer
       const res = await callRpc<WebLoginResult>("web.login.wait", {
         timeoutMs: 120000,
-      });
+      }, 130000);
       if (res.connected) {
         setQrDataUrl(null);
         setWaMessage(null);

--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -66,7 +66,7 @@ interface GatewayContextValue {
   isConnected: boolean;
   error: string | null;
   reconnectAttempt: number;
-  sendReq: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+  sendReq: (method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<unknown>;
   sendChat: (agentId: string, message: string) => void;
   onEvent: (handler: (event: string, data: unknown) => void) => () => void;
   onChatMessage: (handler: (msg: ChatIncomingMessage) => void) => () => void;
@@ -287,7 +287,7 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
   // ---- sendReq ----
 
   const sendReq = useCallback(
-    async (method: string, params?: Record<string, unknown>): Promise<unknown> => {
+    async (method: string, params?: Record<string, unknown>, timeoutMs?: number): Promise<unknown> => {
       // Ensure connected — use event listener instead of polling
       if (wsRef.current?.readyState !== WebSocket.OPEN) {
         await connect();
@@ -320,7 +320,7 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
         const timeout = setTimeout(() => {
           pendingRpcsRef.current.delete(id);
           reject(new Error(`RPC timeout: ${method}`));
-        }, RPC_TIMEOUT_MS);
+        }, timeoutMs ?? RPC_TIMEOUT_MS);
 
         pendingRpcsRef.current.set(id, { resolve, reject, timeout });
 

--- a/apps/frontend/src/hooks/useGatewayRpc.ts
+++ b/apps/frontend/src/hooks/useGatewayRpc.ts
@@ -105,8 +105,9 @@ export function useGatewayRpcMutation() {
     async <T = unknown>(
       method: string,
       params?: Record<string, unknown>,
+      timeoutMs?: number,
     ): Promise<T> => {
-      return (await sendReq(method, params)) as T;
+      return (await sendReq(method, params, timeoutMs)) as T;
     },
     [sendReq],
   );


### PR DESCRIPTION
## Summary

The frontend `RPC_TIMEOUT_MS` (30s) and OpenClaw's `web.login.start` internal timeout (30s) were identical. The frontend timer would fire at exactly the same time OpenClaw was trying to return the QR, causing "RPC timeout: web.login.start" errors — seen both in the onboarding flow and when clicking Relink in the control panel.

**Changes:**
- Added optional `timeoutMs` parameter to `sendReq` in `useGateway.tsx` and threaded through `useGatewayRpcMutation`
- `web.login.start`: 60s frontend timeout (30s OpenClaw + 30s buffer)
- `web.login.wait`: 130s frontend timeout (120s OpenClaw + 10s buffer)

## Test plan
- [ ] Click "Show QR Code" or "Relink" in WhatsApp setup — QR should appear without timeout error
- [ ] After scanning, click "I scanned it" — should confirm connection without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)