### PR TITLE
fix(billing+onboarding): one billing row per payer, durable onboarded flag

### DIFF
--- a/apps/backend/routers/billing.py
+++ b/apps/backend/routers/billing.py
@@ -70,13 +70,14 @@ async def _get_billing_account(auth: AuthContext) -> dict | None:
 async def get_billing_account(
     auth: AuthContext = Depends(get_current_user),
 ):
+    # Read-only endpoint. We intentionally do NOT auto-create a billing row
+    # when the caller has no account — check_budget handles `None` by falling
+    # through to free-tier defaults (see core/services/usage_service.py:128),
+    # and the response shape is identical to a free-tier real account.
+    # Billing rows are only written by POST /billing/checkout (explicit
+    # subscribe intent, admin-gated for orgs).
     owner_id = resolve_owner_id(auth)
     account = await _get_billing_account(auth)
-    if not account:
-        # Auto-create for users who signed up before billing existed
-        billing_service = BillingService()
-        owner_type = get_owner_type(auth)
-        account = await billing_service.create_customer_for_owner(owner_id=owner_id, owner_type=owner_type)
 
     budget = await check_budget(owner_id)
 
@@ -86,6 +87,10 @@ async def get_billing_account(
 
     budget_percent = (budget["current_spend"] / budget["included_budget"] * 100) if budget["included_budget"] > 0 else 0
 
+    # overage_limit only exists on real paid-tier rows; synthetic free-tier
+    # response (account is None) always reports None.
+    overage_limit = float(account["overage_limit"]) / 1_000_000 if account and account.get("overage_limit") else None
+
     return BillingAccountResponse(
         tier=budget["tier"],
         is_subscribed=budget["is_subscribed"],
@@ -94,7 +99,7 @@ async def get_billing_account(
         budget_percent=round(budget_percent, 1),
         lifetime_spend=lifetime_spend,
         overage_enabled=budget["overage_enabled"],
-        overage_limit=float(account.get("overage_limit", 0)) / 1_000_000 if account.get("overage_limit") else None,
+        overage_limit=overage_limit,
         within_included=budget["within_included"],
     )
 

--- a/apps/backend/routers/users.py
+++ b/apps/backend/routers/users.py
@@ -4,9 +4,8 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from core.auth import get_current_user, AuthContext, resolve_owner_id, get_owner_type
+from core.auth import get_current_user, AuthContext
 from core.repositories import user_repo
-from core.services.billing_service import BillingService
 from schemas.user_schemas import SyncUserResponse
 
 logger = logging.getLogger(__name__)
@@ -39,21 +38,16 @@ async def sync_user(auth: AuthContext = Depends(get_current_user)):
     else:
         status = "exists"
 
-    # Ensure billing account exists (idempotent — covers users created before billing)
-    try:
-        billing = BillingService()
-        owner_id = resolve_owner_id(auth)
-        owner_type = get_owner_type(auth)
-        await billing.create_customer_for_owner(
-            owner_id=owner_id,
-            owner_type=owner_type,
-        )
-    except Exception as e:
-        logger.warning("Failed to ensure billing account for user %s: %s", user_id, e)
-
-    # Container provisioning is handled by GET /container/status (ProvisioningStepper polls it).
-    # We do NOT auto-provision here because sync is called from multiple places
-    # (onboarding, ChatLayout mount) and the JWT may not have org context yet,
-    # which would incorrectly create a personal container for an org member.
+    # Note: no billing-account creation here. /users/sync fires from multiple
+    # places (ChatLayout mount, onboarding, settings), and the caller's JWT
+    # may be in a transient personal context while Clerk is mid-activation of
+    # an org. Creating a billing row here would produce phantom
+    # personal-context rows for users who are actually org members. Billing is
+    # created lazily by POST /billing/checkout (the explicit "subscribe" signal)
+    # which is also gated on require_org_admin, so only the first admin click
+    # through Stripe Checkout ever writes the row.
+    #
+    # Container provisioning is also handled elsewhere (GET /container/status
+    # + ProvisioningStepper) for the same reason.
 
     return {"status": status, "user_id": user_id}

--- a/apps/backend/tests/unit/routers/test_billing.py
+++ b/apps/backend/tests/unit/routers/test_billing.py
@@ -51,21 +51,19 @@ class TestGetBillingAccount:
     @patch("routers.billing.billing_repo")
     @patch("core.services.billing_service.stripe")
     @patch("core.services.billing_service.billing_repo")
-    async def test_get_billing_account_auto_creates(
+    async def test_get_billing_account_returns_free_defaults_without_creating(
         self, mock_svc_repo, mock_stripe, mock_router_repo, mock_check_budget, mock_usage_repo, async_client
     ):
-        """Should auto-create billing account when none exists."""
+        """GET /billing/account returns synthetic free-tier defaults when no
+        row exists — it must NOT auto-create a Stripe customer or billing row.
+
+        Regression: previously GET /billing/account called
+        create_customer_for_owner on miss, which created a phantom
+        personal-context row for every user whose ChatLayout mounted before
+        their org was active. After the fix, the row is only created by
+        POST /billing/checkout (the explicit subscribe intent, admin-gated).
+        """
         mock_router_repo.get_by_owner_id = AsyncMock(return_value=None)
-        mock_stripe.Customer.create.return_value = MagicMock(id="cus_auto_created")
-        mock_svc_repo.get_by_owner_id = AsyncMock(return_value=None)
-        mock_svc_repo.create_if_not_exists = AsyncMock(
-            return_value={
-                "owner_id": "user_test_123",
-                "stripe_customer_id": "cus_auto_created",
-                "plan_tier": "free",
-                "stripe_subscription_id": None,
-            }
-        )
         mock_check_budget.return_value = {
             "allowed": True,
             "within_included": True,
@@ -79,11 +77,18 @@ class TestGetBillingAccount:
         mock_usage_repo.get_period_usage = AsyncMock(return_value=None)
 
         response = await async_client.get("/api/v1/billing/account")
+
         assert response.status_code == 200
         data = response.json()
         assert data["tier"] == "free"
         assert data["is_subscribed"] is False
         assert data["budget_percent"] == 0.0
+        assert data["overage_limit"] is None
+
+        # Most important assertion: NO auto-create happened. Neither a Stripe
+        # Customer nor a billing_repo write was issued.
+        mock_stripe.Customer.create.assert_not_called()
+        mock_svc_repo.create_if_not_exists.assert_not_called()
 
 
 class TestGetUsage:

--- a/apps/backend/tests/unit/routers/test_users.py
+++ b/apps/backend/tests/unit/routers/test_users.py
@@ -8,14 +8,11 @@ class TestSyncUser:
     """Tests for POST /api/v1/users/sync endpoint."""
 
     @pytest.mark.asyncio
-    @patch("routers.users.BillingService")
     @patch("routers.users.user_repo")
-    async def test_sync_creates_new_user(self, mock_repo, mock_billing_cls, async_client):
-        """Sync creates new user when not exists. No container provisioning."""
+    async def test_sync_creates_new_user(self, mock_repo, async_client):
+        """Sync creates a new /users row when the user doesn't exist."""
         mock_repo.get = AsyncMock(return_value=None)
         mock_repo.put = AsyncMock(return_value=None)
-        mock_billing_svc = AsyncMock()
-        mock_billing_cls.return_value = mock_billing_svc
 
         response = await async_client.post("/api/v1/users/sync")
 
@@ -34,6 +31,29 @@ class TestSyncUser:
         assert response.status_code == 200
         assert response.json()["status"] == "exists"
         assert response.json()["user_id"] == "user_test_123"
+
+    @pytest.mark.asyncio
+    @patch("core.services.billing_service.billing_repo")
+    @patch("core.services.billing_service.stripe")
+    @patch("routers.users.user_repo")
+    async def test_sync_does_not_create_billing_account(
+        self, mock_user_repo, mock_stripe, mock_billing_repo, async_client
+    ):
+        """Regression: /users/sync must NOT create a billing row.
+
+        Creating billing on sync produced phantom personal-context rows when
+        ChatLayout mounted during the transient "Clerk session has no active
+        org yet" window. Billing is now created only by POST /billing/checkout.
+        """
+        mock_user_repo.get = AsyncMock(return_value=None)
+        mock_user_repo.put = AsyncMock(return_value=None)
+
+        response = await async_client.post("/api/v1/users/sync")
+
+        assert response.status_code == 200
+        # Zero Stripe + repo writes. Sync only touched /users.
+        mock_stripe.Customer.create.assert_not_called()
+        mock_billing_repo.create_if_not_exists.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_sync_requires_authentication(self, unauthenticated_async_client):

--- a/apps/frontend/src/app/onboarding/page.tsx
+++ b/apps/frontend/src/app/onboarding/page.tsx
@@ -36,15 +36,12 @@ export default function OnboardingPage() {
   //    an invite but Clerk didn't auto-activate. Call setActive() first,
   //    then redirect once the JWT is settled.
   //
-  // Path 1 is the primary fix for the "Finish button does nothing" bug:
-  // the previous version used afterCreateOrganizationUrl="/onboarding"
-  // which navigated to the same URL (no-op), and the useEffect watching
-  // userMemberships (with infinite: true) never re-fired because the
-  // paginated hook didn't revalidate. useOrganization() IS reactive —
-  // Clerk updates it synchronously when the active org changes.
-  // Auto-redirect when the user already has an org (e.g. accepted an
-  // invite and landed here, or returning to /onboarding after the
-  // CreateOrganization flow finishes via afterCreateOrganizationUrl).
+  // In BOTH paths we also write `unsafeMetadata.onboarded = true`, matching
+  // the personal-flow behavior below. The flag is the durable, user-scoped
+  // source of truth for "has this user completed onboarding" — Clerk's
+  // active-org state is session-scoped and doesn't persist across fresh
+  // logins, so without the flag a user would bounce to /onboarding every
+  // time they log in on a new browser.
   //
   // IMPORTANT: skip when mode === "org" — the user is actively inside
   // Clerk's CreateOrganization component (which includes the invitation
@@ -54,19 +51,31 @@ export default function OnboardingPage() {
   useEffect(() => {
     if (!isLoaded || !orgLoaded || !orgsLoaded) return;
     if (mode === "org") return; // let CreateOrganization handle its flow
+
+    const markOnboardedAndRedirect = async () => {
+      try {
+        await user?.update({ unsafeMetadata: { onboarded: true } });
+      } catch {
+        // Best-effort — failure to write the flag shouldn't block the
+        // redirect; ChatLayout's auto-activate fallback will still get the
+        // user into /chat on subsequent loads.
+      }
+      router.push("/chat");
+    };
+
     // Path 1: org already active
     if (organization) {
-      router.push("/chat");
+      markOnboardedAndRedirect();
       return;
     }
     // Path 2: has memberships but no active org
     const memberships = userMemberships?.data;
     if (memberships && memberships.length > 0 && setActive) {
-      setActive({ organization: memberships[0].organization.id }).then(() => {
-        router.push("/chat");
-      });
+      setActive({ organization: memberships[0].organization.id }).then(
+        markOnboardedAndRedirect,
+      );
     }
-  }, [isLoaded, orgLoaded, orgsLoaded, organization, userMemberships, setActive, router, mode]);
+  }, [isLoaded, orgLoaded, orgsLoaded, organization, userMemberships, setActive, router, mode, user]);
 
   if (!isLoaded || !orgsLoaded || !orgLoaded) return null;
 

--- a/apps/frontend/src/components/chat/ChatLayout.tsx
+++ b/apps/frontend/src/components/chat/ChatLayout.tsx
@@ -2,7 +2,7 @@
 
 import "./ChatLayout.css";
 import { useEffect, useRef, useState } from "react";
-import { useAuth, useOrganization, useUser, UserButton } from "@clerk/nextjs";
+import { useAuth, useOrganization, useOrganizationList, useUser, UserButton } from "@clerk/nextjs";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Settings, Plus, Bot, CheckCircle, CreditCard, Menu, X, FolderOpen, Pencil, Trash2 } from "lucide-react";
 import Link from "next/link";
@@ -53,6 +53,13 @@ export function ChatLayout({
   const { isSignedIn } = useAuth();
   const { user, isLoaded: userLoaded } = useUser();
   const { organization, isLoaded: orgLoaded } = useOrganization();
+  // Watch all of the user's org memberships so we can auto-activate the
+  // first one on fresh logins — Clerk doesn't persist active-org state
+  // across sessions, so without this a user who created an org on laptop A
+  // would land on /onboarding on laptop B despite already being a member.
+  const { userMemberships, setActive, isLoaded: orgListLoaded } = useOrganizationList({
+    userMemberships: true,
+  });
   const router = useRouter();
   const api = useApi();
   const { agents, defaultId, createAgent, deleteAgent, updateAgent } = useAgents();
@@ -82,18 +89,34 @@ export function ChatLayout({
     .slice(0, 2)
     .toUpperCase();
 
-  // Onboarding gate: a single Clerk user must pick personal-vs-org exactly
-  // ONCE, before any container is provisioned. We block rendering until both
-  // Clerk hooks have finished loading AND the user has either marked
-  // themselves onboarded (personal choice stored in unsafeMetadata) or has
-  // an active Clerk organization in their session (org choice — either
-  // invited-via-link or picked via <CreateOrganization/>). Doing the gate
-  // here as an early return (NOT a useEffect) means ProvisioningStepper
-  // literally never mounts until the decision is settled, so it can't fire
-  // a speculative provision with a loading-state JWT.
-  const clerkLoaded = userLoaded && orgLoaded;
+  // Onboarding / context gate. Three orthogonal states, in priority order:
+  //
+  // 1. Needs onboarding: never signed the "personal or org" picker. Send
+  //    them to /onboarding.
+  // 2. Needs auto-activate: already completed onboarding (personal or org)
+  //    AND has at least one org membership BUT no org is active in this
+  //    Clerk session. Fresh login on a new device lands here. We call
+  //    setActive to pick the first membership, which flips `organization`
+  //    on the next render and we continue into /chat.
+  // 3. Ready: either personal (no memberships, onboarded=true) or org
+  //    (organization is non-null).
+  //
+  // Both the onboarding redirect AND the auto-activate branch BLOCK the
+  // main render (early return below). This is critical: we must not let
+  // useAgents / useBilling / useContainerStatus / api.syncUser run while
+  // the JWT is in a transient personal-context state, or those calls
+  // resolve owner_id to the user_id and create phantom personal billing
+  // rows. The 3 orphan billing rows we see in prod today came from exactly
+  // this race.
+  const clerkLoaded = userLoaded && orgLoaded && orgListLoaded;
   const isOnboarded = (user?.unsafeMetadata as Record<string, unknown> | undefined)?.onboarded === true;
-  const needsOnboarding = clerkLoaded && isSignedIn === true && !isOnboarded && !organization;
+  const hasMemberships = (userMemberships?.data?.length ?? 0) > 0;
+
+  // A user needs onboarding if they have neither the flag nor any org
+  // memberships. If they have memberships they're effectively already past
+  // the personal/org decision — we just need to activate one.
+  const needsOnboarding = clerkLoaded && isSignedIn === true && !isOnboarded && !hasMemberships && !organization;
+  const needsAutoActivate = clerkLoaded && isSignedIn === true && !organization && hasMemberships;
 
   useEffect(() => {
     if (needsOnboarding) {
@@ -102,10 +125,24 @@ export function ChatLayout({
   }, [needsOnboarding, router]);
 
   useEffect(() => {
-    if (!isSignedIn) return;
+    if (!needsAutoActivate || !setActive) return;
+    const first = userMemberships?.data?.[0];
+    if (!first) return;
+    setActive({ organization: first.organization.id }).catch((err: unknown) => {
+      console.error("Auto-activate first org membership failed:", err);
+    });
+  }, [needsAutoActivate, setActive, userMemberships]);
 
+  useEffect(() => {
+    if (!isSignedIn) return;
+    // Skip /users/sync while we're still resolving the user's org context.
+    // Firing sync with a pre-activation JWT used to create phantom personal
+    // billing rows — the backend no longer does that write, but we gate
+    // here too so other context-sensitive endpoints called from sync
+    // paths (future-proofing) don't misresolve owner_id either.
+    if (needsAutoActivate || needsOnboarding) return;
     api.syncUser().catch((err: unknown) => console.error("User sync failed:", err));
-  }, [isSignedIn, api]);
+  }, [isSignedIn, api, needsAutoActivate, needsOnboarding]);
 
   // Dispatch DOM event so page.tsx picks up the current agent (external system sync)
   const lastDispatchedRef = useRef<string | null>(null);
@@ -138,11 +175,13 @@ export function ChatLayout({
   }
 
   // Block the whole chat shell until Clerk hydration + onboarding state are
-  // settled. This is the hinge for the personal/org race fix: if we render
-  // ProvisioningStepper before the JWT has finished flipping into its final
-  // context, it fires POST /container/provision with the stale JWT and we
-  // end up with two containers for the same human.
-  if (!clerkLoaded || isSignedIn !== true || needsOnboarding) {
+  // settled AND any pending org auto-activation has landed. This is the
+  // hinge for the personal/org race fix: if we render ProvisioningStepper
+  // (or any owner_id-aware hook) before the JWT has finished flipping into
+  // its final context, it fires POST /container/provision and /billing
+  // reads with a stale JWT and we end up with orphan personal rows for a
+  // user who was always meant to be an org member.
+  if (!clerkLoaded || isSignedIn !== true || needsOnboarding || needsAutoActivate) {
     return (
       <div className="app-shell" style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "100vh" }}>
         <div style={{ color: "#6b6b6b", fontSize: 14 }}>Loading…</div>


### PR DESCRIPTION
## Summary

Two related bugs uncovered by the cofounder's prod test:

1. **Phantom personal billing rows.** Prod had 5 billing-accounts rows for 5 Clerk users + 2 orgs, but only 2 of the user rows mapped to people who actually operated in personal context. The other 3 were orphans created by a ChatLayout race.
2. **Fresh-browser login bounces org users to /onboarding.** Users who completed org creation on one device saw the onboarding picker on the next device because `unsafeMetadata.onboarded` was never written for the org path.

## Billing hygiene

Before: both `POST /users/sync` and `GET /billing/account` called `create_customer_for_owner` on miss. ChatLayout fires both of these the instant `isSignedIn` flips true — **before** Clerk has activated the user's org in a fresh session. The pre-activation JWT resolves `owner_id` to `user_id` (personal context), and a phantom billing row gets written for a user who's exclusively an org member.

After: billing is only written by `POST /billing/checkout` (the explicit "click Subscribe" signal, which is already gated by `require_org_admin` for org callers). `/users/sync` only writes the `/users` row. `GET /billing/account` returns synthetic free-tier defaults computed from `check_budget` when no row exists — identical response shape.

**Invariant:** one billing-accounts row per logical payer. One per org whose admin subscribed. One per personal user who subscribed. Nothing else.

### Free-tier capping is unaffected

Verified before touching anything. `usage-counters` is keyed on `(owner_id, period)`, not on billing rows. `check_budget` and `record_usage` both handle `account is None` by defaulting to `tier="free"` with the hardcoded `$2` lifetime budget from `TIER_CONFIG`. The websocket chat gate at `routers/websocket_chat.py:353` still drops every message with `BUDGET_EXCEEDED` once a free user hits the cap, regardless of whether they have a billing row.

| Concern | Before | After |
|---|---|---|
| Free-tier usage tracked per owner_id | ✅ | ✅ |
| Free-tier $2 cap enforced on every chat | ✅ | ✅ |
| BUDGET_EXCEEDED error shown at cap | ✅ | ✅ |
| `is_subscribed` correctly false in error msg | ✅ | ✅ |
| Phantom personal rows from /users/sync race | ❌ | ✅ |
| Org member triggers a personal row | ❌ | ✅ |

## Onboarding persistence

`unsafeMetadata.onboarded` is user-level (follows the user across devices). Clerk's active-org state is session-level (fresh session = no active org, even if the user is a member). The previous code conflated them: the gate was `!isOnboarded && !organization`, and only the personal path wrote the flag.

Now:
- **Personal path** writes `unsafeMetadata.onboarded = true` (unchanged).
- **Org path** also writes it, on both the "org already active" redirect and the "auto-activate first membership" branch.
- **ChatLayout** treats "has any membership" as equivalent to onboarded, auto-activates the first membership when none is active, and blocks rendering until the activation lands.

Net effect: a user who completed onboarding anywhere — personal or org — never sees /onboarding again on any device.

## ChatLayout gate — the three states

| State | Condition | Render |
|---|---|---|
| **Onboarding** | `!isOnboarded && !hasMemberships && !organization` | Redirect to `/onboarding`, block |
| **Auto-activate** | `!organization && hasMemberships` | Call `setActive(firstMembership)`, block |
| **Ready** | `organization \|\| (isOnboarded && !hasMemberships)` | Render the chat shell |

Blocking on `needsAutoActivate` is the critical bit — it stops `useAgents` / `useBilling` / `useContainerStatus` / `api.syncUser()` from firing during the transient pre-activation window. Combined with the backend fix (sync no longer writes billing), this closes the phantom-row path completely.

## Tests

- **`test_users.py`** — new regression: `test_sync_does_not_create_billing_account` asserts `/users/sync` makes zero Stripe API calls and zero `billing_repo.create_if_not_exists` writes.
- **`test_billing.py`** — rewrote the old `test_get_billing_account_auto_creates` as `test_get_billing_account_returns_free_defaults_without_creating`, asserting the **opposite** — no auto-create happens and the response is well-formed with `overage_limit=None`.
- Backend: **596 tests passing** including the two regression tests above.
- Frontend: `tsc --noEmit` clean, `pnpm lint` 0 errors (11 pre-existing warnings).

## Test plan after deploy

- [ ] Log into prod as an existing org admin on a browser Clerk has never seen → should land directly on `/chat` with the org active, NOT round-trip through `/onboarding`
- [ ] Fresh sign-up → picks Personal → `/chat` loads → `billing-accounts` has exactly one row keyed on `user_id`
- [ ] Fresh sign-up → picks Org → invites a member → member accepts → member logs in → `billing-accounts` has exactly one row keyed on `org_id`, NOT a personal row for the member
- [ ] Org admin clicks Subscribe → completes Stripe checkout → webhook fires → `plan_tier` flips to starter (this also validates the Stripe webhook URL fix happening in parallel)
- [ ] Free user on personal account hits $2 cap → next chat message gets `BUDGET_EXCEEDED` error
- [ ] Prod DynamoDB scan after a fresh round of testing → expect exactly (N org rows + M personal rows) where M = number of users who actually chose Personal

🤖 Generated with [Claude Code](https://claude.com/claude-code)