### PR TITLE
feat: desktop app auth support

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -25,6 +25,7 @@ from routers import (
     container_rpc,
     control_ui_proxy,
     debug,
+    desktop_auth,
     integrations,
     proxy,
     settings_keys,
@@ -220,6 +221,8 @@ app.include_router(integrations.router, prefix="/api/v1", tags=["integrations"])
 
 # Debug routes (dev-only container provisioning)
 app.include_router(debug.router, prefix="/api/v1/debug", tags=["debug"])
+
+app.include_router(desktop_auth.router, prefix="/api/v1/auth", tags=["desktop"])
 
 
 @app.get(

--- a/apps/backend/routers/desktop_auth.py
+++ b/apps/backend/routers/desktop_auth.py
@@ -1,0 +1,59 @@
+"""
+Desktop app authentication via Clerk sign-in tokens.
+
+Creates a one-time sign-in token that the desktop app's WebView
+can consume to establish a Clerk session. This bridges the gap
+between the system browser (where OAuth/passkeys work) and the
+Tauri WKWebView (which needs its own Clerk session).
+"""
+
+import logging
+import os
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+
+from core.auth import AuthContext, get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["desktop"])
+
+CLERK_API_URL = "https://api.clerk.com/v1"
+
+
+@router.post("/desktop/sign-in-token")
+async def create_sign_in_token(
+    auth: AuthContext = Depends(get_current_user),
+):
+    """
+    Create a one-time Clerk sign-in token for the desktop app.
+
+    Called by the desktop-callback page after the user authenticates
+    via Google OAuth in the system browser. The token is sent to the
+    Tauri app via deep link, where the WebView consumes it to establish
+    its own Clerk session.
+    """
+    clerk_secret = os.getenv("CLERK_SECRET_KEY")
+    if not clerk_secret:
+        raise HTTPException(status_code=500, detail="CLERK_SECRET_KEY not configured")
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{CLERK_API_URL}/sign_in_tokens",
+            headers={
+                "Authorization": f"Bearer {clerk_secret}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "user_id": auth.user_id,
+                "expires_in_seconds": 60,
+            },
+        )
+
+    if resp.status_code != 200:
+        logger.error("Clerk sign-in token creation failed: %s %s", resp.status_code, resp.text)
+        raise HTTPException(status_code=502, detail="Failed to create sign-in token")
+
+    data = resp.json()
+    return {"token": data["token"]}

--- a/apps/frontend/src/app/auth/desktop-callback/page.tsx
+++ b/apps/frontend/src/app/auth/desktop-callback/page.tsx
@@ -3,6 +3,8 @@
 import { useAuth } from "@clerk/nextjs";
 import { useEffect, useState } from "react";
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api-dev.isol8.co/api/v1";
+
 export default function DesktopCallback() {
   const { isSignedIn, getToken } = useAuth();
   const [status, setStatus] = useState("Signing in...");
@@ -10,12 +12,40 @@ export default function DesktopCallback() {
   useEffect(() => {
     if (!isSignedIn) return;
 
-    getToken().then((token) => {
-      if (token) {
+    async function getSignInToken() {
+      try {
+        // Get a Clerk JWT for authenticating with our backend
+        const jwt = await getToken();
+        if (!jwt) return;
+
+        setStatus("Preparing desktop sign-in...");
+
+        // Ask our backend to create a one-time Clerk sign-in token
+        const resp = await fetch(`${API_URL}/auth/desktop/sign-in-token`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${jwt}`,
+            "Content-Type": "application/json",
+          },
+        });
+
+        if (!resp.ok) {
+          setStatus("Failed to create sign-in token. Please try again.");
+          return;
+        }
+
+        const data = await resp.json();
+
+        // Redirect to the desktop app with the sign-in token
         setStatus("Opening Isol8 desktop app...");
-        window.location.href = `isol8://auth?token=${encodeURIComponent(token)}`;
+        window.location.href = `isol8://auth?ticket=${encodeURIComponent(data.token)}`;
+      } catch (err) {
+        console.error("Desktop callback error:", err);
+        setStatus("Something went wrong. Please try again.");
       }
-    });
+    }
+
+    getSignInToken();
   }, [isSignedIn, getToken]);
 
   return (

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Host_Grotesk, DM_Sans, Lora, Press_Start_2P } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { DesktopAuthListener } from "@/components/DesktopAuthListener";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -56,6 +57,7 @@ export default function RootLayout({
           className={`${geistSans.variable} ${geistMono.variable} ${hostGrotesk.variable} ${dmSans.variable} ${lora.variable} ${pressStart2P.variable} antialiased`}
         >
           <ErrorBoundary>
+            <DesktopAuthListener />
             {children}
           </ErrorBoundary>
         </body>

--- a/apps/frontend/src/components/DesktopAuthListener.tsx
+++ b/apps/frontend/src/components/DesktopAuthListener.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useDesktopAuth } from "@/hooks/useDesktopAuth";
+
+/**
+ * Invisible component that listens for Clerk sign-in tickets
+ * from the Tauri desktop app. Must be inside ClerkProvider.
+ */
+export function DesktopAuthListener() {
+  useDesktopAuth();
+  return null;
+}

--- a/apps/frontend/src/components/chat/ChatLayout.tsx
+++ b/apps/frontend/src/components/chat/ChatLayout.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 
 import { ProvisioningStepper } from "@/components/chat/ProvisioningStepper";
 import { HealthIndicator } from "@/components/chat/HealthIndicator";
+import { useGateway } from "@/hooks/useGateway";
 import { useApi } from "@/lib/api";
 import { useAgents, type Agent } from "@/hooks/useAgents";
 import { useBilling } from "@/hooks/useBilling";
@@ -45,6 +46,7 @@ export function ChatLayout({
   const api = useApi();
   const { agents, defaultId, deleteAgent, createAgent } = useAgents();
   const { refresh: refreshBilling, account } = useBilling();
+  const { nodeConnected } = useGateway();
   const searchParams = useSearchParams();
 
   const [userSelectedId, setUserSelectedId] = useState<string | null>(null);
@@ -460,6 +462,27 @@ export function ChatLayout({
 
           {/* Health Indicator */}
           <HealthIndicator onRecoveryReprovision={() => setRecoveryTriggered(true)} />
+
+          {/* Node Status */}
+          {nodeConnected && (
+            <div style={{
+              padding: '4px 12px',
+              fontSize: '12px',
+              color: '#16a34a',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+            }}>
+              <span style={{
+                width: '6px',
+                height: '6px',
+                borderRadius: '50%',
+                backgroundColor: '#16a34a',
+                display: 'inline-block',
+              }} />
+              Local tools available
+            </div>
+          )}
 
           {/* Tab Switcher */}
           <div className="tab-switcher">

--- a/apps/frontend/src/hooks/useDesktopAuth.ts
+++ b/apps/frontend/src/hooks/useDesktopAuth.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useSignIn, useAuth } from "@clerk/nextjs";
+import { useEffect, useRef } from "react";
+
+/**
+ * Listens for Clerk sign-in tickets from the Tauri desktop app.
+ *
+ * When the user authenticates via Google OAuth in the system browser,
+ * the desktop-callback page creates a one-time Clerk sign-in token
+ * and sends it to the Tauri app via deep link (isol8://auth?ticket=...).
+ * Tauri emits an "auth:sign-in-ticket" event to the WebView.
+ * This hook consumes the ticket to establish a Clerk session in the WebView.
+ */
+export function useDesktopAuth() {
+  const { signIn, setActive } = useSignIn();
+  const { isSignedIn } = useAuth();
+  const consumingRef = useRef(false);
+
+  useEffect(() => {
+    // Only run in Tauri desktop app
+    const tauri = (window as any).__TAURI__;
+    if (!tauri?.event?.listen) return;
+    if (isSignedIn) return; // Already signed in, no need
+
+    let unlisten: (() => void) | null = null;
+
+    async function setup() {
+      const { listen } = tauri.event;
+
+      unlisten = await listen("auth:sign-in-ticket", async (event: { payload: string }) => {
+        const ticket = event.payload;
+        if (!ticket || !signIn || consumingRef.current) return;
+
+        consumingRef.current = true;
+        console.log("[desktop-auth] Consuming sign-in ticket...");
+
+        try {
+          const result = await signIn.create({
+            strategy: "ticket",
+            ticket,
+          });
+
+          if (result.status === "complete" && result.createdSessionId) {
+            await setActive({ session: result.createdSessionId });
+            console.log("[desktop-auth] Session activated, reloading...");
+            window.location.reload();
+          } else {
+            console.error("[desktop-auth] Unexpected sign-in status:", result.status);
+          }
+        } catch (err) {
+          console.error("[desktop-auth] Failed to consume ticket:", err);
+        } finally {
+          consumingRef.current = false;
+        }
+      });
+    }
+
+    setup();
+
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, [signIn, setActive, isSignedIn]);
+}

--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -77,6 +77,7 @@ interface PendingRpc {
 
 interface GatewayContextValue {
   isConnected: boolean;
+  nodeConnected: boolean;
   error: string | null;
   reconnectAttempt: number;
   sendReq: (method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<unknown>;
@@ -95,6 +96,7 @@ const GatewayContext = createContext<GatewayContextValue | null>(null);
 export function GatewayProvider({ children }: { children: ReactNode }) {
   const { getToken } = useAuth();
   const [isConnected, setIsConnected] = useState(false);
+  const [nodeConnected, setNodeConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reconnectAttempt, setReconnectAttempt] = useState(0);
 
@@ -176,6 +178,12 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    // Node status — update desktop node connection state
+    if (msgType === "node_status") {
+      setNodeConnected(data.status === "connected");
+      return;
+    }
+
     // Chat messages — dispatch to subscribers
     if (
       msgType === "chunk" ||
@@ -214,6 +222,11 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
     try {
       const token = await getToken();
       if (!token) throw new Error("Not authenticated");
+
+      // Post token to Electron main process for node-host auth
+      if (typeof window !== "undefined" && window.isol8?.isDesktop && token) {
+        window.isol8.sendAuthToken(token);
+      }
 
       const wsUrl = getWebSocketUrl();
       const ws = new WebSocket(`${wsUrl}?token=${token}`);
@@ -298,6 +311,17 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
       }
     };
   }, [connect, clearReconnectTimeout, clearPingInterval]);
+
+  // ---- Electron IPC: listen for node status from desktop app ----
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.isol8?.onNodeStatus) {
+      const unsubscribe = window.isol8.onNodeStatus((status) => {
+        setNodeConnected(status === "connected");
+      });
+      return unsubscribe;
+    }
+  }, []);
 
   // ---- sendReq ----
 
@@ -387,8 +411,8 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
   );
 
   const value = useMemo(
-    () => ({ isConnected, error, reconnectAttempt, sendReq, sendChat, onEvent, onChatMessage, reconnect }),
-    [isConnected, error, reconnectAttempt, sendReq, sendChat, onEvent, onChatMessage, reconnect],
+    () => ({ isConnected, nodeConnected, error, reconnectAttempt, sendReq, sendChat, onEvent, onChatMessage, reconnect }),
+    [isConnected, nodeConnected, error, reconnectAttempt, sendReq, sendChat, onEvent, onChatMessage, reconnect],
   );
 
   return (

--- a/apps/frontend/src/types/electron.d.ts
+++ b/apps/frontend/src/types/electron.d.ts
@@ -1,0 +1,9 @@
+interface Isol8Desktop {
+  isDesktop: boolean;
+  sendAuthToken: (jwt: string) => void;
+  onNodeStatus: (callback: (status: string) => void) => () => void;
+}
+
+interface Window {
+  isol8?: Isol8Desktop;
+}


### PR DESCRIPTION
## Summary
- DesktopAuthListener: consumes Clerk sign-in tickets from Tauri deep link
- Backend endpoint: `POST /api/v1/auth/desktop/sign-in-token` creates one-time Clerk sign-in token
- Desktop callback page: exchanges JWT for sign-in token, sends via `isol8://` deep link
- useGateway: posts Clerk JWT to Tauri, `nodeConnected` state
- ChatLayout: "Local tools available" indicator
- All changes are no-op on the web (check `window.__TAURI__` first)

## Test plan
- [ ] Verify web app works identically (no regressions)
- [ ] Verify desktop-callback page creates sign-in token
- [ ] Verify Tauri app consumes ticket and establishes Clerk session

🤖 Generated with [Claude Code](https://claude.com/claude-code)