### PR TITLE
fix: add startup command to CDK task definition for QMD and runtime deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 # Dependencies
 node_modules/
 .pnpm-store/

--- a/apps/infra/lib/stacks/container-stack.ts
+++ b/apps/infra/lib/stacks/container-stack.ts
@@ -183,9 +183,34 @@ export class ContainerStack extends cdk.Stack {
       executionRole: this.taskExecutionRole,
     });
 
+    // Startup command installs runtime dependencies before launching the
+    // OpenClaw gateway.  Mirrors the Terraform task definition in
+    // apps/terraform/modules/ecs/main.tf so both infra paths stay in sync.
+    const startupCommand = [
+      // System packages
+      "apt-get update -qq && apt-get install -y -qq socat python3-pip sqlite3 build-essential python3 > /dev/null 2>&1",
+      "pip install --break-system-packages websockets > /dev/null 2>&1",
+      // npm global prefix + PATH for the node user
+      "export NPM_CONFIG_PREFIX=/home/node/.npm-global && export PATH=$NPM_CONFIG_PREFIX/bin:$PATH",
+      // npm packages: MCP bridge, skill hub, OpenAI compat, QMD memory backend
+      "npm i -g --ignore-scripts mcporter clawhub openai 2>/dev/null",
+      "npm i -g @tobilu/qmd 2>/dev/null",
+      // GitHub CLI
+      'GH_VER=2.65.0 && wget -qO- https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_amd64.tar.gz | tar xz -C /tmp && cp /tmp/gh_${GH_VER}_linux_amd64/bin/gh $NPM_CONFIG_PREFIX/bin/gh 2>/dev/null',
+      // uv (Python package manager)
+      "wget -qO- https://astral.sh/uv/install.sh | HOME=/home/node sh 2>/dev/null && export PATH=/home/node/.local/bin:$PATH",
+      // Bundled skills
+      "clawhub install markdown-converter --no-input 2>/dev/null",
+      // Launch gateway
+      "exec node /app/openclaw.mjs gateway --port 18789 --bind lan",
+    ].join("; ");
+
     const openclawContainer = openclawTaskDef.addContainer("openclaw", {
       image: ecs.ContainerImage.fromRegistry("ghcr.io/openclaw/openclaw:latest"),
       essential: true,
+      command: ["sh", "-c", startupCommand],
+      user: "0:0",
+      workingDirectory: "/home/node",
       portMappings: [{ containerPort: 18789, protocol: ecs.Protocol.TCP }],
       logging: ecs.LogDrivers.awsLogs({
         logGroup: openclawLogGroup,


### PR DESCRIPTION
## Summary
- CDK `container-stack.ts` was missing the startup `command` that the Terraform task definition had
- Without it, `@tobilu/qmd` (and other runtime deps like mcporter, clawhub, gh, uv) were never installed in the container
- This caused QMD memory initialization to fail with `spawn /home/node/.npm-global/bin/qmd ENOENT`

## Changes
- Added the full startup command to the CDK task definition, matching `apps/terraform/modules/ecs/main.tf`
- Added `user: "0:0"` and `workingDirectory: "/home/node"` to match Terraform config

## Test plan
- [ ] Deploy to dev via CDK
- [ ] Reprovision a container (PATCH `/debug/provision`)
- [ ] Verify no `qmd ENOENT` errors in container logs
- [ ] Verify memory search works in chat UI

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)