### PR TITLE
fix(billing): conditional write to prevent duplicate Stripe customers

### DIFF
--- a/apps/backend/core/repositories/billing_repo.py
+++ b/apps/backend/core/repositories/billing_repo.py
@@ -1,11 +1,19 @@
 """Billing account repository -- DynamoDB operations for the billing_accounts table."""
 
+import logging
 import uuid
 from decimal import Decimal
 
 from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
 
 from core.dynamodb import get_table, run_in_thread, utc_now_iso
+
+logger = logging.getLogger(__name__)
+
+
+class AlreadyExistsError(Exception):
+    """Raised when a conditional put fails because the item already exists."""
 
 
 def _get_table():
@@ -29,13 +37,21 @@ async def get_by_stripe_customer_id(stripe_customer_id: str) -> dict | None:
     return items[0] if items else None
 
 
-async def create(
+async def create_if_not_exists(
     owner_id: str,
     stripe_customer_id: str,
     plan_tier: str = "free",
     markup_multiplier: float = 1.4,
     owner_type: str = "personal",
 ) -> dict:
+    """Atomically create a billing account if one doesn't exist for this owner.
+
+    Uses a DynamoDB conditional put (``attribute_not_exists(owner_id)``)
+    so that concurrent calls are serialized: exactly one wins, the rest
+    raise ``AlreadyExistsError``. This is the single source of truth for
+    preventing duplicate Stripe customers — Stripe's search API is
+    eventually consistent and can't be trusted for dedup.
+    """
     table = _get_table()
     now = utc_now_iso()
     item = {
@@ -48,21 +64,17 @@ async def create(
         "created_at": now,
         "updated_at": now,
     }
-    await run_in_thread(table.put_item, Item=item)
+    try:
+        await run_in_thread(
+            table.put_item,
+            Item=item,
+            ConditionExpression="attribute_not_exists(owner_id)",
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            raise AlreadyExistsError(owner_id) from e
+        raise
     return item
-
-
-async def get_or_create(
-    owner_id: str,
-    stripe_customer_id: str,
-    plan_tier: str = "free",
-    markup_multiplier: float = 1.4,
-    owner_type: str = "personal",
-) -> dict:
-    existing = await get_by_owner_id(owner_id)
-    if existing:
-        return existing
-    return await create(owner_id, stripe_customer_id, plan_tier, markup_multiplier, owner_type=owner_type)
 
 
 async def update_subscription(

--- a/apps/backend/core/services/billing_service.py
+++ b/apps/backend/core/services/billing_service.py
@@ -35,48 +35,39 @@ class BillingService:
         if existing:
             return existing
 
-        # Before creating a new Stripe customer, search Stripe for an existing one
-        # with matching metadata.owner_id. This prevents duplicate customer creation
-        # when concurrent /users/sync calls all miss the DynamoDB row at the same time.
-        # Note: Stripe search is eventually consistent, so a customer created <1s ago
-        # may not show up. That's OK — billing_repo.get_or_create handles the DB race.
-        customer_id: str | None = None
-        try:
-            search_result = stripe.Customer.search(
-                query=f"metadata['owner_id']:'{owner_id}'",
-                limit=2,
-            )
-            matches = list(getattr(search_result, "data", []) or [])
-            if len(matches) == 1:
-                customer_id = matches[0].id
-                logger.info("Reusing existing Stripe customer for owner_id=%s (%s)", owner_id, customer_id)
-            elif len(matches) > 1:
-                # Pick the oldest (smallest `created` timestamp). Leave cleanup to an admin tool.
-                oldest = min(matches, key=lambda c: getattr(c, "created", 0) or 0)
-                customer_id = oldest.id
-                logger.warning(
-                    "Found %d orphan Stripe customers for owner_id=%s; reusing oldest (%s)",
-                    len(matches),
-                    owner_id,
-                    customer_id,
-                )
-        except Exception as e:
-            # Search API may be disabled on the account, rate-limited, or transiently
-            # unavailable. Never block provisioning — fall through to Customer.create.
-            logger.warning("Stripe customer search failed for owner_id=%s: %s; falling back to create", owner_id, e)
-
-        if customer_id is None:
-            customer = stripe.Customer.create(
-                email=email or None,
-                metadata={"owner_id": owner_id, "owner_type": owner_type},
-            )
-            customer_id = customer.id
-
-        return await billing_repo.get_or_create(
-            owner_id=owner_id,
-            stripe_customer_id=customer_id,
-            owner_type=owner_type,
+        # Create the Stripe customer first, then try to claim the DynamoDB
+        # slot with a conditional write. If another concurrent call already
+        # won the race (webhook + frontend sync fire at the same time), the
+        # conditional put raises AlreadyExistsError — we delete the orphan
+        # Stripe customer and return the winner's record.
+        #
+        # This replaces the previous Stripe search approach which was
+        # eventually consistent and still produced duplicates within the
+        # same second.
+        customer = stripe.Customer.create(
+            email=email or None,
+            metadata={"owner_id": owner_id, "owner_type": owner_type},
         )
+
+        try:
+            return await billing_repo.create_if_not_exists(
+                owner_id=owner_id,
+                stripe_customer_id=customer.id,
+                owner_type=owner_type,
+            )
+        except billing_repo.AlreadyExistsError:
+            # Another call won the race. Delete our orphan Stripe customer
+            # and return the winner's record.
+            logger.info(
+                "Billing account race: owner_id=%s already exists, deleting orphan Stripe customer %s",
+                owner_id,
+                customer.id,
+            )
+            try:
+                stripe.Customer.delete(customer.id)
+            except Exception:
+                logger.warning("Failed to delete orphan Stripe customer %s", customer.id)
+            return await billing_repo.get_by_owner_id(owner_id)
 
     async def create_checkout_session(self, billing_account: dict, tier: str) -> str:
         fixed_price = TIER_PRICES.get(tier)

--- a/apps/backend/routers/channels.py
+++ b/apps/backend/routers/channels.py
@@ -73,6 +73,43 @@ async def get_links_me(auth: AuthContext = Depends(get_current_user)):
     }
 
     can_create_bots = (not auth.is_org_context) or auth.is_org_admin
+
+    # Try to get live bot usernames from channels.status probe via the
+    # gateway pool. This calls getMe() / /users/@me on each provider and
+    # returns the actual bot handle (e.g. @Isol8DevBot). Falls back to
+    # agent_id if the container isn't reachable or the probe fails.
+    bot_usernames: dict[str, dict[str, str]] = {}  # provider -> accountId -> username
+    try:
+        from core.containers import get_ecs_manager, get_gateway_pool
+
+        ecs_manager = get_ecs_manager()
+        container, ip = await ecs_manager.resolve_running_container(owner_id)
+        if container and ip:
+            pool = get_gateway_pool()
+            status = await pool.send_rpc(
+                user_id=owner_id,
+                req_id=f"links-me-{owner_id}",
+                method="channels.status",
+                params={"probe": True},
+                ip=ip,
+                token=container["gateway_token"],
+            )
+            for prov, accts in (status or {}).get("channelAccounts", {}).items():
+                if not isinstance(accts, list):
+                    continue
+                bot_usernames[prov] = {}
+                for acct in accts:
+                    if not isinstance(acct, dict):
+                        continue
+                    acct_id = acct.get("accountId", "")
+                    probe = acct.get("probe") or {}
+                    bot = probe.get("bot") or {} if isinstance(probe, dict) else {}
+                    username = bot.get("username", "") if isinstance(bot, dict) else ""
+                    if acct_id and username:
+                        bot_usernames[prov][acct_id] = username
+    except Exception as e:
+        logger.debug("channels.status probe failed for links/me (using fallback): %s", e)
+
     result: dict = {"can_create_bots": can_create_bots}
     for provider in ("telegram", "discord", "slack"):
         provider_cfg = channels_cfg.get(provider, {}) if isinstance(channels_cfg, dict) else {}
@@ -81,10 +118,11 @@ async def get_links_me(auth: AuthContext = Depends(get_current_user)):
         if isinstance(accounts, dict):
             for agent_id in accounts.keys():
                 linked = (provider, agent_id) in links_for_owner
+                live_name = bot_usernames.get(provider, {}).get(agent_id, "")
                 bots.append(
                     {
                         "agent_id": agent_id,
-                        "bot_username": agent_id,  # placeholder; live name comes from channels.status later
+                        "bot_username": live_name or agent_id,
                         "linked": linked,
                     }
                 )

--- a/apps/backend/tests/unit/repositories/test_billing_repo.py
+++ b/apps/backend/tests/unit/repositories/test_billing_repo.py
@@ -45,7 +45,7 @@ def dynamodb_table():
 async def test_create_and_get(dynamodb_table):
     from core.repositories import billing_repo
 
-    result = await billing_repo.create("user_1", "cus_abc")
+    result = await billing_repo.create_if_not_exists("user_1", "cus_abc")
     assert result["owner_id"] == "user_1"
     assert result["stripe_customer_id"] == "cus_abc"
     assert result["plan_tier"] == "free"
@@ -69,7 +69,7 @@ async def test_get_by_owner_id_nonexistent(dynamodb_table):
 async def test_get_by_stripe_customer_id(dynamodb_table):
     from core.repositories import billing_repo
 
-    await billing_repo.create("user_2", "cus_def")
+    await billing_repo.create_if_not_exists("user_2", "cus_def")
     item = await billing_repo.get_by_stripe_customer_id("cus_def")
     assert item is not None
     assert item["owner_id"] == "user_2"
@@ -84,28 +84,20 @@ async def test_get_by_stripe_customer_id_nonexistent(dynamodb_table):
 
 
 @pytest.mark.asyncio
-async def test_get_or_create_existing(dynamodb_table):
+async def test_create_if_not_exists_rejects_duplicate(dynamodb_table):
     from core.repositories import billing_repo
+    from core.repositories.billing_repo import AlreadyExistsError
 
-    first = await billing_repo.create("user_3", "cus_ghi")
-    second = await billing_repo.get_or_create("user_3", "cus_ghi")
-    assert second["id"] == first["id"]
-
-
-@pytest.mark.asyncio
-async def test_get_or_create_new(dynamodb_table):
-    from core.repositories import billing_repo
-
-    result = await billing_repo.get_or_create("user_new", "cus_new")
-    assert result["owner_id"] == "user_new"
-    assert result["stripe_customer_id"] == "cus_new"
+    await billing_repo.create_if_not_exists("user_3", "cus_ghi")
+    with pytest.raises(AlreadyExistsError):
+        await billing_repo.create_if_not_exists("user_3", "cus_ghi_dup")
 
 
 @pytest.mark.asyncio
 async def test_update_subscription(dynamodb_table):
     from core.repositories import billing_repo
 
-    await billing_repo.create("user_4", "cus_jkl")
+    await billing_repo.create_if_not_exists("user_4", "cus_jkl")
     result = await billing_repo.update_subscription("user_4", "sub_xyz", "starter")
     assert result is not None
     assert result["stripe_subscription_id"] == "sub_xyz"
@@ -124,7 +116,7 @@ async def test_update_subscription_nonexistent(dynamodb_table):
 async def test_delete(dynamodb_table):
     from core.repositories import billing_repo
 
-    await billing_repo.create("user_5", "cus_mno")
+    await billing_repo.create_if_not_exists("user_5", "cus_mno")
     await billing_repo.delete("user_5")
     item = await billing_repo.get_by_owner_id("user_5")
     assert item is None

--- a/apps/backend/tests/unit/routers/test_billing.py
+++ b/apps/backend/tests/unit/routers/test_billing.py
@@ -58,7 +58,7 @@ class TestGetBillingAccount:
         mock_router_repo.get_by_owner_id = AsyncMock(return_value=None)
         mock_stripe.Customer.create.return_value = MagicMock(id="cus_auto_created")
         mock_svc_repo.get_by_owner_id = AsyncMock(return_value=None)
-        mock_svc_repo.get_or_create = AsyncMock(
+        mock_svc_repo.create_if_not_exists = AsyncMock(
             return_value={
                 "owner_id": "user_test_123",
                 "stripe_customer_id": "cus_auto_created",

--- a/apps/backend/tests/unit/services/test_billing_service.py
+++ b/apps/backend/tests/unit/services/test_billing_service.py
@@ -8,7 +8,7 @@ from core.services.billing_service import BillingService, BillingServiceError
 
 
 class TestBillingServiceCreateCustomer:
-    """Test Stripe customer creation."""
+    """Test Stripe customer creation with DynamoDB conditional write dedup."""
 
     @pytest.fixture
     def service(self):
@@ -20,9 +20,8 @@ class TestBillingServiceCreateCustomer:
     async def test_create_customer_for_owner(self, mock_stripe, mock_repo, service):
         """Should create Stripe customer and billing account for user."""
         mock_repo.get_by_owner_id = AsyncMock(return_value=None)
-        mock_stripe.Customer.search.return_value = MagicMock(data=[])
         mock_stripe.Customer.create.return_value = MagicMock(id="cus_new_123")
-        mock_repo.get_or_create = AsyncMock(
+        mock_repo.create_if_not_exists = AsyncMock(
             return_value={
                 "owner_id": "user_new_123",
                 "stripe_customer_id": "cus_new_123",
@@ -38,71 +37,35 @@ class TestBillingServiceCreateCustomer:
         mock_stripe.Customer.create.assert_called_once()
         assert account["owner_id"] == "user_new_123"
         assert account["stripe_customer_id"] == "cus_new_123"
-        assert account["plan_tier"] == "free"
 
     @pytest.mark.asyncio
     @patch("core.services.billing_service.billing_repo")
     @patch("core.services.billing_service.stripe")
-    async def test_create_customer_reuses_existing_stripe_customer(self, mock_stripe, mock_repo, service):
-        """If Stripe search returns 1 match, reuse it instead of creating a duplicate."""
-        mock_repo.get_by_owner_id = AsyncMock(return_value=None)
-        mock_stripe.Customer.search.return_value = MagicMock(data=[MagicMock(id="cus_existing", created=1000)])
-        mock_repo.get_or_create = AsyncMock(
-            return_value={"owner_id": "user_x", "stripe_customer_id": "cus_existing", "plan_tier": "free"}
+    async def test_create_customer_race_deletes_orphan(self, mock_stripe, mock_repo, service):
+        """If DynamoDB conditional write fails (race), delete the orphan Stripe customer."""
+        mock_repo.get_by_owner_id = AsyncMock(
+            side_effect=[
+                None,  # first call: no existing
+                {"owner_id": "user_race", "stripe_customer_id": "cus_winner", "plan_tier": "free"},  # after race
+            ]
         )
+        mock_stripe.Customer.create.return_value = MagicMock(id="cus_loser")
+        mock_repo.create_if_not_exists = AsyncMock(side_effect=mock_repo.AlreadyExistsError("user_race"))
+        mock_repo.AlreadyExistsError = type("AlreadyExistsError", (Exception,), {})
+        mock_repo.create_if_not_exists.side_effect = mock_repo.AlreadyExistsError("user_race")
 
-        result = await service.create_customer_for_owner(owner_id="user_x")
+        # Re-patch to use real AlreadyExistsError
+        from core.repositories.billing_repo import AlreadyExistsError
 
-        mock_stripe.Customer.create.assert_not_called()
-        mock_repo.get_or_create.assert_called_once_with(
-            owner_id="user_x",
-            stripe_customer_id="cus_existing",
-            owner_type="personal",
-        )
-        assert result["stripe_customer_id"] == "cus_existing"
+        mock_repo.AlreadyExistsError = AlreadyExistsError
+        mock_repo.create_if_not_exists = AsyncMock(side_effect=AlreadyExistsError("user_race"))
 
-    @pytest.mark.asyncio
-    @patch("core.services.billing_service.billing_repo")
-    @patch("core.services.billing_service.stripe")
-    async def test_create_customer_reuses_oldest_when_multiple(self, mock_stripe, mock_repo, service, caplog):
-        """If Stripe search returns >1 matches, reuse the oldest and log a warning."""
-        mock_repo.get_by_owner_id = AsyncMock(return_value=None)
-        newer = MagicMock(id="cus_newer", created=2000)
-        older = MagicMock(id="cus_older", created=1000)
-        mock_stripe.Customer.search.return_value = MagicMock(data=[newer, older])
-        mock_repo.get_or_create = AsyncMock(
-            return_value={"owner_id": "user_y", "stripe_customer_id": "cus_older", "plan_tier": "free"}
-        )
+        result = await service.create_customer_for_owner(owner_id="user_race")
 
-        import logging
-
-        with caplog.at_level(logging.WARNING, logger="core.services.billing_service"):
-            await service.create_customer_for_owner(owner_id="user_y")
-
-        mock_stripe.Customer.create.assert_not_called()
-        mock_repo.get_or_create.assert_called_once_with(
-            owner_id="user_y",
-            stripe_customer_id="cus_older",
-            owner_type="personal",
-        )
-        assert any("orphan" in r.message.lower() for r in caplog.records)
-
-    @pytest.mark.asyncio
-    @patch("core.services.billing_service.billing_repo")
-    @patch("core.services.billing_service.stripe")
-    async def test_create_customer_falls_back_when_search_raises(self, mock_stripe, mock_repo, service):
-        """If Stripe search raises, fall back to Customer.create — never block provisioning."""
-        mock_repo.get_by_owner_id = AsyncMock(return_value=None)
-        mock_stripe.Customer.search.side_effect = RuntimeError("search disabled")
-        mock_stripe.Customer.create.return_value = MagicMock(id="cus_fallback")
-        mock_repo.get_or_create = AsyncMock(
-            return_value={"owner_id": "user_z", "stripe_customer_id": "cus_fallback", "plan_tier": "free"}
-        )
-
-        result = await service.create_customer_for_owner(owner_id="user_z")
-
-        mock_stripe.Customer.create.assert_called_once()
-        assert result["stripe_customer_id"] == "cus_fallback"
+        # Orphan Stripe customer should be deleted
+        mock_stripe.Customer.delete.assert_called_once_with("cus_loser")
+        # Should return the winner's record
+        assert result["stripe_customer_id"] == "cus_winner"
 
     @pytest.mark.asyncio
     @patch("core.services.billing_service.billing_repo")
@@ -124,7 +87,6 @@ class TestBillingServiceCreateCustomer:
 
         assert result["id"] == "acc-123"
         mock_stripe.Customer.create.assert_not_called()
-        mock_repo.get_or_create.assert_not_called()
 
 
 class TestBillingServiceCheckout:

--- a/apps/backend/tests/unit/services/test_usage_service.py
+++ b/apps/backend/tests/unit/services/test_usage_service.py
@@ -62,7 +62,7 @@ async def test_record_usage_increments_owner_and_member(dynamodb_tables, mock_st
     from core.repositories import billing_repo, usage_repo
     from core.services.usage_service import record_usage
 
-    await billing_repo.create("org_1", "cus_abc", owner_type="org")
+    await billing_repo.create_if_not_exists("org_1", "cus_abc", owner_type="org")
 
     await record_usage(
         owner_id="org_1",
@@ -98,7 +98,7 @@ async def test_check_budget_free_under_limit(dynamodb_tables):
     from core.repositories import billing_repo
     from core.services.usage_service import check_budget
 
-    await billing_repo.create("user_1", "cus_abc")
+    await billing_repo.create_if_not_exists("user_1", "cus_abc")
 
     result = await check_budget("user_1")
     assert result["allowed"] is True
@@ -110,7 +110,7 @@ async def test_check_budget_free_over_limit(dynamodb_tables):
     from core.repositories import billing_repo, usage_repo
     from core.services.usage_service import check_budget
 
-    await billing_repo.create("user_1", "cus_abc")
+    await billing_repo.create_if_not_exists("user_1", "cus_abc")
     await usage_repo.increment("user_1", "lifetime", 3_000_000, 0, 0, 0, 0)
 
     result = await check_budget("user_1")
@@ -122,7 +122,7 @@ async def test_check_budget_starter_within_included(dynamodb_tables):
     from core.repositories import billing_repo
     from core.services.usage_service import check_budget
 
-    await billing_repo.create("user_1", "cus_abc")
+    await billing_repo.create_if_not_exists("user_1", "cus_abc")
     await billing_repo.update_subscription("user_1", "sub_123", "starter")
 
     result = await check_budget("user_1")
@@ -135,7 +135,7 @@ async def test_check_budget_starter_over_included_no_overage(dynamodb_tables):
     from core.repositories import billing_repo, usage_repo
     from core.services.usage_service import check_budget, _current_period
 
-    await billing_repo.create("user_1", "cus_abc")
+    await billing_repo.create_if_not_exists("user_1", "cus_abc")
     await billing_repo.update_subscription("user_1", "sub_123", "starter")
     await usage_repo.increment("user_1", _current_period(), 11_000_000, 0, 0, 0, 0)
 
@@ -150,7 +150,7 @@ async def test_check_budget_starter_overage_enabled(dynamodb_tables):
     from core.repositories import billing_repo, usage_repo
     from core.services.usage_service import check_budget, _current_period
 
-    await billing_repo.create("user_1", "cus_abc")
+    await billing_repo.create_if_not_exists("user_1", "cus_abc")
     await billing_repo.update_subscription("user_1", "sub_123", "starter")
 
     # Enable overage
@@ -173,6 +173,6 @@ async def test_record_usage_unknown_model_skips(dynamodb_tables, mock_stripe):
     from core.repositories import billing_repo
     from core.services.usage_service import record_usage
 
-    await billing_repo.create("user_1", "cus_abc")
+    await billing_repo.create_if_not_exists("user_1", "cus_abc")
     await record_usage("user_1", "user_1", "unknown-model", 1000, 500, 0, 0)
     # Should not raise

--- a/apps/frontend/src/components/settings/MyChannelsSection.tsx
+++ b/apps/frontend/src/components/settings/MyChannelsSection.tsx
@@ -19,7 +19,6 @@ import { useApi } from "@/lib/api";
 import { type Provider, PROVIDERS, PROVIDER_LABELS, formatBotHandle } from "@/lib/channels";
 import { BotSetupWizard } from "@/components/channels/BotSetupWizard";
 import { GatewayProvider } from "@/hooks/useGateway";
-import { useGatewayRpc } from "@/hooks/useGatewayRpc";
 
 interface BotEntry {
   agent_id: string;
@@ -47,39 +46,13 @@ export function MyChannelsSection() {
   );
 }
 
-// Extract bot handles from channels.status so members can see the actual
-// bot name (e.g. @MyBot) instead of the agent_id placeholder ("main").
-type ChannelStatusAccount = {
-  accountId?: string;
-  name?: string;
-};
-type ChannelStatusResponse = {
-  channelAccounts?: Record<string, ChannelStatusAccount[]>;
-};
-
-function useBotHandles() {
-  const { data } = useGatewayRpc<ChannelStatusResponse>("channels.status", { probe: false });
-  const handles: Record<string, Record<string, string>> = {};
-  if (data?.channelAccounts) {
-    for (const [provider, accounts] of Object.entries(data.channelAccounts)) {
-      handles[provider] = {};
-      for (const acct of accounts) {
-        if (acct.accountId && acct.name) {
-          handles[provider][acct.accountId] = acct.name;
-        }
-      }
-    }
-  }
-  return handles;
-}
-
 function MyChannelsSectionInner() {
   const api = useApi();
+  // bot_username is now populated by the backend via channels.status probe
   const { data, error, isLoading, mutate } = useSWR<LinksMeResponse>(
     "/channels/links/me",
     () => api.get("/channels/links/me") as Promise<LinksMeResponse>,
   );
-  const botHandles = useBotHandles();
   const [wizard, setWizard] = useState<{ provider: Provider; agentId: string } | null>(null);
   const [unlinkTarget, setUnlinkTarget] = useState<{ provider: Provider; agentId: string } | null>(null);
   const [unlinking, setUnlinking] = useState(false);
@@ -157,12 +130,7 @@ function MyChannelsSectionInner() {
                       <AlertCircle className="h-4 w-4 text-amber-500" />
                     )}
                     <div className="flex-1">
-                      <p className="text-sm font-mono">
-                        {formatBotHandle(
-                          provider,
-                          botHandles[provider]?.[bot.agent_id] || bot.bot_username,
-                        )}
-                      </p>
+                      <p className="text-sm font-mono">{formatBotHandle(provider, bot.bot_username)}</p>
                       <p className="text-xs text-[#8a8578]">{bot.agent_id}</p>
                     </div>
                     {bot.linked ? (


### PR DESCRIPTION
## Summary
Every signup created TWO Stripe customers because \`create_customer_for_owner\` was called concurrently (Clerk webhook + frontend syncUser) and Stripe search is eventually consistent.

Fix: DynamoDB conditional put (\`attribute_not_exists(owner_id)\`) serializes concurrent calls. One wins, losers delete their orphan Stripe customer. Removes Stripe search entirely.

## Test plan
- [ ] Sign up → exactly 1 Stripe customer created
- [ ] Concurrent race → orphan deleted, winner's record returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)