### PR TITLE
fix: WhatsApp QR flow — ensure plugin loads, persist config on connect

### DIFF
--- a/apps/frontend/src/components/chat/ChannelCards.tsx
+++ b/apps/frontend/src/components/chat/ChannelCards.tsx
@@ -259,8 +259,39 @@ export function ChannelCards({ onDismiss }: ChannelCardsProps) {
       return next;
     });
     try {
-      // web.login.start is always available regardless of channels.whatsapp.enabled —
-      // the WhatsApp plugin registers its gateway methods unconditionally.
+      // The WhatsApp plugin only loads at gateway startup when channels.whatsapp has
+      // at least one config key beyond "enabled" (e.g. dmPolicy). Old containers
+      // provisioned before dmPolicy was added to the default config may only have
+      // { enabled: false }, causing the plugin to be absent from the registry — which
+      // makes web.login.start, web.login.wait, and channels.logout all fail.
+      // Patching dmPolicy for such containers triggers a gateway restart (channels.whatsapp
+      // has no reload rule when the plugin isn't registered) which loads the plugin.
+      const snapshot = configData as ConfigSnapshot | undefined;
+      const waConfig = (snapshot?.config as Record<string, Record<string, unknown>> | undefined)
+        ?.channels?.["whatsapp"] as Record<string, unknown> | undefined;
+      const pluginLikelyLoaded = waConfig != null && Object.keys(waConfig).some((k) => k !== "enabled");
+
+      if (!pluginLikelyLoaded && snapshot?.hash) {
+        setWaMessage("Preparing WhatsApp…");
+        await callRpc("config.patch", {
+          raw: JSON.stringify({ channels: { whatsapp: { dmPolicy: "pairing" } } }),
+          baseHash: snapshot.hash,
+        });
+        // Poll until the gateway is back up after the restart triggered by the patch.
+        setWaMessage("Waiting for gateway…");
+        const pollDeadline = Date.now() + 20_000;
+        while (Date.now() < pollDeadline) {
+          await new Promise((r) => setTimeout(r, 1500));
+          try {
+            await callRpc("config.get", undefined);
+            break; // Gateway is up
+          } catch {
+            // Still restarting
+          }
+        }
+        setWaMessage(null);
+      }
+
       // Pass a 60s frontend RPC timeout — the 30s OpenClaw-side timeout plus buffer.
       const res = await callRpc<WebLoginResult>("web.login.start", {
         force: waLoginFailed,

--- a/apps/frontend/src/components/control/panels/ChannelsPanel.tsx
+++ b/apps/frontend/src/components/control/panels/ChannelsPanel.tsx
@@ -332,6 +332,35 @@ export function ChannelsPanel() {
     setActionError(null);
     setLoginMessage(null);
     try {
+      // Ensure the WhatsApp plugin is loaded. The plugin only loads when channels.whatsapp
+      // has at least one key beyond "enabled". Old containers may only have { enabled: false },
+      // which means the plugin is absent — patching dmPolicy triggers a gateway restart that
+      // loads it (channels.whatsapp has no registered reload rule when the plugin is missing).
+      const snapshot = configData as ConfigSnapshot | undefined;
+      const waConfig = (snapshot?.config as Record<string, Record<string, unknown>> | undefined)
+        ?.channels?.["whatsapp"] as Record<string, unknown> | undefined;
+      const pluginLikelyLoaded = waConfig != null && Object.keys(waConfig).some((k) => k !== "enabled");
+
+      if (!pluginLikelyLoaded && snapshot?.hash) {
+        setLoginMessage("Preparing WhatsApp…");
+        await callRpc("config.patch", {
+          raw: JSON.stringify({ channels: { whatsapp: { dmPolicy: "pairing" } } }),
+          baseHash: snapshot.hash,
+        });
+        setLoginMessage("Waiting for gateway…");
+        const pollDeadline = Date.now() + 20_000;
+        while (Date.now() < pollDeadline) {
+          await new Promise((r) => setTimeout(r, 1500));
+          try {
+            await callRpc("config.get", undefined);
+            break;
+          } catch {
+            // Still restarting
+          }
+        }
+        setLoginMessage(null);
+      }
+
       // 60s frontend timeout = 30s OpenClaw QR timeout + 30s buffer
       const res = await callRpc<WebLoginResult>("web.login.start", {
         force,


### PR DESCRIPTION
## Summary

Root cause of both errors ("web login provider is not available" and "invalid channels.logout channel"):
The OpenClaw gateway uses normalizeAnyChannelId (plugin-registry lookup) for the channels.* and web.* RPC handlers. If the WhatsApp plugin is not registered, both web.login.start and channels.logout fail.

Why the plugin was not loading: The plugin only loads at startup when channels.whatsapp has at least one config key beyond "enabled" (hasMeaningfulChannelConfig). Old containers provisioned before dmPolicy was in the default config have only { enabled: false }, so the plugin never registers.

Fix: Before calling web.login.start, check if the current config has meaningful WhatsApp config. If not, patch dmPolicy:pairing — this triggers a gateway restart (no reload rule exists for channels.whatsapp when the plugin is not registered), after which the plugin loads and all RPCs work. For containers that already have dmPolicy, the check is a no-op.

Also fixes: after successful pairing, persist enabled:true and dmPolicy:pairing so the channel auto-starts on future gateway restarts. Remove unnecessary sleeps from 515 recovery. Add enabled:true to 515 recovery config patch.

## Files Changed

- apps/frontend/src/components/chat/ChannelCards.tsx — WhatsApp QR flow in onboarding
- apps/frontend/src/components/control/panels/ChannelsPanel.tsx — WhatsApp QR flow in control panel

## Test plan

- [ ] New container (has dmPolicy in config): Show QR button works immediately, no gateway restart
- [ ] Old container (only enabled:false): Show QR triggers "Preparing WhatsApp" then QR code displays after restart
- [ ] After scanning QR: channels.whatsapp.enabled is set to true in config
- [ ] Logout button no longer returns "invalid channels.logout channel"

Generated with [Claude Code](https://claude.com/claude-code)
