### PR TITLE
fix: auth fallback redirect + bot handle display for members

### DIFF
--- a/apps/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/frontend/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -381,7 +381,7 @@ export default function Page() {
               </p>
             </div>
 
-            <SignIn forceRedirectUrl="/chat" signUpForceRedirectUrl="/chat" />
+            <SignIn fallbackRedirectUrl="/chat" signUpFallbackRedirectUrl="/chat" />
 
             <p className="auth-footer">
               Don&apos;t have an account?{" "}

--- a/apps/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/frontend/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -303,7 +303,7 @@ export default function Page() {
               </svg>
             </Link>
 
-            <SignUp forceRedirectUrl="/chat" signInForceRedirectUrl="/chat" />
+            <SignUp fallbackRedirectUrl="/chat" signInFallbackRedirectUrl="/chat" />
 
             <div className="auth-footer-links">
               Already have an account?{" "}

--- a/apps/frontend/src/components/settings/MyChannelsSection.tsx
+++ b/apps/frontend/src/components/settings/MyChannelsSection.tsx
@@ -19,6 +19,7 @@ import { useApi } from "@/lib/api";
 import { type Provider, PROVIDERS, PROVIDER_LABELS, formatBotHandle } from "@/lib/channels";
 import { BotSetupWizard } from "@/components/channels/BotSetupWizard";
 import { GatewayProvider } from "@/hooks/useGateway";
+import { useGatewayRpc } from "@/hooks/useGatewayRpc";
 
 interface BotEntry {
   agent_id: string;
@@ -46,12 +47,39 @@ export function MyChannelsSection() {
   );
 }
 
+// Extract bot handles from channels.status so members can see the actual
+// bot name (e.g. @MyBot) instead of the agent_id placeholder ("main").
+type ChannelStatusAccount = {
+  accountId?: string;
+  name?: string;
+};
+type ChannelStatusResponse = {
+  channelAccounts?: Record<string, ChannelStatusAccount[]>;
+};
+
+function useBotHandles() {
+  const { data } = useGatewayRpc<ChannelStatusResponse>("channels.status", { probe: false });
+  const handles: Record<string, Record<string, string>> = {};
+  if (data?.channelAccounts) {
+    for (const [provider, accounts] of Object.entries(data.channelAccounts)) {
+      handles[provider] = {};
+      for (const acct of accounts) {
+        if (acct.accountId && acct.name) {
+          handles[provider][acct.accountId] = acct.name;
+        }
+      }
+    }
+  }
+  return handles;
+}
+
 function MyChannelsSectionInner() {
   const api = useApi();
   const { data, error, isLoading, mutate } = useSWR<LinksMeResponse>(
     "/channels/links/me",
     () => api.get("/channels/links/me") as Promise<LinksMeResponse>,
   );
+  const botHandles = useBotHandles();
   const [wizard, setWizard] = useState<{ provider: Provider; agentId: string } | null>(null);
   const [unlinkTarget, setUnlinkTarget] = useState<{ provider: Provider; agentId: string } | null>(null);
   const [unlinking, setUnlinking] = useState(false);
@@ -129,7 +157,12 @@ function MyChannelsSectionInner() {
                       <AlertCircle className="h-4 w-4 text-amber-500" />
                     )}
                     <div className="flex-1">
-                      <p className="text-sm font-mono">{formatBotHandle(provider, bot.bot_username)}</p>
+                      <p className="text-sm font-mono">
+                        {formatBotHandle(
+                          provider,
+                          botHandles[provider]?.[bot.agent_id] || bot.bot_username,
+                        )}
+                      </p>
                       <p className="text-xs text-[#8a8578]">{bot.agent_id}</p>
                     </div>
                     {bot.linked ? (


### PR DESCRIPTION
## Summary
Two fixes that missed the PR #215 squash merge:

1. **Auth redirect:** \`forceRedirectUrl\` → \`fallbackRedirectUrl\` on SignIn/SignUp so middleware deep-link redirects are preserved (Codex P2).
2. **Bot handle display:** Settings → Channels shows real bot name from \`channels.status\` instead of agent_id placeholder.

## Test plan
- [ ] Visit /settings while signed out → sign in → land on /settings (not /chat)
- [ ] Settings → Channels shows real bot handle for configured bots

🤖 Generated with [Claude Code](https://claude.com/claude-code)