### PR TITLE
fix: desktop auth callback flow

### DIFF
--- a/apps/frontend/src/app/auth/desktop-callback/page.tsx
+++ b/apps/frontend/src/app/auth/desktop-callback/page.tsx
@@ -1,26 +1,25 @@
 "use client";
 
-import { useAuth } from "@clerk/nextjs";
+import { useAuth, SignIn } from "@clerk/nextjs";
 import { useEffect, useState } from "react";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api-dev.isol8.co/api/v1";
 
 export default function DesktopCallback() {
-  const { isSignedIn, getToken } = useAuth();
+  const { isSignedIn, isLoaded, getToken } = useAuth();
   const [status, setStatus] = useState("Signing in...");
+  const [error, setError] = useState(false);
 
   useEffect(() => {
-    if (!isSignedIn) return;
+    if (!isLoaded || !isSignedIn) return;
 
     async function getSignInToken() {
       try {
-        // Get a Clerk JWT for authenticating with our backend
         const jwt = await getToken();
         if (!jwt) return;
 
         setStatus("Preparing desktop sign-in...");
 
-        // Ask our backend to create a one-time Clerk sign-in token
         const resp = await fetch(`${API_URL}/auth/desktop/sign-in-token`, {
           method: "POST",
           headers: {
@@ -30,30 +29,50 @@ export default function DesktopCallback() {
         });
 
         if (!resp.ok) {
-          setStatus("Failed to create sign-in token. Please try again.");
+          const text = await resp.text();
+          console.error("Sign-in token failed:", resp.status, text);
+          setStatus("Failed to create sign-in token.");
+          setError(true);
           return;
         }
 
         const data = await resp.json();
 
-        // Redirect to the desktop app with the sign-in token
         setStatus("Opening Isol8 desktop app...");
         window.location.href = `isol8://auth?ticket=${encodeURIComponent(data.token)}`;
       } catch (err) {
         console.error("Desktop callback error:", err);
-        setStatus("Something went wrong. Please try again.");
+        setStatus("Something went wrong.");
+        setError(true);
       }
     }
 
     getSignInToken();
-  }, [isSignedIn, getToken]);
+  }, [isLoaded, isSignedIn, getToken]);
+
+  // If not signed in, show the Clerk sign-in component.
+  // After sign-in, Clerk sets isSignedIn=true and the useEffect fires.
+  if (isLoaded && !isSignedIn) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <SignIn
+          forceRedirectUrl="/auth/desktop-callback"
+          appearance={{
+            elements: { rootBox: "mx-auto" },
+          }}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="flex justify-center items-center h-screen">
       <div className="text-center">
         <h1 className="text-xl font-semibold mb-2">{status}</h1>
         <p className="text-sm text-muted-foreground">
-          You can close this tab after the app opens.
+          {error
+            ? "Please close this tab and try again from the desktop app."
+            : "You can close this tab after the app opens."}
         </p>
       </div>
     </div>

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-const isProtectedRoute = createRouteMatcher(["/chat(.*)", "/auth/desktop-callback", "/onboarding", "/settings(.*)"]);
+const isProtectedRoute = createRouteMatcher(["/chat(.*)", "/onboarding", "/settings(.*)"]);
 
 export default clerkMiddleware(async (auth, req) => {
   const authObj = await auth();


### PR DESCRIPTION
## Summary
- Remove `/auth/desktop-callback` from middleware protection (page handles auth itself)
- Embed Clerk `<SignIn>` component with `forceRedirectUrl` on the callback page
- After sign-in completes, page creates sign-in token and deep links to `isol8://`

## Test plan
- [ ] Open desktop-callback in browser → shows sign-in
- [ ] Sign in with Google → redirects back to callback → deep links to app

🤖 Generated with [Claude Code](https://claude.com/claude-code)