### PR TITLE
fix(logging): structured backend logs for chat pipeline

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -345,20 +345,48 @@ class GatewayConnection:
         member receive the message (per-member event routing for orgs).
         When ``None``, broadcast to all connections (status changes, etc.).
         """
+        all_conns = list(self._frontend_connections)
+        if not all_conns:
+            msg_type = message.get("type", "?")
+            logger.warning(
+                "[%s] forward: no frontend connections for msg type=%s target=%s",
+                self.user_id,
+                msg_type,
+                target_member_id or "broadcast",
+            )
+            return
         gone: list[str] = []
-        for conn_id in list(self._frontend_connections):
+        delivered = 0
+        skipped = 0
+        for conn_id in all_conns:
             if target_member_id is not None:
                 if self._conn_member_map.get(conn_id) != target_member_id:
+                    skipped += 1
                     continue
             try:
                 if not self._management_api.send_message(conn_id, message):
                     gone.append(conn_id)
+                else:
+                    delivered += 1
             except Exception:
                 logger.warning("Failed to forward message to %s", conn_id)
                 gone.append(conn_id)
         for conn_id in gone:
             self._frontend_connections.discard(conn_id)
             logger.info("Pruned gone frontend connection %s for user %s", conn_id, self.user_id)
+        # Log delivery summary for non-chunk messages (chunks are too frequent)
+        msg_type = message.get("type", "?")
+        if msg_type not in ("chunk",):
+            logger.info(
+                "[%s] forward type=%s target=%s delivered=%d skipped=%d gone=%d total=%d",
+                self.user_id,
+                msg_type,
+                target_member_id or "broadcast",
+                delivered,
+                skipped,
+                len(gone),
+                len(all_conns),
+            )
 
     def _record_usage_from_session(self, payload: dict) -> None:
         """Record usage after a billable event by resolving the session key
@@ -570,14 +598,25 @@ class GatewayConnection:
                 session_key = payload.get("sessionKey", "")
             target_member = _parse_session_key(session_key).get("member_id") if session_key else None
 
-            # Log all non-agent events for debugging usage pipeline
-            if event_name != "agent":
+            # Demote noisy periodic events (health, tick) to DEBUG so they
+            # don't drown actual chat/agent signals in the logs. Log
+            # meaningful non-agent events (chat state changes, sessions,
+            # etc.) at INFO.
+            if event_name in ("health", "tick"):
+                logger.debug(
+                    "Gateway heartbeat for %s: event=%s",
+                    self.user_id,
+                    event_name,
+                )
+            elif event_name != "agent":
                 state = payload.get("state", "") if isinstance(payload, dict) else ""
                 logger.info(
-                    "Gateway event for user %s: event=%s state=%s",
+                    "[%s] gateway event=%s state=%s sessionKey=%s target=%s",
                     self.user_id,
                     event_name,
                     state,
+                    session_key[:60] if session_key else "-",
+                    target_member or "broadcast",
                 )
 
             if event_name == "agent":
@@ -611,6 +650,14 @@ class GatewayConnection:
                 # Chat events -- only terminal states.
                 # Delta states are skipped; agent events handle streaming.
                 state = payload.get("state", "")
+                if state in ("final", "error", "aborted"):
+                    logger.info(
+                        "[%s] chat %s sessionKey=%s target=%s",
+                        self.user_id,
+                        state,
+                        session_key[:60] if session_key else "-",
+                        target_member or "broadcast",
+                    )
                 if state == "final":
                     # Send thinking content if present (before visible text)
                     thinking_text = self._extract_thinking_text(payload)

--- a/apps/backend/routers/websocket_chat.py
+++ b/apps/backend/routers/websocket_chat.py
@@ -111,7 +111,13 @@ async def ws_connect(
     if not x_user_id:
         raise HTTPException(status_code=401, detail="Missing x-user-id header")
 
-    logger.info("WebSocket connect: connection_id=%s, user_id=%s", x_connection_id, x_user_id)
+    logger.info(
+        "WS connect: conn=%s user=%s org=%s owner=%s",
+        x_connection_id[:12],
+        x_user_id,
+        x_org_id or "-",
+        x_org_id or x_user_id,
+    )
 
     connection_service = await get_connection_service()
     connection_service.store_connection(
@@ -214,6 +220,17 @@ async def ws_message(
         management_api = await get_management_api_client()
         management_api.send_message(x_connection_id, {"type": "pong"})
         return Response(status_code=200)
+
+    # Log all non-ping message types so chat/RPC flow is visible at INFO
+    logger.info(
+        "[%s] ws msg type=%s owner=%s conn=%s method=%s agent=%s",
+        user_id,
+        msg_type,
+        owner_id,
+        x_connection_id[:12] if x_connection_id else "?",
+        body.get("method", "-") if msg_type == "req" else "-",
+        body.get("agent_id", "-") if msg_type == "agent_chat" else "-",
+    )
 
     if msg_type == "pong":
         return Response(status_code=200)
@@ -390,6 +407,9 @@ async def _process_rpc_background(
     params: dict,
 ) -> None:
     """Process an OpenClaw RPC request via the gateway connection pool."""
+    # Log non-noisy RPCs at INFO (skip health/channels.status which fire every 3s)
+    if method not in ("health", "channels.status"):
+        logger.info("[%s] rpc %s owner=%s conn=%s", user_id, method, owner_id, connection_id[:12])
     management_api = await get_management_api_client()
 
     try:
@@ -495,11 +515,13 @@ async def _process_agent_chat_background(
     (text_delta, turn_completed, etc.) are handled by the pool's reader
     task and forwarded to the frontend automatically.
     """
-    logger.debug(
-        "Processing agent chat - connection_id=%s, user_id=%s, agent=%s",
-        connection_id,
+    logger.info(
+        "[%s] chat.send START agent=%s owner=%s conn=%s msg_len=%d",
         user_id,
         agent_id,
+        owner_id,
+        connection_id[:12],
+        len(message),
     )
 
     management_api = await get_management_api_client()
@@ -510,6 +532,7 @@ async def _process_agent_chat_background(
         container, ip = await ecs_manager.resolve_running_container(owner_id)
 
         if not container:
+            logger.warning("[%s] chat.send FAIL: no container for owner=%s", user_id, owner_id)
             management_api.send_message(
                 connection_id,
                 {
@@ -520,6 +543,7 @@ async def _process_agent_chat_background(
             return
 
         if not ip:
+            logger.warning("[%s] chat.send FAIL: no IP for owner=%s (container starting)", user_id, owner_id)
             management_api.send_message(
                 connection_id,
                 {
@@ -537,6 +561,14 @@ async def _process_agent_chat_background(
         is_org = owner_id != user_id
         session_key = f"agent:{agent_id}:{user_id}" if is_org else f"agent:{agent_id}:main"
 
+        logger.info(
+            "[%s] chat.send RPC agent=%s sessionKey=%s ip=%s",
+            user_id,
+            agent_id,
+            session_key,
+            ip,
+        )
+
         result = await pool.send_rpc(
             user_id=owner_id,
             req_id=req_id,
@@ -549,11 +581,11 @@ async def _process_agent_chat_background(
             ip=ip,
             token=container["gateway_token"],
         )
-        logger.debug("chat.send acked for agent %s: %s", agent_id, result)
+        logger.info("[%s] chat.send ACK agent=%s result=%s", user_id, agent_id, result)
         # Streaming response events are forwarded by the connection pool's reader task
 
     except Exception as e:
-        logger.error("chat.send failed for agent %s: %s", agent_id, e)
+        logger.error("[%s] chat.send FAIL agent=%s: %s", user_id, agent_id, e)
         try:
             management_api.send_message(
                 connection_id,


### PR DESCRIPTION
## Summary
Backend logs were unusable for debugging chat issues: health events every 3s drowned actual signals, and the chat pipeline had zero INFO-level logging.

### What changed
- **Demoted noise:** \`event=health\` and \`event=tick\` → DEBUG (previously INFO, ~20/sec)
- **Added visibility:** INFO logs for incoming WS messages (type, user, owner, agent), RPC dispatch, chat.send lifecycle (START → RPC → ACK → FAIL), chat terminal states (final/error/aborted), event delivery summary (delivered/skipped/gone counts)
- **Structured format:** All logs use \`[user_id]\` prefix for per-user filtering via CloudWatch Insights
- **Dead delivery warning:** Logs when \`_forward_to_frontends\` has zero connections

### What the logs now show per chat message
\`\`\`
[user_abc] ws msg type=agent_chat owner=org_xyz conn=blJMgfQNIA... agent=main
[user_abc] chat.send START agent=main owner=org_xyz conn=blJMgfQNIA... msg_len=42
[user_abc] chat.send RPC agent=main sessionKey=agent:main:user_abc ip=10.0.2.94
[user_abc] chat.send ACK agent=main result={...}
[org_xyz] chat final sessionKey=agent:main:user_abc target=user_abc
[org_xyz] forward type=done target=user_abc delivered=1 skipped=1 gone=0 total=2
\`\`\`

## Test plan
- [ ] Send a chat message, verify the full pipeline is logged at INFO
- [ ] Health events no longer appear in INFO logs
- [ ] Per-member routing shows correct delivered/skipped counts for org members

🤖 Generated with [Claude Code](https://claude.com/claude-code)