### PR TITLE
feat: add legal/support pages and fix footer links

### DIFF
--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -584,3 +584,317 @@ button:focus-visible { border-radius: 999px; }
   .wf-seq .wf-task, .wf-seq .wf-conn-line, .wf-seq .wf-conn-badge { opacity: 1 !important; transform: none !important; }
   .wf-seq .wf-check svg path { stroke-dashoffset: 0 !important; }
 }
+
+/* ═══════════════════════════════════════════════
+   LEGAL / SUPPORT PAGE STYLES
+   ═══════════════════════════════════════════════ */
+
+.legal-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #faf7f2;
+  color: #1a1a1a;
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
+  line-height: 1.7;
+}
+
+.legal-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 960px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px 24px;
+}
+
+.legal-logo-link {
+  display: inline-flex;
+  text-decoration: none;
+}
+
+.legal-btn-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #06402B;
+  background: transparent;
+  border: 2px solid #06402B;
+  border-radius: 999px;
+  padding: 8px 20px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 200ms ease-out, color 200ms ease-out;
+}
+
+.legal-btn-back:hover {
+  background: #06402B;
+  color: #fff;
+}
+
+.legal-divider {
+  border: none;
+  border-top: 1px solid #e0dbd0;
+  max-width: 960px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.legal-content {
+  flex: 1;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+  width: 100%;
+}
+
+.legal-content h1 {
+  font-family: var(--font-lora-serif), 'Lora', serif;
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: #06402B;
+  margin-bottom: 8px;
+  line-height: 1.3;
+}
+
+.legal-content h2 {
+  font-family: var(--font-lora-serif), 'Lora', serif;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #06402B;
+  margin-top: 40px;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #e0dbd0;
+}
+
+.legal-meta {
+  font-size: 14px;
+  color: #555;
+  margin-bottom: 40px;
+}
+
+.legal-content p {
+  margin-bottom: 16px;
+}
+
+.legal-content ul,
+.legal-content ol {
+  margin-bottom: 16px;
+  padding-left: 24px;
+}
+
+.legal-content li {
+  margin-bottom: 8px;
+}
+
+.legal-content li::marker {
+  color: #06402B;
+}
+
+.legal-content strong {
+  font-weight: 600;
+}
+
+.legal-content a {
+  color: #06402B;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.legal-content a:hover {
+  opacity: 0.8;
+}
+
+.legal-tier-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0 24px;
+  font-size: 15px;
+}
+
+.legal-tier-table th,
+.legal-tier-table td {
+  text-align: left;
+  padding: 10px 16px;
+  border: 1px solid #e0dbd0;
+}
+
+.legal-tier-table th {
+  background: #06402B;
+  color: #fff;
+  font-weight: 600;
+}
+
+.legal-tier-table td {
+  background: #fff;
+}
+
+.legal-footer {
+  border-top: 1px solid #e0dbd0;
+  padding: 32px 24px;
+  text-align: center;
+  font-size: 14px;
+  color: #555;
+}
+
+.legal-footer-links {
+  margin-top: 8px;
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+}
+
+.legal-footer-links a {
+  font-size: 14px;
+  color: #06402B;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.legal-footer-links a:hover {
+  text-decoration: underline;
+}
+
+/* ── Support page specifics ── */
+
+.support-content {
+  flex: 1;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 48px 24px 64px;
+  width: 100%;
+}
+
+.support-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.support-header h1 {
+  font-family: var(--font-lora-serif), 'Lora', serif;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #06402B;
+  margin-bottom: 8px;
+}
+
+.support-header p {
+  font-size: 1.05rem;
+  color: #5c5c5c;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.support-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.support-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.support-field label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.support-field input,
+.support-field select,
+.support-field textarea {
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
+  font-size: 16px;
+  color: #1a1a1a;
+  background: #fff;
+  border: 1px solid #e0dbd0;
+  border-radius: 12px;
+  padding: 12px 16px;
+  min-height: 44px;
+  transition: border-color 200ms ease-out, box-shadow 200ms ease-out;
+}
+
+.support-field input:focus,
+.support-field select:focus,
+.support-field textarea:focus {
+  outline: none;
+  border-color: #06402B;
+  box-shadow: 0 0 0 3px rgba(6, 64, 43, 0.15);
+}
+
+.support-field input::placeholder,
+.support-field textarea::placeholder {
+  color: #a0a0a0;
+}
+
+.support-field select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%235c5c5c' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+  padding-right: 40px;
+  cursor: pointer;
+}
+
+.support-field textarea {
+  min-height: 160px;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.support-submit {
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+  background: #06402B;
+  border: none;
+  border-radius: 999px;
+  padding: 14px 32px;
+  min-height: 48px;
+  cursor: pointer;
+  align-self: flex-start;
+  transition: background 200ms ease-out, transform 100ms ease-out;
+}
+
+.support-submit:hover {
+  background: #053822;
+}
+
+.support-submit:active {
+  transform: scale(0.98);
+}
+
+.support-direct {
+  margin-top: 40px;
+  text-align: center;
+  padding-top: 32px;
+  border-top: 1px solid #e0dbd0;
+  color: #5c5c5c;
+  font-size: 15px;
+}
+
+.support-direct a {
+  color: #06402B;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.support-direct a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+  .legal-content h1,
+  .support-header h1 { font-size: 1.75rem; }
+  .legal-content h2 { font-size: 1.15rem; }
+  .support-submit { width: 100%; text-align: center; }
+}

--- a/apps/frontend/src/app/privacy/page.tsx
+++ b/apps/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,146 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — isol8",
+  description: "How isol8 collects, uses, stores, and protects your personal information.",
+};
+
+function Logo() {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect width="40" height="40" rx="10" fill="#06402B" />
+      <text x="50%" y="54%" dominantBaseline="central" textAnchor="middle" fill="#ffffff" fontFamily="var(--font-lora-serif), 'Lora', serif" fontStyle="italic" fontSize="24" fontWeight="700">8</text>
+    </svg>
+  );
+}
+
+export default function PrivacyPage() {
+  return (
+    <div className="legal-page">
+      <header className="legal-topbar">
+        <Link href="/" className="legal-logo-link" aria-label="isol8 home">
+          <Logo />
+        </Link>
+        <Link href="/" className="legal-btn-back">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M10 12L6 8L10 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Back
+        </Link>
+      </header>
+
+      <hr className="legal-divider" />
+
+      <main className="legal-content">
+        <h1>Privacy Policy</h1>
+        <p className="legal-meta">Effective date: March 24, 2026 &middot; Last updated: March 24, 2026</p>
+
+        <h2>1. Introduction</h2>
+        <p>Welcome to isol8. isol8 Inc. (&ldquo;isol8,&rdquo; &ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) operates an AI agent hosting platform that provides users with dedicated, isolated containers for running AI agents. This Privacy Policy explains how we collect, use, store, and protect your personal information when you use our platform and services.</p>
+        <p>By accessing or using isol8, you agree to the practices described in this Privacy Policy. If you do not agree, please discontinue use of our services.</p>
+
+        <h2>2. Information We Collect</h2>
+        <p>We collect the following categories of information:</p>
+        <ul>
+          <li><strong>Account Information:</strong> When you create an account, we collect your name, email address, and authentication credentials through our identity provider, Clerk. This includes your user ID and profile metadata.</li>
+          <li><strong>Usage Data:</strong> We collect information about how you interact with the platform, including session activity, feature usage, API call frequency, and container resource consumption.</li>
+          <li><strong>Agent Interaction Data:</strong> Messages you send to and receive from your AI agents, agent configuration settings, installed skills, and workspace files stored within your isolated environment.</li>
+          <li><strong>Billing Information:</strong> Payment details are collected and processed by Stripe. We store your Stripe customer ID, subscription tier, and usage-based billing records. We do not directly store credit card numbers.</li>
+          <li><strong>Technical Data:</strong> IP addresses, browser type, device information, and connection metadata required to maintain your WebSocket sessions.</li>
+        </ul>
+
+        <h2>3. How We Use Your Information</h2>
+        <p>We use the information we collect to:</p>
+        <ul>
+          <li><strong>Provide and operate the service:</strong> Provision your dedicated containers, maintain WebSocket connections, execute agent interactions, and deliver platform functionality.</li>
+          <li><strong>Process billing:</strong> Calculate usage-based charges, manage subscriptions, process payments through Stripe, and maintain accurate billing records.</li>
+          <li><strong>Improve the platform:</strong> Analyze aggregate usage patterns to improve performance, reliability, and user experience. We use anonymized and aggregated data for this purpose.</li>
+          <li><strong>Ensure security:</strong> Detect and prevent fraud, abuse, and unauthorized access to your account and containers.</li>
+          <li><strong>Communicate with you:</strong> Send service-related notifications, respond to support requests, and provide important updates about your account or our policies.</li>
+        </ul>
+
+        <h2>4. Data Storage &amp; Security</h2>
+        <p>We take the security of your data seriously and employ industry-standard measures to protect it:</p>
+        <ul>
+          <li><strong>Infrastructure:</strong> Our platform runs on Amazon Web Services (AWS) infrastructure, leveraging their enterprise-grade physical and network security controls.</li>
+          <li><strong>Encryption at rest:</strong> All stored data, including database contents, file system volumes, and secrets, is encrypted at rest using AWS KMS-managed encryption keys.</li>
+          <li><strong>Encryption in transit:</strong> All data transmitted between your browser and our servers, and between internal services, is encrypted using TLS.</li>
+          <li><strong>Per-user isolation:</strong> Each user receives a dedicated, isolated container environment on AWS ECS Fargate. Your agent workspaces are stored on dedicated EFS access points, ensuring complete separation from other users&rsquo; data.</li>
+          <li><strong>Secrets management:</strong> Sensitive credentials and API keys are stored using AWS Secrets Manager with envelope encryption.</li>
+        </ul>
+
+        <h2>5. AI &amp; Agent Data</h2>
+        <p>Your interactions with AI agents are treated with special care:</p>
+        <ul>
+          <li><strong>Conversation storage:</strong> Agent conversations are stored within your per-user isolated workspace. Only you (and authorized platform systems required for operation) can access this data.</li>
+          <li><strong>No model training:</strong> Your agent conversations, workspace files, and interaction data are <strong>not</strong> used to train, fine-tune, or improve any AI or machine learning models. Your data remains yours.</li>
+          <li><strong>User control:</strong> You retain full control over your agent data. You can view, manage, and delete agent memory, conversation history, and workspace files at any time through the platform interface.</li>
+          <li><strong>LLM inference:</strong> When your agents use AI models, prompts are sent to the inference provider (e.g., AWS Bedrock) for real-time processing only. These providers process requests under their enterprise terms, which prohibit using your data for model training.</li>
+        </ul>
+
+        <h2>6. Third-Party Services</h2>
+        <p>We rely on the following third-party services to operate our platform. Each has its own privacy policy governing data handling:</p>
+        <ul>
+          <li><strong>Clerk</strong> — Authentication, user identity management, and session handling.</li>
+          <li><strong>Stripe</strong> — Payment processing, subscription management, and usage-based billing.</li>
+          <li><strong>Amazon Web Services (AWS)</strong> — Cloud infrastructure, container orchestration, file storage, and secrets management.</li>
+          <li><strong>AWS Bedrock</strong> — Large language model inference for AI agent capabilities, operating under AWS&rsquo;s enterprise data processing terms.</li>
+        </ul>
+        <p>We do not sell your personal information to any third party.</p>
+
+        <h2>7. Data Retention</h2>
+        <p>We retain your personal information for as long as your account remains active and as needed to provide our services. Specifically:</p>
+        <ul>
+          <li><strong>Active accounts:</strong> Your data, including agent workspaces, conversation history, and configuration, is maintained for the duration of your account.</li>
+          <li><strong>Account deletion:</strong> When you delete your account, we initiate deletion of your personal data, agent workspaces, container resources, and associated records. This process is completed within 30 days, except where retention is required by law.</li>
+          <li><strong>Billing records:</strong> Transaction and billing records may be retained for up to 7 years as required for tax, legal, and accounting compliance.</li>
+          <li><strong>Aggregated data:</strong> Anonymized, aggregated usage statistics that cannot identify individual users may be retained indefinitely for analytics purposes.</li>
+        </ul>
+
+        <h2>8. Your Rights</h2>
+        <p>Depending on your jurisdiction, you may have the following rights regarding your personal data:</p>
+        <ul>
+          <li><strong>Access:</strong> Request a copy of the personal data we hold about you.</li>
+          <li><strong>Correction:</strong> Request correction of any inaccurate or incomplete personal data.</li>
+          <li><strong>Deletion:</strong> Request deletion of your personal data and account, subject to legal retention requirements.</li>
+          <li><strong>Data export:</strong> Request a portable copy of your data, including agent configurations and workspace files.</li>
+          <li><strong>Restriction:</strong> Request restriction of processing of your personal data in certain circumstances.</li>
+          <li><strong>Objection:</strong> Object to processing of your personal data for specific purposes.</li>
+        </ul>
+        <p>To exercise any of these rights, please contact us at <a href="mailto:privacy@isol8.co">privacy@isol8.co</a>. We will respond to your request within 30 days.</p>
+
+        <h2>9. Cookies &amp; Tracking</h2>
+        <p>We use a minimal set of cookies and similar technologies:</p>
+        <ul>
+          <li><strong>Authentication tokens:</strong> Session cookies managed by Clerk to keep you signed in and secure your account.</li>
+          <li><strong>Essential cookies:</strong> Cookies strictly necessary for platform functionality, such as connection state and user preferences.</li>
+        </ul>
+        <p>We do <strong>not</strong> use third-party advertising trackers, social media tracking pixels, or cross-site analytics cookies. We do not participate in ad networks or sell tracking data.</p>
+
+        <h2>10. Children&rsquo;s Privacy</h2>
+        <p>isol8 is not intended for use by children under the age of 13. We do not knowingly collect personal information from children under 13. If we become aware that we have inadvertently collected data from a child under 13, we will take steps to delete that information promptly. If you believe a child under 13 has provided us with personal information, please contact us at <a href="mailto:privacy@isol8.co">privacy@isol8.co</a>.</p>
+
+        <h2>11. Changes to This Policy</h2>
+        <p>We may update this Privacy Policy from time to time to reflect changes in our practices, technologies, legal requirements, or other factors. When we make material changes, we will notify you by updating the &ldquo;Last updated&rdquo; date at the top of this page and, where appropriate, provide additional notice via email or an in-app notification.</p>
+        <p>We encourage you to review this Privacy Policy periodically. Your continued use of isol8 after any changes constitutes your acceptance of the updated policy.</p>
+
+        <h2>12. Contact Us</h2>
+        <p>If you have any questions, concerns, or requests regarding this Privacy Policy or our data practices, please contact us:</p>
+        <ul>
+          <li><strong>Email:</strong> <a href="mailto:privacy@isol8.co">privacy@isol8.co</a></li>
+          <li><strong>Company:</strong> isol8 Inc.</li>
+        </ul>
+        <p>We are committed to resolving any privacy concerns promptly and transparently.</p>
+      </main>
+
+      <footer className="legal-footer">
+        <p>&copy; {new Date().getFullYear()} isol8 Inc. All rights reserved.</p>
+        <nav className="legal-footer-links">
+          <Link href="/terms">Terms of Service</Link>
+          <Link href="/support">Support</Link>
+        </nav>
+      </footer>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/support/page.tsx
+++ b/apps/frontend/src/app/support/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+function Logo() {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect width="40" height="40" rx="10" fill="#06402B" />
+      <text x="50%" y="54%" dominantBaseline="central" textAnchor="middle" fill="#ffffff" fontFamily="var(--font-lora-serif), 'Lora', serif" fontStyle="italic" fontSize="24" fontWeight="700">8</text>
+    </svg>
+  );
+}
+
+export default function SupportPage() {
+  const router = useRouter();
+
+  return (
+    <div className="legal-page">
+      <header className="legal-topbar">
+        <Link href="/" className="legal-logo-link" aria-label="isol8 home">
+          <Logo />
+        </Link>
+        <button onClick={() => router.back()} className="legal-btn-back" type="button">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M10 12L6 8L10 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Back
+        </button>
+      </header>
+
+      <hr className="legal-divider" />
+
+      <main className="support-content">
+        <div className="support-header">
+          <h1>Support</h1>
+          <p>We&rsquo;re here to help. Send us a message and we&rsquo;ll get back to you.</p>
+        </div>
+
+        <form className="support-form" action="mailto:support@isol8.co" method="POST" encType="text/plain">
+          <div className="support-field">
+            <label htmlFor="name">Name</label>
+            <input type="text" id="name" name="name" required autoComplete="name" placeholder="Your name" />
+          </div>
+
+          <div className="support-field">
+            <label htmlFor="email">Email</label>
+            <input type="email" id="email" name="email" required autoComplete="email" placeholder="you@example.com" />
+          </div>
+
+          <div className="support-field">
+            <label htmlFor="subject">Subject</label>
+            <select id="subject" name="subject" required defaultValue="">
+              <option value="" disabled>Select a topic</option>
+              <option value="Bug report">Bug report</option>
+              <option value="Feature request">Feature request</option>
+              <option value="Billing question">Billing question</option>
+              <option value="Account issue">Account issue</option>
+              <option value="GooseTown">GooseTown</option>
+              <option value="Other">Other</option>
+            </select>
+          </div>
+
+          <div className="support-field">
+            <label htmlFor="message">Message</label>
+            <textarea id="message" name="message" required placeholder="Describe how we can help..." />
+          </div>
+
+          <button type="submit" className="support-submit">Send message</button>
+        </form>
+
+        <div className="support-direct">
+          <p>You can also reach us directly at <a href="mailto:support@isol8.co">support@isol8.co</a></p>
+        </div>
+      </main>
+
+      <footer className="legal-footer">
+        <p>&copy; {new Date().getFullYear()} isol8 Inc. All rights reserved.</p>
+        <nav className="legal-footer-links">
+          <Link href="/privacy">Privacy Policy</Link>
+          <Link href="/terms">Terms</Link>
+        </nav>
+      </footer>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/terms/page.tsx
+++ b/apps/frontend/src/app/terms/page.tsx
@@ -1,0 +1,158 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service — isol8",
+  description: "Terms of Service for the isol8 AI agent platform.",
+};
+
+function Logo() {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect width="40" height="40" rx="10" fill="#06402B" />
+      <text x="50%" y="54%" dominantBaseline="central" textAnchor="middle" fill="#ffffff" fontFamily="var(--font-lora-serif), 'Lora', serif" fontStyle="italic" fontSize="24" fontWeight="700">8</text>
+    </svg>
+  );
+}
+
+export default function TermsPage() {
+  return (
+    <div className="legal-page">
+      <header className="legal-topbar">
+        <Link href="/" className="legal-logo-link" aria-label="isol8 home">
+          <Logo />
+        </Link>
+        <Link href="/" className="legal-btn-back">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M10 12L6 8L10 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Back
+        </Link>
+      </header>
+
+      <hr className="legal-divider" />
+
+      <main className="legal-content">
+        <h1>Terms of Service</h1>
+        <p className="legal-meta">Effective date: March 24, 2026 &middot; Last updated: March 24, 2026</p>
+
+        <h2>1. Acceptance of Terms</h2>
+        <p>By accessing or using the isol8 platform (&ldquo;Service&rdquo;), operated by isol8 Inc. (&ldquo;isol8,&rdquo; &ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;), you (&ldquo;User&rdquo; or &ldquo;you&rdquo;) agree to be bound by these Terms of Service (&ldquo;Terms&rdquo;). If you do not agree, you may not use the Service.</p>
+        <p>These Terms constitute a legally binding agreement between you and isol8 Inc. Your continued use of the Service following the posting of any changes to these Terms constitutes acceptance of those changes.</p>
+
+        <h2>2. Description of Service</h2>
+        <p>isol8 is an AI agent hosting platform that provides each user with a dedicated, isolated compute container running persistent AI agents. Key features of the Service include:</p>
+        <ul>
+          <li><strong>Per-user containers:</strong> Each user receives their own isolated ECS Fargate container with a persistent workspace for agent configuration, data, and state.</li>
+          <li><strong>Persistent agents:</strong> AI agents run continuously within your container, maintaining context and state across sessions.</li>
+          <li><strong>Real-time interaction:</strong> WebSocket-based communication enables real-time streaming of agent responses and tool use.</li>
+          <li><strong>Multi-channel support:</strong> Agents can be connected to third-party messaging platforms such as Telegram, Discord, and WhatsApp.</li>
+          <li><strong>LLM inference:</strong> The platform provides access to large language models via AWS Bedrock for agent reasoning and generation.</li>
+        </ul>
+
+        <h2>3. Account Registration</h2>
+        <p>To use the Service, you must create an account through our authentication provider, Clerk. By registering, you agree to:</p>
+        <ul>
+          <li>Provide accurate, current, and complete information during registration.</li>
+          <li>Maintain the security of your account credentials and not share them with any third party.</li>
+          <li>Promptly notify isol8 of any unauthorized use of your account.</li>
+          <li>Accept responsibility for all activities that occur under your account.</li>
+        </ul>
+        <p>You must be at least 18 years of age to create an account. isol8 reserves the right to refuse registration or terminate accounts at its discretion.</p>
+
+        <h2>4. Subscription &amp; Billing</h2>
+        <p>The Service offers the following subscription tiers:</p>
+        <table className="legal-tier-table">
+          <thead>
+            <tr><th>Plan</th><th>Monthly Budget</th><th>Details</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Free</td><td>$2</td><td>No subscription required. Usage capped at $2 of compute per month.</td></tr>
+            <tr><td>Starter</td><td>$25</td><td>Fixed monthly subscription plus usage-based metering.</td></tr>
+            <tr><td>Pro</td><td>$75</td><td>Fixed monthly subscription plus usage-based metering.</td></tr>
+          </tbody>
+        </table>
+        <p>Billing is processed through Stripe. By subscribing to a paid plan, you authorize isol8 to charge your payment method on a recurring basis.</p>
+        <p><strong>Usage-based metering:</strong> Compute and inference usage is tracked and billed based on actual consumption. A markup of 1.4x is applied to the base cost of model inference and compute resources to cover platform infrastructure and operational costs.</p>
+        <p>You may upgrade, downgrade, or cancel your subscription at any time through the billing portal. Downgrades and cancellations take effect at the end of the current billing period. Refunds are not provided for partial billing periods.</p>
+
+        <h2>5. Acceptable Use</h2>
+        <p>You agree not to use the Service to:</p>
+        <ul>
+          <li>Engage in any illegal activity or facilitate unlawful conduct.</li>
+          <li>Abuse compute resources, including but not limited to cryptocurrency mining, denial-of-service attacks, or resource-exhaustion attacks.</li>
+          <li>Circumvent or attempt to circumvent usage limits, billing mechanisms, or rate-limiting controls.</li>
+          <li>Deploy agents that engage in harassment, generate harmful or deceptive content, or distribute malware.</li>
+          <li>Attempt to access other users&rsquo; containers, workspaces, or data.</li>
+          <li>Reverse engineer, decompile, or disassemble any part of the Service.</li>
+          <li>Use the Service in any manner that could damage, disable, or impair the platform&rsquo;s infrastructure.</li>
+        </ul>
+        <p>isol8 reserves the right to suspend or terminate your account immediately if we determine, in our sole discretion, that you have violated this section.</p>
+
+        <h2>6. AI Agent Conduct</h2>
+        <p>You are solely responsible for the actions, outputs, and behavior of the AI agents you configure and deploy on the platform. This includes:</p>
+        <ul>
+          <li><strong>Compliance:</strong> Your agents must comply with all applicable laws, regulations, and third-party API terms of service.</li>
+          <li><strong>Supervision:</strong> You must monitor your agents and ensure they operate within the bounds of their intended purpose.</li>
+          <li><strong>Financial transactions:</strong> Agents must not execute autonomous financial transactions without appropriate human-in-the-loop safeguards and explicit user confirmation mechanisms.</li>
+          <li><strong>Third-party interactions:</strong> When your agents interact with external services, you are responsible for ensuring those interactions comply with the respective service&rsquo;s terms of use.</li>
+        </ul>
+        <p>isol8 does not endorse, verify, or assume liability for any content generated by or actions taken by your AI agents.</p>
+
+        <h2>7. Intellectual Property</h2>
+        <p><strong>Platform ownership:</strong> The isol8 platform, including its software, design, documentation, branding, and infrastructure, is the exclusive property of isol8 Inc. and is protected by intellectual property laws.</p>
+        <p><strong>User content:</strong> You retain all rights to the content you upload, configure, or input into the Service, including agent configurations, prompts, and data files.</p>
+        <p><strong>Agent outputs:</strong> Content generated by your AI agents belongs to you, subject to the terms of the underlying model providers. isol8 does not claim ownership of agent-generated outputs.</p>
+
+        <h2>8. Data &amp; Privacy</h2>
+        <p>Your privacy is important to us. Our collection, use, and protection of your personal data is governed by our <Link href="/privacy">Privacy Policy</Link>, which is incorporated into these Terms by reference.</p>
+        <p>By using the Service, you acknowledge that your data, including agent configurations and conversation history, is stored in your isolated container workspace and in our database systems. We employ encryption at rest and in transit to protect your data.</p>
+
+        <h2>9. Third-Party Services</h2>
+        <p>The Service integrates with and relies upon the following third-party services, each of which is subject to its own terms and conditions:</p>
+        <ul>
+          <li><strong>OpenClaw:</strong> Open-source AI agent framework powering your containers.</li>
+          <li><strong>AWS Bedrock:</strong> Large language model inference provider.</li>
+          <li><strong>Clerk:</strong> Authentication and user management.</li>
+          <li><strong>Stripe:</strong> Payment processing and subscription management.</li>
+        </ul>
+        <p>isol8 is not responsible for the availability, accuracy, or performance of third-party services.</p>
+
+        <h2>10. Service Availability</h2>
+        <p>isol8 strives to maintain high availability of the Service but provides it on a &ldquo;best effort&rdquo; basis. We do not guarantee uninterrupted or error-free operation.</p>
+        <ul>
+          <li>Scheduled maintenance windows may result in temporary service interruptions. We will endeavor to provide reasonable advance notice.</li>
+          <li>Unplanned outages may occur due to infrastructure failures, upstream provider issues, or other unforeseen circumstances.</li>
+          <li>isol8 does not provide service-level agreements (SLAs) for uptime unless separately agreed upon in writing.</li>
+        </ul>
+
+        <h2>11. Limitation of Liability</h2>
+        <p>TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, ISOL8 INC., ITS OFFICERS, DIRECTORS, EMPLOYEES, AND AGENTS SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR RELATED TO YOUR USE OF THE SERVICE.</p>
+        <p>IN NO EVENT SHALL ISOL8&rsquo;S TOTAL LIABILITY TO YOU FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THESE TERMS OR THE SERVICE EXCEED THE AMOUNT YOU PAID TO ISOL8 IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.</p>
+
+        <h2>12. Termination</h2>
+        <p><strong>By you:</strong> You may delete your account and terminate your use of the Service at any time. Upon account deletion, your container, workspace data, and agent configurations will be permanently destroyed after a 30-day grace period.</p>
+        <p><strong>By isol8:</strong> We may suspend or terminate your account immediately and without prior notice if you violate these Terms, engage in fraudulent activity, or pose a risk to the platform or other users.</p>
+        <p>Upon termination, your right to use the Service ceases immediately. Sections 7, 8, 11, and 13 survive termination.</p>
+
+        <h2>13. Governing Law</h2>
+        <p>These Terms shall be governed by and construed in accordance with the laws of the State of Delaware, United States, without regard to its conflict-of-law provisions. Any disputes arising under these Terms shall be subject to the exclusive jurisdiction of the state and federal courts located in Delaware.</p>
+
+        <h2>14. Changes to Terms</h2>
+        <p>isol8 reserves the right to modify these Terms at any time. When we make material changes, we will update the &ldquo;Last updated&rdquo; date at the top of this page and notify you via email or an in-app notification at least 30 days before the changes take effect.</p>
+
+        <h2>15. Contact</h2>
+        <p>If you have any questions about these Terms, please contact us at:</p>
+        <p><strong>isol8 Inc.</strong><br />Email: <a href="mailto:legal@isol8.co">legal@isol8.co</a></p>
+      </main>
+
+      <footer className="legal-footer">
+        <p>&copy; {new Date().getFullYear()} isol8 Inc. All rights reserved.</p>
+        <nav className="legal-footer-links">
+          <Link href="/privacy">Privacy Policy</Link>
+          <Link href="/support">Support</Link>
+        </nav>
+      </footer>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/landing/Footer.tsx
+++ b/apps/frontend/src/components/landing/Footer.tsx
@@ -6,9 +6,9 @@ export function Footer() {
       <div className="footer-inner">
         <span className="footer-logo">ISOL8</span>
         <div className="footer-links">
-          <Link href="#">Privacy Policy</Link>
-          <Link href="#">Terms of Service</Link>
-          <Link href="#">Twitter</Link>
+          <Link href="/privacy">Privacy Policy</Link>
+          <Link href="/terms">Terms of Service</Link>
+          <Link href="/support">Support</Link>
         </div>
         <span className="footer-copy">
           © {new Date().getFullYear()} isol8 Inc. All rights reserved.


### PR DESCRIPTION
## Summary
- Add `/privacy`, `/terms`, `/support` pages with branded legal styling (from PR #78)
- Add legal/support CSS to `globals.css`
- Fix Footer: replace dead `href="#"` links with `/privacy`, `/terms`, `/support`; replace Twitter with Support

## Test plan
- [ ] Visit `/privacy` — renders privacy policy with green branding
- [ ] Visit `/terms` — renders terms of service with tier table
- [ ] Visit `/support` — renders contact form
- [ ] Footer links navigate correctly
- [ ] Sign-up page Terms/Privacy links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)