### PR TITLE
fix(frontend): derive ws.isol8.co for prod apex hostname

### DIFF
--- a/apps/frontend/src/components/control/ControlIframe.tsx
+++ b/apps/frontend/src/components/control/ControlIframe.tsx
@@ -3,21 +3,7 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
 import { Loader2 } from "lucide-react";
-import { BACKEND_URL } from "@/lib/api";
-
-function getWsUrl(): string {
-  if (process.env.NEXT_PUBLIC_WS_URL) return process.env.NEXT_PUBLIC_WS_URL;
-  // Derive from API URL, same logic as useGateway.tsx
-  const apiUrl =
-    process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
-  return apiUrl
-    .replace(/^https:\/\//, "wss://")
-    .replace(/^http:\/\//, "ws://")
-    .replace("api-", "ws-")
-    .replace(/\/api\/v1$/, "");
-}
-
-const WS_URL = getWsUrl();
+import { BACKEND_URL, WS_URL } from "@/lib/api";
 
 export function ControlIframe() {
   const { getToken } = useAuth();

--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -12,6 +12,7 @@ import {
   type ReactNode,
 } from "react";
 import { useAuth } from "@clerk/nextjs";
+import { WS_URL } from "@/lib/api";
 
 // =============================================================================
 // Constants
@@ -22,19 +23,6 @@ const RECONNECT_DELAYS = [1000, 2000, 4000, 8000, 16000, 16000, 16000, 16000, 16
 const PING_INTERVAL_MS = 30000;
 const CONNECTION_TIMEOUT_MS = 10000;
 const RPC_TIMEOUT_MS = 30000;
-
-function getWebSocketUrl(): string {
-  if (process.env.NEXT_PUBLIC_WS_URL) {
-    return process.env.NEXT_PUBLIC_WS_URL;
-  }
-  const apiUrl =
-    process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
-  return apiUrl
-    .replace(/^https:\/\//, "wss://")
-    .replace(/^http:\/\//, "ws://")
-    .replace("api-", "ws-")
-    .replace(/\/api\/v1$/, "");
-}
 
 // =============================================================================
 // Types
@@ -232,8 +220,7 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
         }
       }
 
-      const wsUrl = getWebSocketUrl();
-      const ws = new WebSocket(`${wsUrl}?token=${token}`);
+      const ws = new WebSocket(`${WS_URL}?token=${token}`);
 
       ws.onopen = () => {
         reconnectAttemptRef.current = 0;

--- a/apps/frontend/src/lib/__tests__/api.test.ts
+++ b/apps/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { deriveWebSocketUrl } from '../api';
+
+describe('deriveWebSocketUrl', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_WS_URL;
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_WS_URL;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_WS_URL;
+    } else {
+      process.env.NEXT_PUBLIC_WS_URL = originalEnv;
+    }
+  });
+
+  it('rewrites prod apex hostname: api.isol8.co → ws.isol8.co', () => {
+    // Regression: before the fix this returned `wss://api.isol8.co` because the
+    // old `.replace("api-", "ws-")` only matched env-prefixed hostnames. Prod
+    // silently routed WebSocket traffic to the ALB and failed.
+    expect(deriveWebSocketUrl('https://api.isol8.co/api/v1')).toBe(
+      'wss://ws.isol8.co',
+    );
+  });
+
+  it('rewrites dev env-prefixed hostname: api-dev.isol8.co → ws-dev.isol8.co', () => {
+    expect(deriveWebSocketUrl('https://api-dev.isol8.co/api/v1')).toBe(
+      'wss://ws-dev.isol8.co',
+    );
+  });
+
+  it('rewrites staging env-prefixed hostname', () => {
+    expect(deriveWebSocketUrl('https://api-staging.isol8.co/api/v1')).toBe(
+      'wss://ws-staging.isol8.co',
+    );
+  });
+
+  it('leaves localhost untouched and strips /api/v1', () => {
+    expect(deriveWebSocketUrl('http://localhost:8000/api/v1')).toBe(
+      'ws://localhost:8000',
+    );
+  });
+
+  it('downgrades https→wss and http→ws', () => {
+    expect(deriveWebSocketUrl('http://api-dev.isol8.co/api/v1')).toBe(
+      'ws://ws-dev.isol8.co',
+    );
+  });
+
+  it('NEXT_PUBLIC_WS_URL override short-circuits derivation', () => {
+    process.env.NEXT_PUBLIC_WS_URL = 'wss://custom.example.com';
+    expect(deriveWebSocketUrl('https://api.isol8.co/api/v1')).toBe(
+      'wss://custom.example.com',
+    );
+  });
+
+  it('does not rewrite an unrelated hostname that happens to start with "api"', () => {
+    // "apiary.com" must not become "wsary.com" — the lookahead guards against
+    // matching substrings of longer labels.
+    expect(deriveWebSocketUrl('https://apiary.com/api/v1')).toBe(
+      'wss://apiary.com',
+    );
+  });
+});

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -4,6 +4,39 @@ import { useAuth } from "@clerk/nextjs";
 // Use environment variable for production, fallback to localhost for development
 export const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
 
+/**
+ * Derive the WebSocket gateway URL from `apiUrl`.
+ *
+ * Hostname rewrite:
+ *   api.isol8.co       → ws.isol8.co
+ *   api-dev.isol8.co   → ws-dev.isol8.co
+ *   api-staging.isol8.co → ws-staging.isol8.co
+ *   localhost:8000     → localhost:8000   (untouched — local dev hits the same host)
+ *
+ * Protocol: http → ws, https → wss. Path `/api/v1` is stripped so callers get
+ * the bare WebSocket origin (they append their own path, e.g. `/control-ui/`).
+ *
+ * An explicit `NEXT_PUBLIC_WS_URL` env var takes precedence over derivation so
+ * bespoke environments (e.g. a PR preview against a non-standard gateway) can
+ * override without code changes.
+ */
+export function deriveWebSocketUrl(apiUrl: string): string {
+  if (process.env.NEXT_PUBLIC_WS_URL) {
+    return process.env.NEXT_PUBLIC_WS_URL;
+  }
+  return apiUrl
+    .replace(/^https:\/\//, "wss://")
+    .replace(/^http:\/\//, "ws://")
+    // Rewrite the HOSTNAME only. `\/\/` anchors us right after the scheme so a
+    // path segment like `/api/v1` can't accidentally match; lookahead `(?=[-.])`
+    // requires `-` or `.` after `api` so "apiary.com" wouldn't match and
+    // localhost (which doesn't start with "api") is left alone.
+    .replace(/\/\/api(?=[-.])/, "//ws")
+    .replace(/\/api\/v1$/, "");
+}
+
+export const WS_URL = deriveWebSocketUrl(BACKEND_URL);
+
 interface UploadedFile {
   filename: string;
   path: string;


### PR DESCRIPTION
## Summary

Prod users saw "can't connect to the gateway" after logging in. The frontend was opening a WebSocket against `wss://api.isol8.co` (the ALB, which doesn't speak WebSocket upgrade) instead of `wss://ws.isol8.co` (the API Gateway).

**Root cause:** the WS URL derivation in `useGateway.tsx` used `apiUrl.replace("api-", "ws-")`, which only matches env-prefixed hostnames like `api-dev.isol8.co`. Prod uses the apex `api.isol8.co` (no hyphen), so the replace was a silent no-op.

**Fix:** replace the brittle string substitution with a hostname-anchored regex `\/\/api(?=[-.])` that matches both `//api.` (apex) and `//api-` (env prefix), and leaves localhost and unrelated hostnames untouched.

**Deduplication:** the same derivation existed verbatim in `useGateway.tsx` and `ControlIframe.tsx`, with the second literally commented "same logic as useGateway.tsx." Extract a single `deriveWebSocketUrl` helper in `lib/api.ts` so it can't re-diverge.

**Regression guard:** 7 unit tests in `src/lib/__tests__/api.test.ts` — including the prod-apex case that would have caught this at PR time.

## Test plan
- [x] `pnpm exec vitest run src/lib/__tests__/api.test.ts` — 7/7 passing
- [x] `pnpm run lint` — 0 new errors/warnings
- [ ] After deploy, sign in to `isol8.co` and confirm WebSocket opens to `wss://ws.isol8.co` (not `wss://api.isol8.co`)

## Cases covered
| Input | Output |
|---|---|
| `https://api.isol8.co/api/v1` | `wss://ws.isol8.co` ← the regression |
| `https://api-dev.isol8.co/api/v1` | `wss://ws-dev.isol8.co` |
| `https://api-staging.isol8.co/api/v1` | `wss://ws-staging.isol8.co` |
| `http://localhost:8000/api/v1` | `ws://localhost:8000` |
| `https://apiary.com/api/v1` | `wss://apiary.com` (not rewritten) |
| `NEXT_PUBLIC_WS_URL=wss://custom...` | `wss://custom...` (override wins) |

## Follow-up (separate PR)
`frontend-ci.yml` runs lint + tsc + build only — it does **not** run `pnpm test`, which is why 7 pre-existing unit-test failures (from #205 / #217 / #218 / #221 component changes) have been merging unnoticed. Add `pnpm --filter @isol8/frontend test` to the CI gate as a separate PR so broken tests can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)