### PR TITLE
fix(agents): hide delete button on default agent in control panel

### DIFF
--- a/apps/frontend/src/components/control/panels/AgentsPanel.tsx
+++ b/apps/frontend/src/components/control/panels/AgentsPanel.tsx
@@ -130,20 +130,23 @@ export function AgentsPanel() {
                   <span className="text-[10px] text-[#8a8578] ml-1">(default)</span>
                 )}
               </span>
-              <button
-                className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 hover:text-[#dc2626]"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDelete(agent.id);
-                }}
-                disabled={deleting === agent.id}
-              >
-                {deleting === agent.id ? (
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                ) : (
-                  <Trash2 className="h-3 w-3" />
-                )}
-              </button>
+              {agent.id !== defaultId && (
+                <button
+                  className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 hover:text-[#dc2626]"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete(agent.id);
+                  }}
+                  disabled={deleting === agent.id}
+                  aria-label={`Delete ${agent.name || agent.id}`}
+                >
+                  {deleting === agent.id ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-3 w-3" />
+                  )}
+                </button>
+              )}
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Follow-up to #224. The chat sidebar already hides the delete affordance on the default `main` agent, but the control panel's `AgentsPanel` had no such guard — clicking the trash icon on `main` would fire `agents.delete` and OpenClaw would reject it with an error. This hides the button there too so the two surfaces match.

OpenClaw enforces it at the backend (`src/gateway/server-methods/agents.ts:706-712` rejects `agents.delete` for `DEFAULT_AGENT_ID`), so this is purely a UX fix — preventing the user from clicking a button that can't actually do anything.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] After deploy, open the control panel → Agents → confirm `main` has no trash icon on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)