### PR TITLE
fix: add loopback to trustedProxies for agent internal tools

### DIFF
--- a/apps/backend/core/containers/config.py
+++ b/apps/backend/core/containers/config.py
@@ -241,7 +241,7 @@ def write_openclaw_config(
             "mode": "local",
             "bind": "lan",
             "auth": auth,
-            "trustedProxies": ["10.0.0.0/8"],
+            "trustedProxies": ["10.0.0.0/8", "127.0.0.1", "::1"],
             "controlUi": {
                 "enabled": False,
             },


### PR DESCRIPTION
Adds 127.0.0.1 and ::1 to trustedProxies so agent internal tools (gateway config, sessions, cron, memory) can connect via loopback. Per OpenClaw docs.

Existing containers need re-provisioning (PATCH /debug/provision) to pick up the new config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)