### PR TITLE
fix(gateway): case-insensitive member matching for event routing

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -360,7 +360,12 @@ class GatewayConnection:
         skipped = 0
         for conn_id in all_conns:
             if target_member_id is not None:
-                if self._conn_member_map.get(conn_id) != target_member_id:
+                # Case-insensitive: OpenClaw lowercases sessionKeys
+                # internally, so the member_id parsed from the event is
+                # lowercase, but conn_member_map stores the original
+                # Clerk user_id (mixed case).
+                member = self._conn_member_map.get(conn_id, "")
+                if member.lower() != target_member_id.lower():
                     skipped += 1
                     continue
             try:


### PR DESCRIPTION
## Summary
Per-member event routing (PR #212) delivered zero events because OpenClaw lowercases sessionKeys internally. The member_id parsed from events was lowercase but conn_member_map stores original Clerk user_ids in mixed case. Case-insensitive comparison fixes it.

Evidence from logs:
\`\`\`
chat.send ACK ✓ runId=08b0aa27 status=started
chat final sessionKey=agent:main:user_3c8onc5g...  ← lowercase
forward type=done target=user_3c8onc5g... delivered=0 skipped=2  ← ZERO delivered
\`\`\`

Fix: \`.lower()\` both sides of the comparison in \`_forward_to_frontends\`.

## Test plan
- [ ] Send message → \`delivered=1\` (not 0) in logs
- [ ] Two org members chatting simultaneously each see only their own response

🤖 Generated with [Claude Code](https://claude.com/claude-code)