### PR TITLE
feat(auth+billing): pass Clerk JWT email to Stripe customer creation

### DIFF
--- a/apps/backend/core/auth.py
+++ b/apps/backend/core/auth.py
@@ -61,6 +61,14 @@ class AuthContext:
     org_role: str | None = None
     org_slug: str | None = None
     org_permissions: list[str] = field(default_factory=list)
+    # Caller's primary email, populated from the Clerk JWT `email` claim.
+    # Requires the Clerk JWT template to include
+    # `"email": "{{user.primary_email_address}}"`. Optional — older tokens
+    # issued before that template change won't have it. Used by billing to
+    # attach the email to newly-created Stripe customers so the dashboard
+    # surfaces who each customer belongs to (including bail-outs who clicked
+    # Subscribe but never completed Checkout).
+    email: str | None = None
 
     @property
     def is_org_context(self) -> bool:
@@ -171,6 +179,7 @@ async def get_current_user(
             org_role=org["org_role"],
             org_slug=org["org_slug"],
             org_permissions=org["org_permissions"],
+            email=payload.get("email"),
         )
 
     except jwt.ExpiredSignatureError:
@@ -208,6 +217,7 @@ async def get_optional_user(
             org_role=org["org_role"],
             org_slug=org["org_slug"],
             org_permissions=org["org_permissions"],
+            email=payload.get("email"),
         )
     except Exception:
         return None

--- a/apps/backend/core/services/billing_service.py
+++ b/apps/backend/core/services/billing_service.py
@@ -30,7 +30,9 @@ class BillingServiceError(Exception):
 
 
 class BillingService:
-    async def create_customer_for_owner(self, owner_id: str, owner_type: str = "personal", email: str = "") -> dict:
+    async def create_customer_for_owner(
+        self, owner_id: str, owner_type: str = "personal", email: str | None = None
+    ) -> dict:
         existing = await billing_repo.get_by_owner_id(owner_id)
         if existing:
             return existing
@@ -45,7 +47,7 @@ class BillingService:
         # eventually consistent and still produced duplicates within the
         # same second.
         customer = stripe.Customer.create(
-            email=email or None,
+            email=email,
             metadata={"owner_id": owner_id, "owner_type": owner_type},
         )
 

--- a/apps/backend/routers/billing.py
+++ b/apps/backend/routers/billing.py
@@ -240,7 +240,16 @@ async def create_checkout(
     if not account:
         owner_id = resolve_owner_id(auth)
         owner_type = get_owner_type(auth)
-        account = await billing_service.create_customer_for_owner(owner_id=owner_id, owner_type=owner_type)
+        # Pass the caller's email so the new Stripe customer is born
+        # identifiable. For org context this is the admin who clicked
+        # Subscribe (the org's first paying admin); for personal context
+        # it's the user themselves. Requires the Clerk session token
+        # template to include `"email": "{{user.primary_email_address}}"`.
+        account = await billing_service.create_customer_for_owner(
+            owner_id=owner_id,
+            owner_type=owner_type,
+            email=auth.email,
+        )
 
     url = await billing_service.create_checkout_session(account, request.tier.value)
     return CheckoutResponse(checkout_url=url)

--- a/apps/backend/tests/unit/routers/test_billing.py
+++ b/apps/backend/tests/unit/routers/test_billing.py
@@ -216,6 +216,66 @@ class TestCheckout:
         assert response.status_code == 200
         assert "checkout_url" in response.json()
 
+    @pytest.mark.asyncio
+    @patch("routers.billing.billing_repo")
+    @patch("core.services.billing_service.TIER_PRICES", {"starter": "price_starter"})
+    @patch("core.services.billing_service.billing_repo")
+    @patch("core.services.billing_service.stripe")
+    async def test_create_checkout_passes_email_to_stripe_when_customer_is_new(
+        self,
+        mock_stripe,
+        mock_svc_repo,
+        mock_router_repo,
+        async_client,
+    ):
+        """When the caller has no billing row yet, /billing/checkout creates a
+        new Stripe customer and the AuthContext.email must be passed through
+        so the customer is born identifiable in the Stripe dashboard.
+
+        Regression: previously the email parameter wasn't plumbed through, so
+        every customer created on a Subscribe click had `email=None` until
+        Stripe Checkout's form back-filled it (and only if the user actually
+        completed Checkout — bail-outs were anonymous orphans forever).
+        """
+        from core.auth import AuthContext, get_current_user
+        from main import app
+
+        # Override get_current_user to inject an email-bearing AuthContext.
+        # The default conftest fixture sets email=None, which would just
+        # pass an empty string through and tell us nothing.
+        async def auth_with_email() -> AuthContext:
+            return AuthContext(user_id="user_test_123", email="prabu@example.com")
+
+        app.dependency_overrides[get_current_user] = auth_with_email
+        try:
+            # No existing billing row → checkout will create one.
+            mock_router_repo.get_by_owner_id = AsyncMock(return_value=None)
+            mock_svc_repo.get_by_owner_id = AsyncMock(return_value=None)
+            mock_svc_repo.create_if_not_exists = AsyncMock(
+                return_value={
+                    "owner_id": "user_test_123",
+                    "stripe_customer_id": "cus_new_with_email",
+                    "plan_tier": "free",
+                    "stripe_subscription_id": None,
+                }
+            )
+            mock_stripe.Customer.create.return_value = MagicMock(id="cus_new_with_email")
+            mock_stripe.checkout.Session.create.return_value = MagicMock(url="https://checkout.stripe.com/test_session")
+
+            response = await async_client.post(
+                "/api/v1/billing/checkout",
+                json={"tier": "starter"},
+            )
+
+            assert response.status_code == 200
+            # The critical assertion: Stripe.Customer.create was called with
+            # the email from AuthContext, not None / not empty.
+            mock_stripe.Customer.create.assert_called_once()
+            call_kwargs = mock_stripe.Customer.create.call_args.kwargs
+            assert call_kwargs["email"] == "prabu@example.com"
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+
 
 class TestOverageToggle:
     """Test PUT /api/v1/billing/overage."""


### PR DESCRIPTION
## Summary

Today every Stripe customer we create is born with no email. Only the ones who reach Stripe Checkout get an email back-filled by Stripe's checkout form. Bail-outs and mid-flow drops are anonymous orphans in the dashboard, identifiable only by `cus_*` ID — that's exactly what bit us this week with the 4 unidentifiable customers in the Stripe dashboard after testing.

This change pulls the user's primary email out of the Clerk JWT and passes it through to `Stripe.Customer.create` at the only place we still create customers: the lazy-create on `POST /billing/checkout` (the Subscribe-click path that PR #227 kept).

## What changed

- **`core/auth.py`** — `AuthContext` gains `email: str | None`. Both `get_current_user` and `get_optional_user` populate it from `payload.get("email")`. No defensive fallbacks — `dict.get` already returns None on miss and Stripe accepts `email=None` natively.
- **`core/services/billing_service.py`** — `create_customer_for_owner` signature is now `email: str | None = None`. Passes the value straight through to `Stripe.Customer.create(email=...)`.
- **`routers/billing.py`** — `create_checkout` passes `auth.email` directly to `create_customer_for_owner`.

## Required Clerk dashboard change

Once this is deployed, you need to add the claim in Clerk for the email to actually flow:

**Sessions → Customize session token → Claims editor:**

```json
{
  "email": "{{user.primary_email_address}}"
}
```

Save. Every JWT issued from that point on has the email field populated.

The backend deploys safely **before or after** the Clerk change — without the claim, every JWT just has `email == None` and Stripe customers are created the same way they are today (no email until Stripe Checkout fills one in side-effect-style). So order doesn't matter.

## Effect

| Scenario | Before | After |
|---|---|---|
| User clicks Subscribe + completes Checkout | Stripe back-fills email after Checkout completes | Email set at create. Stripe Checkout matches it. |
| User clicks Subscribe + bails on Checkout | Customer with **no email** in Stripe — orphan, can't identify | Customer with the user's email — identifiable in the dashboard, queryable for funnel/re-engagement |
| Webhook lookup by `cus_*` ID | Works either way | Same |

For org context, the Stripe customer is created when the **first admin** clicks Subscribe and gets that admin's email attached. Subsequent admin clicks reuse the existing customer (per PR #218's conditional-write dedup), so the original buyer's email stays on file. For personal users, the customer gets their own email.

## What this unlocks

- **Identifying bail-out customers in Stripe dashboard** (the immediate problem)
- **Funnel analysis**: sign-up → Subscribe click → Checkout → completion. Each step has an email anchor.
- **Re-engagement**: "Hey, you started signing up — anything we can help with?" sent to bail-outs
- **Support lookups by email** instead of guessing `cus_*` IDs
- **Stripe-sent emails** (receipts, invoices, payment-failed notifications) actually go somewhere now

## Test plan

- [x] Backend: 597 tests passing including new regression
- [x] `test_create_checkout_passes_email_to_stripe_when_customer_is_new` — overrides `get_current_user` with an AuthContext carrying an email, fires `POST /billing/checkout` against a fresh caller (no existing billing row), asserts `Stripe.Customer.create` was called with `email="prabu@example.com"`
- [ ] After deploy + Clerk claim save: fresh signup → click Subscribe → check the new customer in Stripe live dashboard, should show the email immediately
- [ ] Verify backwards compat: a user whose JWT was issued *before* the Clerk claim was saved should still be able to subscribe (just gets email=None on the customer until their JWT refreshes within the next 60s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)