### PR TITLE
fix(billing): defer metered overage line item to explicit opt-in

### DIFF
--- a/apps/backend/core/services/billing_service.py
+++ b/apps/backend/core/services/billing_service.py
@@ -76,9 +76,15 @@ class BillingService:
         if not fixed_price:
             raise BillingServiceError(f"Unknown tier: {tier}")
 
+        # Initial subscription includes ONLY the fixed-price tier line item.
+        # The metered overage line item (STRIPE_METERED_PRICE_ID) is attached
+        # later, and only if the user explicitly opts in via PUT /billing/overage.
+        # See `set_metered_overage_item` below.
+        #
+        # This keeps the Stripe Checkout page clean (one line item, one price)
+        # and prevents the confusing "you're subscribing to Starter AND 1 more"
+        # display where the metered item appears as a second product.
         line_items = [{"price": fixed_price, "quantity": 1}]
-        if METERED_PRICE_ID:
-            line_items.append({"price": METERED_PRICE_ID})
 
         session = stripe.checkout.Session.create(
             customer=billing_account["stripe_customer_id"],
@@ -90,6 +96,52 @@ class BillingService:
             cancel_url=f"{FRONTEND_URL}/chat?subscription=canceled",
         )
         return session.url
+
+    async def set_metered_overage_item(self, billing_account: dict, enabled: bool) -> None:
+        """Attach or detach the metered overage line item on the user's active
+        Stripe subscription.
+
+        Called from PUT /billing/overage when the user toggles the overage
+        setting. Idempotent — if the line item is already in the desired state,
+        no Stripe write happens beyond the lookup.
+
+        Raises:
+            BillingServiceError: when the account has no active subscription
+                (free tier or canceled), or when STRIPE_METERED_PRICE_ID is
+                unconfigured. Caller is expected to surface this as a 400.
+        """
+        if not METERED_PRICE_ID:
+            raise BillingServiceError("Metered price ID not configured")
+
+        sub_id = billing_account.get("stripe_subscription_id")
+        if not sub_id:
+            raise BillingServiceError("No active subscription to modify")
+
+        subscription = stripe.Subscription.retrieve(sub_id)
+        existing_metered_item = None
+        for item in subscription["items"]["data"]:
+            if item["price"]["id"] == METERED_PRICE_ID:
+                existing_metered_item = item
+                break
+
+        if enabled and existing_metered_item is None:
+            # Add the metered line item to the existing subscription. The
+            # user's card auth from initial checkout covers this — Stripe
+            # doesn't require a new authorization to add a metered usage
+            # component.
+            stripe.Subscription.modify(
+                sub_id,
+                items=[{"price": METERED_PRICE_ID}],
+            )
+        elif not enabled and existing_metered_item is not None:
+            # Remove the metered line item. Stripe's `deleted: true` flag on
+            # an existing item id removes that item without affecting the
+            # rest of the subscription.
+            stripe.Subscription.modify(
+                sub_id,
+                items=[{"id": existing_metered_item["id"], "deleted": True}],
+            )
+        # else: already in the desired state — no-op.
 
     async def create_portal_session(self, billing_account: dict) -> str:
         session = stripe.billing_portal.Session.create(

--- a/apps/backend/routers/billing.py
+++ b/apps/backend/routers/billing.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from core.auth import AuthContext, get_current_user, resolve_owner_id, get_owner_type, require_org_admin
 from core.config import settings, TIER_CONFIG
 from core.repositories import billing_repo, usage_repo
-from core.services.billing_service import BillingService
+from core.services.billing_service import BillingService, BillingServiceError
 from core.services.usage_service import check_budget, get_usage_summary
 from core.services.bedrock_pricing import get_all_prices
 from core.services.update_service import queue_tier_change
@@ -294,6 +294,18 @@ async def toggle_overage(
     account = await billing_repo.get_by_owner_id(owner_id)
     if not account:
         raise HTTPException(status_code=404, detail="Billing account not found")
+
+    # Attach or detach the metered line item on the live Stripe subscription
+    # FIRST. We only flip the DynamoDB flag if the Stripe write succeeds —
+    # otherwise the two diverge and `record_usage` could try to report meter
+    # events against a subscription that doesn't have the metered item
+    # (Stripe would silently drop them and the customer would never be billed
+    # for usage they actually consumed).
+    billing_service = BillingService()
+    try:
+        await billing_service.set_metered_overage_item(account, request.enabled)
+    except BillingServiceError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     limit_microdollars = int(request.limit_dollars * 1_000_000) if request.limit_dollars is not None else None
     await billing_repo.set_overage_enabled(owner_id, request.enabled, overage_limit=limit_microdollars)

--- a/apps/backend/tests/unit/routers/test_billing.py
+++ b/apps/backend/tests/unit/routers/test_billing.py
@@ -197,9 +197,18 @@ class TestCheckout:
     @pytest.mark.asyncio
     @patch("routers.billing.billing_repo")
     @patch("core.services.billing_service.TIER_PRICES", {"starter": "price_starter"})
+    @patch("core.services.billing_service.METERED_PRICE_ID", "price_metered_test")
     @patch("core.services.billing_service.stripe")
-    async def test_create_checkout(self, mock_stripe, mock_repo, async_client):
-        """Should return Stripe checkout URL."""
+    async def test_create_checkout_only_attaches_fixed_tier_item(self, mock_stripe, mock_repo, async_client):
+        """Initial checkout must include ONLY the fixed-price tier line item.
+
+        Regression: previously the metered overage line item
+        (STRIPE_METERED_PRICE_ID) was always attached at checkout time, which
+        produced a confusing two-line Stripe Checkout page where users thought
+        they were subscribing to two products. The metered item is now only
+        attached when the user explicitly toggles overage on via PUT
+        /billing/overage — see `set_metered_overage_item` in billing_service.
+        """
         mock_repo.get_by_owner_id = AsyncMock(
             return_value={
                 "owner_id": "user_test_123",
@@ -215,6 +224,13 @@ class TestCheckout:
         )
         assert response.status_code == 200
         assert "checkout_url" in response.json()
+
+        # Critical assertion: exactly one line item, the fixed-price tier.
+        # No metered overage line item, even though METERED_PRICE_ID is
+        # configured (patched to "price_metered_test" above).
+        mock_stripe.checkout.Session.create.assert_called_once()
+        call_kwargs = mock_stripe.checkout.Session.create.call_args.kwargs
+        assert call_kwargs["line_items"] == [{"price": "price_starter", "quantity": 1}]
 
     @pytest.mark.asyncio
     @patch("routers.billing.billing_repo")
@@ -278,47 +294,166 @@ class TestCheckout:
 
 
 class TestOverageToggle:
-    """Test PUT /api/v1/billing/overage."""
+    """Test PUT /api/v1/billing/overage.
+
+    The toggle now does TWO things in sequence:
+      1. Stripe: attach (or detach) the metered overage line item on the
+         user's active subscription via `Subscription.modify`.
+      2. DynamoDB: flip the `overage_enabled` flag.
+
+    Stripe-first ordering matters: if the Stripe write fails the DB stays
+    untouched, so we never end up in a state where the DB says "overage on"
+    but the subscription has no metered item (which would silently drop
+    meter events and the customer wouldn't get billed for usage).
+    """
 
     @pytest.mark.asyncio
     @patch("routers.billing.billing_repo")
-    async def test_toggle_overage_on(self, mock_repo, async_client):
-        """Should enable overage with limit."""
+    @patch("core.services.billing_service.METERED_PRICE_ID", "price_metered_test")
+    @patch("core.services.billing_service.stripe")
+    async def test_toggle_overage_on_attaches_metered_item_to_subscription(self, mock_stripe, mock_repo, async_client):
+        """Toggling overage ON adds the metered line item to the existing
+        Stripe subscription AND flips the DynamoDB flag."""
         mock_repo.get_by_owner_id = AsyncMock(
             return_value={
                 "owner_id": "user_test_123",
                 "stripe_customer_id": "cus_test",
+                "stripe_subscription_id": "sub_test_123",
                 "plan_tier": "starter",
             }
         )
         mock_repo.set_overage_enabled = AsyncMock(return_value={})
+        # Subscription currently has only the fixed tier item (the new
+        # post-checkout state), no metered item yet.
+        mock_stripe.Subscription.retrieve.return_value = {
+            "items": {
+                "data": [
+                    {"id": "si_fixed", "price": {"id": "price_starter"}},
+                ]
+            }
+        }
 
         response = await async_client.put(
             "/api/v1/billing/overage",
             json={"enabled": True, "limit_dollars": 50.0},
         )
         assert response.status_code == 200
+
+        # Stripe: metered item ADDED to the existing subscription
+        mock_stripe.Subscription.modify.assert_called_once_with(
+            "sub_test_123",
+            items=[{"price": "price_metered_test"}],
+        )
+        # DynamoDB: flag flipped on
         mock_repo.set_overage_enabled.assert_called_once_with("user_test_123", True, overage_limit=50_000_000)
 
     @pytest.mark.asyncio
     @patch("routers.billing.billing_repo")
-    async def test_toggle_overage_off(self, mock_repo, async_client):
-        """Should disable overage."""
+    @patch("core.services.billing_service.METERED_PRICE_ID", "price_metered_test")
+    @patch("core.services.billing_service.stripe")
+    async def test_toggle_overage_off_removes_metered_item_from_subscription(
+        self, mock_stripe, mock_repo, async_client
+    ):
+        """Toggling overage OFF removes the metered line item from the
+        existing Stripe subscription AND flips the DynamoDB flag."""
         mock_repo.get_by_owner_id = AsyncMock(
             return_value={
                 "owner_id": "user_test_123",
                 "stripe_customer_id": "cus_test",
+                "stripe_subscription_id": "sub_test_123",
                 "plan_tier": "starter",
             }
         )
         mock_repo.set_overage_enabled = AsyncMock(return_value={})
+        # Subscription has BOTH the fixed item AND the metered item.
+        mock_stripe.Subscription.retrieve.return_value = {
+            "items": {
+                "data": [
+                    {"id": "si_fixed", "price": {"id": "price_starter"}},
+                    {"id": "si_metered", "price": {"id": "price_metered_test"}},
+                ]
+            }
+        }
 
         response = await async_client.put(
             "/api/v1/billing/overage",
             json={"enabled": False},
         )
         assert response.status_code == 200
+
+        # Stripe: metered item REMOVED via deleted=true on its item id
+        mock_stripe.Subscription.modify.assert_called_once_with(
+            "sub_test_123",
+            items=[{"id": "si_metered", "deleted": True}],
+        )
+        # DynamoDB: flag flipped off
         mock_repo.set_overage_enabled.assert_called_once_with("user_test_123", False, overage_limit=None)
+
+    @pytest.mark.asyncio
+    @patch("routers.billing.billing_repo")
+    @patch("core.services.billing_service.METERED_PRICE_ID", "price_metered_test")
+    @patch("core.services.billing_service.stripe")
+    async def test_toggle_overage_on_is_idempotent_when_item_already_present(
+        self, mock_stripe, mock_repo, async_client
+    ):
+        """Toggling on when the metered item is already attached must be a
+        no-op on Stripe (no Subscription.modify call) but still update the
+        DynamoDB row (e.g. limit change without a state change)."""
+        mock_repo.get_by_owner_id = AsyncMock(
+            return_value={
+                "owner_id": "user_test_123",
+                "stripe_customer_id": "cus_test",
+                "stripe_subscription_id": "sub_test_123",
+                "plan_tier": "starter",
+            }
+        )
+        mock_repo.set_overage_enabled = AsyncMock(return_value={})
+        mock_stripe.Subscription.retrieve.return_value = {
+            "items": {
+                "data": [
+                    {"id": "si_fixed", "price": {"id": "price_starter"}},
+                    {"id": "si_metered", "price": {"id": "price_metered_test"}},
+                ]
+            }
+        }
+
+        response = await async_client.put(
+            "/api/v1/billing/overage",
+            json={"enabled": True, "limit_dollars": 100.0},
+        )
+        assert response.status_code == 200
+
+        # No Stripe modify call — already in desired state
+        mock_stripe.Subscription.modify.assert_not_called()
+        # DynamoDB still updated with the new limit
+        mock_repo.set_overage_enabled.assert_called_once_with("user_test_123", True, overage_limit=100_000_000)
+
+    @pytest.mark.asyncio
+    @patch("routers.billing.billing_repo")
+    @patch("core.services.billing_service.METERED_PRICE_ID", "price_metered_test")
+    @patch("core.services.billing_service.stripe")
+    async def test_toggle_overage_400_when_no_active_subscription(self, mock_stripe, mock_repo, async_client):
+        """Toggling overage on a free-tier (or canceled) account must 400 —
+        you can't have overage without a subscription to attach it to."""
+        mock_repo.get_by_owner_id = AsyncMock(
+            return_value={
+                "owner_id": "user_test_123",
+                "stripe_customer_id": "cus_test",
+                "stripe_subscription_id": None,  # ← no active sub
+                "plan_tier": "free",
+            }
+        )
+        mock_repo.set_overage_enabled = AsyncMock(return_value={})
+
+        response = await async_client.put(
+            "/api/v1/billing/overage",
+            json={"enabled": True},
+        )
+        assert response.status_code == 400
+
+        # Neither Stripe nor the DB was touched after the validation failed
+        mock_stripe.Subscription.modify.assert_not_called()
+        mock_repo.set_overage_enabled.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("routers.billing.billing_repo")


### PR DESCRIPTION
## Summary

Today every Stripe Checkout for a paid tier ships with TWO line items: the fixed-price tier (e.g. Starter $40/mo) AND the metered overage price ($0.01 per million tokens). The Stripe Checkout page renders this as **"Subscribe to Isol8 Starter and 1 more"** with a confusing second-line entry labeled "Isol8 Enterprise — Price varies — \$0.01 per unit", and users worry they're being double-charged or added to a second plan.

The metered item is dormant ($0 today, only bills if usage exceeds the included budget AND `overage_enabled=True`), but the UX is broken regardless. This PR splits the two: initial subscribe shows ONE clean line item, the metered overage is attached only when the user explicitly opts in via Settings.

## What changed

- **`billing_service.create_checkout_session`** — no longer attaches the metered line item. Initial subscribe = one fixed-price line item, period.
- **New `billing_service.set_metered_overage_item(account, enabled)`**:
  - Looks up the active subscription via `Stripe.Subscription.retrieve`
  - **Enabled & not present** → adds via `Subscription.modify(items=[{price: METERED_PRICE_ID}])`
  - **Disabled & present** → removes via `Subscription.modify(items=[{id: ..., deleted: True}])`
  - Idempotent (already-in-desired-state is a no-op)
  - Raises `BillingServiceError` if no active subscription or `METERED_PRICE_ID` is unconfigured
- **`routers/billing.toggle_overage`** — calls the service method **first**, then flips the DynamoDB flag only if the Stripe write succeeds. Stripe-first ordering matters: if we flipped the DB first and Stripe failed, the DB would say "overage on" but the subscription would have no metered item, and `record_usage` would silently drop meter events forever.

## What the user sees

| Action | Before | After |
|---|---|---|
| Click Subscribe to Starter | Stripe Checkout shows **2 line items**: Starter $40 + "Isol8 Enterprise / $0.01 per unit". User confused. | Stripe Checkout shows **1 line item**: Starter $40. Clean. |
| Settings → Enable overage toggle | DynamoDB flag flipped, no Stripe change | DynamoDB flag flipped + metered item attached to subscription via API. **No Stripe redirect** — card auth from initial checkout covers it. |
| Settings → Disable overage toggle | DynamoDB flag flipped, no Stripe change | DynamoDB flag flipped + metered item removed from subscription |
| Free tier toggles overage on | 200 OK, flag flipped (silently broken) | **400** — can't have overage without an active subscription |

## Tests

- **`test_create_checkout_only_attaches_fixed_tier_item`** — patches `METERED_PRICE_ID` to a non-empty value (proving the omission is intentional, not a env-var-not-set side effect) and asserts `Stripe.checkout.Session.create` was called with exactly one line item: `[{"price": "price_starter", "quantity": 1}]`.
- **`test_toggle_overage_on_attaches_metered_item_to_subscription`** — asserts `Subscription.modify` is called to add the metered item AND the DynamoDB flag is flipped.
- **`test_toggle_overage_off_removes_metered_item_from_subscription`** — asserts `Subscription.modify` is called with `{id: ..., deleted: True}` to remove the metered item.
- **`test_toggle_overage_on_is_idempotent_when_item_already_present`** — asserts no Stripe call when the metered item is already attached, but DynamoDB still updates (e.g. for a limit change).
- **`test_toggle_overage_400_when_no_active_subscription`** — asserts free-tier toggle attempts return 400 and touch neither Stripe nor the DB.
- Backend: **599 tests passing**.

## Stripe dashboard cleanup (separate, not in this PR)

The product currently named **"Isol8 Enterprise"** that holds the metered price (`STRIPE_METERED_PRICE_ID`) should be renamed in the Stripe Dashboard to something like **"LLM Usage Overage"** with a description like *"Pay-as-you-go usage charged per million tokens beyond your included monthly budget"*. The price ID stays the same so no env var update — pure dashboard rename. Only matters when overage is actually enabled (the metered item appears in invoices and the customer portal at that point).

## Test plan

- [x] Backend tests passing (599)
- [ ] After deploy: subscribe to Starter on prod with the test promo code, confirm Stripe Checkout shows ONE line item (Starter $40), not two
- [ ] After subscribe: in Settings, toggle "Enable overage" on, confirm in Stripe dashboard that the metered item appears on the subscription
- [ ] Toggle "Enable overage" off, confirm the metered item is removed from the subscription
- [ ] Verify free-tier user attempting to toggle overage gets a 400 in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)