### PR TITLE
fix: skip channel setup for free tier + CLAUDE.md reset docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,58 @@ await fetch('https://api-dev.isol8.co/api/v1/debug/provision', {method:'POST', h
 
 Debug endpoints return 403 in production.
 
+### Clean-Slate Dev Reset
+
+Full wipe of dev state for fresh testing. Requires AWS SSO (`aws sso login --profile isol8-admin`).
+
+**1. Delete ECS containers:** User deletes their OpenClaw ECS services + EFS access points manually from the AWS console (or via `DELETE /debug/provision` per user above).
+
+**2. Wipe EFS user workspaces** (via ECS exec on the backend task):
+```bash
+# Find the backend task
+TASK=$(aws ecs list-tasks --cluster isol8-dev-container-ClusterEB0386A7-Cjwm2mIlW4Aw \
+  --service-name isol8-dev-service-ServiceD69D759B-Va1bdS6qTw9Y \
+  --profile isol8-admin --region us-east-1 \
+  --query 'taskArns[0]' --output text | awk -F'/' '{print $NF}')
+
+# List then wipe all user dirs
+aws ecs execute-command --cluster isol8-dev-container-ClusterEB0386A7-Cjwm2mIlW4Aw \
+  --task $TASK --container backend --interactive \
+  --command "/bin/sh -c 'ls /mnt/efs/users/ && rm -rf /mnt/efs/users/* && ls -la /mnt/efs/users/'" \
+  --profile isol8-admin --region us-east-1
+```
+
+**3. Wipe DynamoDB tables** (all 8 isol8-dev-* tables):
+```bash
+for t in isol8-dev-api-keys isol8-dev-billing-accounts isol8-dev-channel-links \
+         isol8-dev-containers isol8-dev-pending-updates isol8-dev-usage-counters \
+         isol8-dev-users isol8-dev-ws-connections; do
+  keys=$(aws dynamodb describe-table --table-name "$t" --profile isol8-admin \
+    --region us-east-1 --query 'Table.KeySchema[].AttributeName' --output text)
+  count=0
+  while read -r line; do
+    [ -z "$line" ] && continue
+    aws dynamodb delete-item --table-name "$t" --key "$line" \
+      --profile isol8-admin --region us-east-1 >/dev/null 2>&1
+    count=$((count+1))
+  done < <(aws dynamodb scan --table-name "$t" --profile isol8-admin \
+    --region us-east-1 --output json 2>/dev/null | python3 -c "
+import json, sys
+keys = '$keys'.split()
+d = json.load(sys.stdin)
+for item in d.get('Items', []):
+    print(json.dumps({k: item[k] for k in keys}))
+")
+  echo "  $t: $count deleted"
+done
+```
+
+**4. Clean up Stripe:** Delete orphan test customers manually from the [Stripe dashboard](https://dashboard.stripe.com/test/customers) (dev uses test mode keys).
+
+**5. Clean up Clerk:** Delete test users/orgs from the [Clerk dashboard](https://dashboard.clerk.com) if needed.
+
+After all five steps, re-provision starts fresh: new Clerk sign-up → onboarding → container provision → single Stripe customer.
+
 ### Manual dev testing accounts
 
 DO NOT use `isol8-e2e-testing@mailsac.com` for manual dev testing. That Clerk

--- a/apps/frontend/src/components/chat/ProvisioningStepper.tsx
+++ b/apps/frontend/src/components/chat/ProvisioningStepper.tsx
@@ -192,7 +192,9 @@ export function ProvisioningStepper({
     );
     if (anyConnected) return "ready";
 
-    // No channels connected — show onboarding
+    // No channels connected — show onboarding (paid tiers only; free tier
+    // containers scale to zero so bots can't stay connected)
+    if (isFree) return "ready";
     return "channels";
   }, [trigger, isSubscribed, isFree, container, containerReady, gatewayHealth, channelsData, channelsError, onboardingComplete]);
 

--- a/apps/frontend/src/components/control/panels/AgentChannelsSection.tsx
+++ b/apps/frontend/src/components/control/panels/AgentChannelsSection.tsx
@@ -18,6 +18,7 @@ import {
 import { useApi } from "@/lib/api";
 import { type Provider, PROVIDERS, PROVIDER_LABELS, formatBotHandle } from "@/lib/channels";
 import { BotSetupWizard } from "@/components/channels/BotSetupWizard";
+import { useBilling } from "@/hooks/useBilling";
 
 interface BotEntry {
   agent_id: string;
@@ -38,22 +39,27 @@ interface AgentChannelsSectionProps {
 
 export function AgentChannelsSection({ agentId }: AgentChannelsSectionProps) {
   const api = useApi();
+  const { planTier } = useBilling();
+  const isFree = planTier === "free";
   const { data, mutate } = useSWR<LinksMeResponse>(
     "/channels/links/me",
     () => api.get("/channels/links/me") as Promise<LinksMeResponse>,
   );
-  const [wizardFor, setWizardFor] = useState<Provider | null>(null);
+  const [wizardFor, setWizardFor] = useState<{ provider: Provider; mode: "create" | "link-only" } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Provider | null>(null);
   const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
-    if (!wizardFor) return;
+    if (!wizardFor && !deleteTarget) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setWizardFor(null);
+      if (e.key === "Escape") {
+        setWizardFor(null);
+        setDeleteTarget(null);
+      }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [wizardFor]);
+  }, [wizardFor, deleteTarget]);
 
   if (!data) {
     return <div className="p-4 text-sm text-[#8a8578]">Loading channels…</div>;
@@ -83,7 +89,11 @@ export function AgentChannelsSection({ agentId }: AgentChannelsSectionProps) {
                 {PROVIDER_LABELS[provider]}
               </span>
             </div>
-            {bots.length === 0 ? (
+            {isFree ? (
+              <p className="text-xs text-[#8a8578]">
+                Channels require a paid plan. Upgrade from the Billing page to connect {PROVIDER_LABELS[provider]}.
+              </p>
+            ) : bots.length === 0 ? (
               <p className="text-xs text-[#8a8578]">No bot configured</p>
             ) : (
               bots.map((bot) => (
@@ -95,23 +105,35 @@ export function AgentChannelsSection({ agentId }: AgentChannelsSectionProps) {
                   )}
                   <span className="font-mono">{formatBotHandle(provider, bot.bot_username)}</span>
                   <div className="flex-1" />
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setDeleteTarget(provider)}
-                    aria-label={`Delete ${provider} bot`}
-                  >
-                    <Trash2 className="h-3 w-3" />
-                  </Button>
+                  {!bot.linked && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setWizardFor({ provider, mode: "link-only" })}
+                      aria-label={`Link your ${PROVIDER_LABELS[provider]} to ${bot.bot_username}`}
+                    >
+                      Link
+                    </Button>
+                  )}
+                  {data.can_create_bots && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDeleteTarget(provider)}
+                      aria-label={`Delete ${provider} bot`}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
+                  )}
                 </div>
               ))
             )}
-            {data.can_create_bots && bots.length === 0 && (
+            {!isFree && data.can_create_bots && bots.length === 0 && (
               <Button
                 variant="outline"
                 size="sm"
                 className="mt-2"
-                onClick={() => setWizardFor(provider)}
+                onClick={() => setWizardFor({ provider, mode: "create" })}
               >
                 <Plus className="h-3 w-3 mr-1" />
                 Add {PROVIDER_LABELS[provider]} bot
@@ -133,8 +155,8 @@ export function AgentChannelsSection({ agentId }: AgentChannelsSectionProps) {
             onClick={(e) => e.stopPropagation()}
           >
             <BotSetupWizard
-              mode="create"
-              provider={wizardFor}
+              mode={wizardFor.mode}
+              provider={wizardFor.provider}
               agentId={agentId}
               onComplete={() => {
                 setWizardFor(null);

--- a/apps/frontend/src/components/settings/MyChannelsSection.tsx
+++ b/apps/frontend/src/components/settings/MyChannelsSection.tsx
@@ -19,6 +19,7 @@ import { useApi } from "@/lib/api";
 import { type Provider, PROVIDERS, PROVIDER_LABELS, formatBotHandle } from "@/lib/channels";
 import { BotSetupWizard } from "@/components/channels/BotSetupWizard";
 import { GatewayProvider } from "@/hooks/useGateway";
+import { useBilling } from "@/hooks/useBilling";
 
 interface BotEntry {
   agent_id: string;
@@ -48,6 +49,8 @@ export function MyChannelsSection() {
 
 function MyChannelsSectionInner() {
   const api = useApi();
+  const { planTier } = useBilling();
+  const isFree = planTier === "free";
   // bot_username is now populated by the backend via channels.status probe
   const { data, error, isLoading, mutate } = useSWR<LinksMeResponse>(
     "/channels/links/me",
@@ -114,8 +117,14 @@ function MyChannelsSectionInner() {
             </h3>
             {bots.length === 0 ? (
               <div className="rounded-md border border-[#e0dbd0] p-3 text-xs text-[#8a8578]">
-                No {PROVIDER_LABELS[provider]} bots set up in this container.
-                {data.can_create_bots && " Set one up from your agent's Channels tab."}
+                {isFree ? (
+                  <>Channels require a paid plan. Upgrade from the Billing page to connect {PROVIDER_LABELS[provider]}.</>
+                ) : (
+                  <>
+                    No {PROVIDER_LABELS[provider]} bots set up in this container.
+                    {data.can_create_bots && " Set one up from your agent's Channels tab."}
+                  </>
+                )}
               </div>
             ) : (
               <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Free tier users saw the Telegram/channel setup prompt on first login even though their containers scale to zero (bots can't stay connected). Skip the channels phase for free tier.
- Added clean-slate dev reset instructions to CLAUDE.md (EFS wipe, DynamoDB wipe, Stripe/Clerk cleanup).

## Test plan
- [ ] Free tier org → no channel setup prompt after provisioning
- [ ] Paid tier org → channel setup prompt still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)