### PR TITLE
feat: backend node-host proxy for desktop local tools

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -659,6 +659,12 @@ class GatewayConnectionPool:
         self._grace_tasks.pop(user_id, None)
         self._last_activity.pop(user_id, None)
 
+    async def broadcast_to_user(self, user_id: str, message: dict) -> None:
+        """Send a message to all frontend connections for a user."""
+        conn = self._connections.get(user_id)
+        if conn:
+            await conn._forward_to_frontends(message)
+
     async def close_all(self) -> None:
         """Shutdown: close all connections."""
         for user_id in list(self._connections.keys()):

--- a/apps/backend/core/gateway/node_connection.py
+++ b/apps/backend/core/gateway/node_connection.py
@@ -1,0 +1,111 @@
+"""
+Dedicated per-user upstream WebSocket for node connections.
+
+The OpenClaw gateway enforces one-role-per-connection, so node traffic
+cannot share the operator connection used by GatewayConnectionPool.
+This class manages a separate WebSocket to the container that connects
+with role:"node", enabling the gateway's NodeRegistry to register the
+node and route node.invoke requests to the user's Mac.
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+
+from websockets import connect as ws_connect
+
+logger = logging.getLogger(__name__)
+
+GATEWAY_PORT = 18789
+
+
+class NodeUpstreamConnection:
+    """Manages a single upstream WebSocket connection for a node."""
+
+    def __init__(
+        self,
+        user_id: str,
+        container_ip: str,
+        node_connect_params: dict,
+    ):
+        self.user_id = user_id
+        self.container_ip = container_ip
+        self.node_connect_params = node_connect_params
+        self._ws = None
+        self._connected = False
+        self._reader_task: asyncio.Task | None = None
+        self._on_message = None
+
+    async def connect(self) -> dict:
+        """Open upstream WS, complete handshake with role:node. Returns hello-ok."""
+        uri = f"ws://{self.container_ip}:{GATEWAY_PORT}"
+        self._ws = await ws_connect(
+            uri,
+            open_timeout=10,
+            close_timeout=5,
+            additional_headers={"x-forwarded-user": self.user_id},
+        )
+
+        # Step 1: receive connect.challenge
+        raw = await asyncio.wait_for(self._ws.recv(), timeout=10)
+        challenge = json.loads(raw)
+        if challenge.get("event") != "connect.challenge":
+            raise RuntimeError(f"Expected connect.challenge, got {challenge}")
+
+        # Step 2: send connect with role:node
+        req_id = str(uuid.uuid4())
+        connect_msg = {
+            "type": "req",
+            "id": req_id,
+            "method": "connect",
+            "params": {
+                "minProtocol": 3,
+                "maxProtocol": 3,
+                **self.node_connect_params,
+            },
+        }
+        await self._ws.send(json.dumps(connect_msg))
+
+        # Step 3: receive hello-ok
+        raw = await asyncio.wait_for(self._ws.recv(), timeout=10)
+        resp = json.loads(raw)
+        if not resp.get("ok"):
+            error = resp.get("error", {}).get("message", "unknown")
+            raise RuntimeError(f"Node handshake failed: {error}")
+
+        self._connected = True
+        logger.info("Node upstream connected for user %s", self.user_id)
+        return resp
+
+    def set_message_callback(self, callback) -> None:
+        """Set callback for messages from upstream (container -> node)."""
+        self._on_message = callback
+
+    async def start_reader(self) -> None:
+        """Start reading from upstream and forwarding to callback."""
+        self._reader_task = asyncio.create_task(self._reader_loop())
+
+    async def _reader_loop(self) -> None:
+        try:
+            async for raw in self._ws:
+                if self._on_message:
+                    data = json.loads(raw)
+                    await self._on_message(data)
+        except Exception as e:
+            logger.warning("Node upstream reader error for %s: %s", self.user_id, e)
+        finally:
+            self._connected = False
+
+    async def relay_to_upstream(self, message: dict) -> None:
+        """Forward a message from the node client to the container."""
+        if self._ws and self._connected:
+            await self._ws.send(json.dumps(message))
+
+    async def close(self) -> None:
+        self._connected = False
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._ws:
+            await self._ws.close()
+        logger.info("Node upstream closed for user %s", self.user_id)

--- a/apps/backend/core/services/connection_service.py
+++ b/apps/backend/core/services/connection_service.py
@@ -62,6 +62,7 @@ class ConnectionService:
         connection_id: str,
         user_id: str,
         org_id: Optional[str],
+        connection_type: str = "chat",
     ) -> None:
         """
         Store a new WebSocket connection mapping.
@@ -72,6 +73,7 @@ class ConnectionService:
             connection_id: API Gateway WebSocket connection ID
             user_id: Authenticated user's ID from Clerk JWT
             org_id: Organization ID from Clerk JWT (None for personal context)
+            connection_type: "chat" (default) or "node" for desktop node-host connections
 
         Raises:
             ConnectionServiceError: If DynamoDB operation fails
@@ -83,6 +85,7 @@ class ConnectionService:
             "userId": {"S": user_id},
             "orgId": {"S": org_id or ""},  # Empty string for None
             "connectedAt": {"S": connected_at},
+            "connectionType": {"S": connection_type},
         }
 
         try:
@@ -145,6 +148,7 @@ class ConnectionService:
         return {
             "user_id": item["userId"]["S"],
             "org_id": org_id_value if org_id_value else None,  # Convert empty string to None
+            "connection_type": item.get("connectionType", {}).get("S", "chat"),
         }
 
     def delete_connection(self, connection_id: str) -> None:

--- a/apps/backend/routers/node_proxy.py
+++ b/apps/backend/routers/node_proxy.py
@@ -1,0 +1,90 @@
+"""
+Node connection proxy.
+
+Manages dedicated upstream WebSocket connections for node clients.
+When a node connects (role:"node" in the connect handshake), a separate
+upstream WebSocket is opened to the user's container. All subsequent
+messages are relayed bidirectionally. The container config is patched
+to enable/disable node tools on connect/disconnect.
+"""
+
+import logging
+
+from core.gateway.node_connection import NodeUpstreamConnection
+from core.containers import get_ecs_manager, get_gateway_pool
+from core.services.config_patcher import patch_openclaw_config
+
+logger = logging.getLogger(__name__)
+
+# connectionId -> NodeUpstreamConnection
+_node_upstreams: dict[str, NodeUpstreamConnection] = {}
+
+
+async def handle_node_connect(
+    owner_id: str,
+    connection_id: str,
+    connect_params: dict,
+    management_api,
+) -> dict | None:
+    """
+    Open a dedicated upstream to the container, complete the node handshake,
+    and set up bidirectional relay. Returns the hello-ok dict on success.
+    """
+    ecs = get_ecs_manager()
+    container, ip = await ecs.resolve_running_container(owner_id)
+
+    upstream = NodeUpstreamConnection(
+        user_id=owner_id,
+        container_ip=ip,
+        node_connect_params=connect_params,
+    )
+
+    async def on_upstream_message(data: dict):
+        await management_api.send_message(connection_id, data)
+
+    upstream.set_message_callback(on_upstream_message)
+
+    hello = await upstream.connect()
+    await upstream.start_reader()
+
+    _node_upstreams[connection_id] = upstream
+
+    # Enable node tools in container config (remove "nodes" from deny list)
+    await patch_openclaw_config(owner_id, {"tools": {"deny": ["canvas"]}})
+
+    # Broadcast status to chat connections
+    pool = get_gateway_pool()
+    await pool.broadcast_to_user(owner_id, {"type": "node_status", "status": "connected"})
+
+    logger.info("Node proxy established: user=%s conn=%s", owner_id, connection_id)
+    return hello
+
+
+async def handle_node_message(connection_id: str, message: dict) -> None:
+    """Relay a message from the node client to the upstream container."""
+    upstream = _node_upstreams.get(connection_id)
+    if upstream:
+        await upstream.relay_to_upstream(message)
+    else:
+        logger.warning("No node upstream for connection %s", connection_id)
+
+
+async def handle_node_disconnect(connection_id: str, owner_id: str) -> None:
+    """Close the upstream connection and re-disable node tools."""
+    upstream = _node_upstreams.pop(connection_id, None)
+    if upstream:
+        await upstream.close()
+
+    # Re-disable node tools
+    await patch_openclaw_config(owner_id, {"tools": {"deny": ["canvas", "nodes"]}})
+
+    # Broadcast status
+    pool = get_gateway_pool()
+    await pool.broadcast_to_user(owner_id, {"type": "node_status", "status": "disconnected"})
+
+    logger.info("Node proxy closed: conn=%s", connection_id)
+
+
+def is_node_connection(connection_id: str) -> bool:
+    """Check if a connection ID has a registered node upstream."""
+    return connection_id in _node_upstreams

--- a/apps/backend/routers/websocket_chat.py
+++ b/apps/backend/routers/websocket_chat.py
@@ -21,6 +21,12 @@ from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Response
 from core.containers import get_ecs_manager, get_gateway_pool
 from core.services.connection_service import ConnectionService, ConnectionServiceError
 from core.services.management_api_client import ManagementApiClient
+from routers.node_proxy import (
+    handle_node_connect,
+    handle_node_message,
+    handle_node_disconnect,
+    is_node_connection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -149,9 +155,14 @@ async def ws_disconnect(
         connection_service = await get_connection_service()
         connection = connection_service.get_connection(x_connection_id)
         if connection:
-            pool = get_gateway_pool()
             owner_id = connection.get("org_id") or connection["user_id"]
-            pool.remove_frontend_connection(owner_id, x_connection_id)
+
+            # Clean up node upstream if this was a node connection
+            if is_node_connection(x_connection_id):
+                await handle_node_disconnect(x_connection_id, owner_id)
+            else:
+                pool = get_gateway_pool()
+                pool.remove_frontend_connection(owner_id, x_connection_id)
     except Exception as e:
         logger.warning("Failed to unregister frontend connection from pool: %s", e)
 
@@ -221,11 +232,40 @@ async def ws_message(
             )
             return Response(status_code=200)
 
-        # OpenClaw connect handshake — respond with hello-ok locally.
-        # The control UI SPA sends this after receiving connect.challenge.
-        # Auth is already handled by the Lambda authorizer, so we accept
-        # any token and respond immediately.
+        # OpenClaw connect handshake.
         if method == "connect":
+            connect_params = params or {}
+            role = connect_params.get("role", "operator")
+
+            # Node connection: open dedicated upstream with role:"node"
+            if role == "node":
+                conn_svc = await get_connection_service()
+                conn_svc.store_connection(x_connection_id, user_id, connection.get("org_id"), connection_type="node")
+                management_api = await get_management_api_client()
+                try:
+                    hello = await handle_node_connect(
+                        owner_id=owner_id,
+                        connection_id=x_connection_id,
+                        connect_params=connect_params,
+                        management_api=management_api,
+                    )
+                    if hello:
+                        management_api.send_message(x_connection_id, hello)
+                except Exception as e:
+                    logger.error("Node connect failed: %s", e)
+                    management_api.send_message(
+                        x_connection_id,
+                        {
+                            "type": "res",
+                            "id": req_id,
+                            "ok": False,
+                            "error": {"message": str(e)},
+                        },
+                    )
+                return Response(status_code=200)
+
+            # Operator connect — respond with hello-ok locally.
+            # Auth is already handled by the Lambda authorizer.
             management_api = await get_management_api_client()
             management_api.send_message(
                 x_connection_id,
@@ -236,6 +276,11 @@ async def ws_message(
                     "payload": {"protocol": 3},
                 },
             )
+            return Response(status_code=200)
+
+        # Node connections: relay all non-connect messages to upstream
+        if is_node_connection(x_connection_id):
+            await handle_node_message(x_connection_id, body)
             return Response(status_code=200)
 
         background_tasks.add_task(


### PR DESCRIPTION
## Summary
- `NodeUpstreamConnection`: dedicated WebSocket to container with `role:"node"`
- `node_proxy.py`: connect/message/disconnect handlers with config patching
- `websocket_chat.py`: detect `role:"node"`, route to node proxy
- `connection_service.py`: `connection_type` field in DynamoDB
- `connection_pool.py`: `broadcast_to_user()` for node status events

When the desktop app's node-host connects through API Gateway, the backend opens a separate upstream WebSocket to the user's container. The container's gateway registers the node and can route `node.invoke` requests to the user's Mac.

## Test plan
- [ ] Existing chat/RPC still works (no regression)
- [ ] Node connection tagged as type:"node" in DynamoDB
- [ ] Node events routed to dedicated upstream, not shared pool
- [ ] Config patched to enable node tools on connect, re-disabled on disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)