### PR TITLE
fix: bot username from backend probe instead of broken frontend RPC

### DIFF
--- a/apps/backend/routers/channels.py
+++ b/apps/backend/routers/channels.py
@@ -73,6 +73,43 @@ async def get_links_me(auth: AuthContext = Depends(get_current_user)):
     }
 
     can_create_bots = (not auth.is_org_context) or auth.is_org_admin
+
+    # Try to get live bot usernames from channels.status probe via the
+    # gateway pool. This calls getMe() / /users/@me on each provider and
+    # returns the actual bot handle (e.g. @Isol8DevBot). Falls back to
+    # agent_id if the container isn't reachable or the probe fails.
+    bot_usernames: dict[str, dict[str, str]] = {}  # provider -> accountId -> username
+    try:
+        from core.containers import get_ecs_manager, get_gateway_pool
+
+        ecs_manager = get_ecs_manager()
+        container, ip = await ecs_manager.resolve_running_container(owner_id)
+        if container and ip:
+            pool = get_gateway_pool()
+            status = await pool.send_rpc(
+                user_id=owner_id,
+                req_id=f"links-me-{owner_id}",
+                method="channels.status",
+                params={"probe": True},
+                ip=ip,
+                token=container["gateway_token"],
+            )
+            for prov, accts in (status or {}).get("channelAccounts", {}).items():
+                if not isinstance(accts, list):
+                    continue
+                bot_usernames[prov] = {}
+                for acct in accts:
+                    if not isinstance(acct, dict):
+                        continue
+                    acct_id = acct.get("accountId", "")
+                    probe = acct.get("probe") or {}
+                    bot = probe.get("bot") or {} if isinstance(probe, dict) else {}
+                    username = bot.get("username", "") if isinstance(bot, dict) else ""
+                    if acct_id and username:
+                        bot_usernames[prov][acct_id] = username
+    except Exception as e:
+        logger.debug("channels.status probe failed for links/me (using fallback): %s", e)
+
     result: dict = {"can_create_bots": can_create_bots}
     for provider in ("telegram", "discord", "slack"):
         provider_cfg = channels_cfg.get(provider, {}) if isinstance(channels_cfg, dict) else {}
@@ -81,10 +118,11 @@ async def get_links_me(auth: AuthContext = Depends(get_current_user)):
         if isinstance(accounts, dict):
             for agent_id in accounts.keys():
                 linked = (provider, agent_id) in links_for_owner
+                live_name = bot_usernames.get(provider, {}).get(agent_id, "")
                 bots.append(
                     {
                         "agent_id": agent_id,
-                        "bot_username": agent_id,  # placeholder; live name comes from channels.status later
+                        "bot_username": live_name or agent_id,
                         "linked": linked,
                     }
                 )

--- a/apps/frontend/src/components/settings/MyChannelsSection.tsx
+++ b/apps/frontend/src/components/settings/MyChannelsSection.tsx
@@ -19,7 +19,6 @@ import { useApi } from "@/lib/api";
 import { type Provider, PROVIDERS, PROVIDER_LABELS, formatBotHandle } from "@/lib/channels";
 import { BotSetupWizard } from "@/components/channels/BotSetupWizard";
 import { GatewayProvider } from "@/hooks/useGateway";
-import { useGatewayRpc } from "@/hooks/useGatewayRpc";
 
 interface BotEntry {
   agent_id: string;
@@ -47,39 +46,13 @@ export function MyChannelsSection() {
   );
 }
 
-// Extract bot handles from channels.status so members can see the actual
-// bot name (e.g. @MyBot) instead of the agent_id placeholder ("main").
-type ChannelStatusAccount = {
-  accountId?: string;
-  name?: string;
-};
-type ChannelStatusResponse = {
-  channelAccounts?: Record<string, ChannelStatusAccount[]>;
-};
-
-function useBotHandles() {
-  const { data } = useGatewayRpc<ChannelStatusResponse>("channels.status", { probe: false });
-  const handles: Record<string, Record<string, string>> = {};
-  if (data?.channelAccounts) {
-    for (const [provider, accounts] of Object.entries(data.channelAccounts)) {
-      handles[provider] = {};
-      for (const acct of accounts) {
-        if (acct.accountId && acct.name) {
-          handles[provider][acct.accountId] = acct.name;
-        }
-      }
-    }
-  }
-  return handles;
-}
-
 function MyChannelsSectionInner() {
   const api = useApi();
+  // bot_username is now populated by the backend via channels.status probe
   const { data, error, isLoading, mutate } = useSWR<LinksMeResponse>(
     "/channels/links/me",
     () => api.get("/channels/links/me") as Promise<LinksMeResponse>,
   );
-  const botHandles = useBotHandles();
   const [wizard, setWizard] = useState<{ provider: Provider; agentId: string } | null>(null);
   const [unlinkTarget, setUnlinkTarget] = useState<{ provider: Provider; agentId: string } | null>(null);
   const [unlinking, setUnlinking] = useState(false);
@@ -157,12 +130,7 @@ function MyChannelsSectionInner() {
                       <AlertCircle className="h-4 w-4 text-amber-500" />
                     )}
                     <div className="flex-1">
-                      <p className="text-sm font-mono">
-                        {formatBotHandle(
-                          provider,
-                          botHandles[provider]?.[bot.agent_id] || bot.bot_username,
-                        )}
-                      </p>
+                      <p className="text-sm font-mono">{formatBotHandle(provider, bot.bot_username)}</p>
                       <p className="text-xs text-[#8a8578]">{bot.agent_id}</p>
                     </div>
                     {bot.linked ? (


### PR DESCRIPTION
## Summary
PR #216's frontend approach (calling \`channels.status\` via gateway RPC from the settings page) didn't work — the GatewayProvider doesn't connect on \`/settings\`, so the RPC never fired and members still saw \`@main\`.

Fix: move the \`channels.status\` probe to the backend's \`/channels/links/me\` REST endpoint instead. The backend already has the gateway pool, so it calls \`channels.status\` with \`probe: true\`, extracts \`probe.bot.username\` from each account, and returns the real bot handle in the REST response. Frontend just reads \`bot.bot_username\` from the REST API — no gateway dependency needed.

Also removes the stale \`useBotHandles\` hook and \`useGatewayRpc\` import that PR #216 left on main.

## Test plan
- [ ] Settings → Channels shows \`@Isol8DevBot\` (not \`@main\`)
- [ ] Works for members who don't have the gateway WS connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)