### PR TITLE
ci: update deploy.yml for observability stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -225,7 +225,7 @@ jobs:
           role-to-assume: arn:aws:iam::877352799272:role/isol8-dev-github-actions
       - id: Publish
         name: Publish Assets-FileAsset14
-        run: /bin/bash ./cdk.out/assembly-prod/publish-Assets-FileAsset14-step.sh
+        run: /bin/bash ./cdk.out/assembly-dev/publish-Assets-FileAsset14-step.sh
   Assets-FileAsset15:
     name: Publish Assets Assets-FileAsset15
     needs:
@@ -422,6 +422,62 @@ jobs:
       - id: Publish
         name: Publish Assets-FileAsset20
         run: /bin/bash ./cdk.out/assembly-prod/publish-Assets-FileAsset20-step.sh
+  Assets-FileAsset21:
+    name: Publish Assets Assets-FileAsset21
+    needs:
+      - Build-Synth
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    outputs:
+      asset-hash: ${{ steps.Publish.outputs.asset-hash }}
+    steps:
+      - name: Download cdk.out
+        uses: actions/download-artifact@v4
+        with:
+          name: cdk.out
+          path: cdk.out
+      - name: Install
+        run: npm install --no-save cdk-assets
+      - name: Authenticate Via OIDC Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-duration-seconds: 1800
+          role-skip-session-tagging: true
+          role-to-assume: arn:aws:iam::877352799272:role/isol8-dev-github-actions
+      - id: Publish
+        name: Publish Assets-FileAsset21
+        run: /bin/bash ./cdk.out/assembly-prod/publish-Assets-FileAsset21-step.sh
+  Assets-FileAsset22:
+    name: Publish Assets Assets-FileAsset22
+    needs:
+      - Build-Synth
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    outputs:
+      asset-hash: ${{ steps.Publish.outputs.asset-hash }}
+    steps:
+      - name: Download cdk.out
+        uses: actions/download-artifact@v4
+        with:
+          name: cdk.out
+          path: cdk.out
+      - name: Install
+        run: npm install --no-save cdk-assets
+      - name: Authenticate Via OIDC Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-duration-seconds: 1800
+          role-skip-session-tagging: true
+          role-to-assume: arn:aws:iam::877352799272:role/isol8-dev-github-actions
+      - id: Publish
+        name: Publish Assets-FileAsset22
+        run: /bin/bash ./cdk.out/assembly-prod/publish-Assets-FileAsset22-step.sh
   Assets-FileAsset3:
     name: Publish Assets Assets-FileAsset3
     needs:
@@ -895,6 +951,48 @@ jobs:
           no-fail-on-empty-changeset: "1"
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
+  dev-isol8-dev-observability-Deploy:
+    name: Deploy devisol8devobservability5B153899
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+      - Build-Synth
+      - Assets-FileAsset14
+      - dev-isol8-dev-network-Deploy
+      - dev-isol8-dev-api-Deploy
+      - dev-isol8-dev-container-Deploy
+      - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-database-Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate Via OIDC Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 1800
+          role-skip-session-tagging: true
+          role-to-assume: arn:aws:iam::877352799272:role/isol8-dev-github-actions
+      - name: Assume CDK Deploy Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 1800
+          role-skip-session-tagging: true
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ env.AWS_SESSION_TOKEN }}
+          role-to-assume: arn:aws:iam::877352799272:role/cdk-hnb659fds-deploy-role-877352799272-us-east-1
+          role-external-id: Pipeline
+      - id: Deploy
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          name: isol8-dev-observability
+          template: https://cdk-hnb659fds-assets-877352799272-us-east-1.s3.us-east-1.amazonaws.com/${{
+            needs.Assets-FileAsset14.outputs.asset-hash }}.json
+          no-fail-on-empty-changeset: "1"
+          capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
+          role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
   dev-DeployVercelDev:
     name: DeployVercelDev
     permissions:
@@ -908,6 +1006,7 @@ jobs:
       - dev-isol8-dev-api-Deploy
       - dev-isol8-dev-container-Deploy
       - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
       - Build-Synth
     env: {}
     steps:
@@ -958,7 +1057,7 @@ jobs:
       id-token: write
     needs:
       - Build-Synth
-      - Assets-FileAsset14
+      - Assets-FileAsset15
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -966,6 +1065,7 @@ jobs:
       - dev-isol8-dev-api-Deploy
       - dev-isol8-dev-container-Deploy
       - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
       - dev-DeployVercelDev
     runs-on: ubuntu-latest
     steps:
@@ -992,7 +1092,7 @@ jobs:
         with:
           name: isol8-prod-auth
           template: https://cdk-hnb659fds-assets-877352799272-us-east-1.s3.us-east-1.amazonaws.com/${{
-            needs.Assets-FileAsset14.outputs.asset-hash }}.json
+            needs.Assets-FileAsset15.outputs.asset-hash }}.json
           no-fail-on-empty-changeset: "1"
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
@@ -1003,7 +1103,7 @@ jobs:
       id-token: write
     needs:
       - Build-Synth
-      - Assets-FileAsset15
+      - Assets-FileAsset16
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1011,6 +1111,7 @@ jobs:
       - dev-isol8-dev-api-Deploy
       - dev-isol8-dev-container-Deploy
       - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
       - dev-DeployVercelDev
     runs-on: ubuntu-latest
     steps:
@@ -1037,7 +1138,7 @@ jobs:
         with:
           name: isol8-prod-dns
           template: https://cdk-hnb659fds-assets-877352799272-us-east-1.s3.us-east-1.amazonaws.com/${{
-            needs.Assets-FileAsset15.outputs.asset-hash }}.json
+            needs.Assets-FileAsset16.outputs.asset-hash }}.json
           no-fail-on-empty-changeset: "1"
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
@@ -1048,7 +1149,7 @@ jobs:
       id-token: write
     needs:
       - Build-Synth
-      - Assets-FileAsset16
+      - Assets-FileAsset17
       - prod-isol8-prod-auth-Deploy
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
@@ -1057,6 +1158,7 @@ jobs:
       - dev-isol8-dev-api-Deploy
       - dev-isol8-dev-container-Deploy
       - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
       - dev-DeployVercelDev
     runs-on: ubuntu-latest
     steps:
@@ -1083,7 +1185,7 @@ jobs:
         with:
           name: isol8-prod-database
           template: https://cdk-hnb659fds-assets-877352799272-us-east-1.s3.us-east-1.amazonaws.com/${{
-            needs.Assets-FileAsset16.outputs.asset-hash }}.json
+            needs.Assets-FileAsset17.outputs.asset-hash }}.json
           no-fail-on-empty-changeset: "1"
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
@@ -1094,7 +1196,7 @@ jobs:
       id-token: write
     needs:
       - Build-Synth
-      - Assets-FileAsset17
+      - Assets-FileAsset18
       - Assets-FileAsset5
       - prod-isol8-prod-dns-Deploy
       - dev-isol8-dev-auth-Deploy
@@ -1104,6 +1206,7 @@ jobs:
       - dev-isol8-dev-api-Deploy
       - dev-isol8-dev-container-Deploy
       - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
       - dev-DeployVercelDev
     runs-on: ubuntu-latest
     steps:
@@ -1130,7 +1233,7 @@ jobs:
         with:
           name: isol8-prod-network
           template: https://cdk-hnb659fds-assets-877352799272-us-east-1.s3.us-east-1.amazonaws.com/${{
-            needs.Assets-FileAsset17.outputs.asset-hash }}.json
+            needs.Assets-FileAsset18.outputs.asset-hash }}.json
           no-fail-on-empty-changeset: "1"
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
@@ -1141,7 +1244,7 @@ jobs:
       id-token: write
     needs:
       - Build-Synth
-      - Assets-FileAsset18
+      - Assets-FileAsset19
       - Assets-FileAsset7
       - Assets-FileAsset8
       - Assets-FileAsset9
@@ -1156,6 +1259,7 @@ jobs:
       - dev-isol8-dev-api-Deploy
       - dev-isol8-dev-container-Deploy
       - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
       - dev-DeployVercelDev
     runs-on: ubuntu-latest
     steps:
@@ -1182,7 +1286,7 @@ jobs:
         with:
           name: isol8-prod-api
           template: https://cdk-hnb659fds-assets-877352799272-us-east-1.s3.us-east-1.amazonaws.com/${{
-            needs.Assets-FileAsset18.outputs.asset-hash }}.json
+            needs.Assets-FileAsset19.outputs.asset-hash }}.json
           no-fail-on-empty-changeset: "1"
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
@@ -1193,7 +1297,7 @@ jobs:
       id-token: write
     needs:
       - Build-Synth
-      - Assets-FileAsset19
+      - Assets-FileAsset20
       - prod-isol8-prod-network-Deploy
       - prod-isol8-prod-auth-Deploy
       - dev-isol8-dev-auth-Deploy
@@ -1203,6 +1307,7 @@ jobs:
       - dev-isol8-dev-api-Deploy
       - dev-isol8-dev-container-Deploy
       - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
       - dev-DeployVercelDev
     runs-on: ubuntu-latest
     steps:
@@ -1229,7 +1334,7 @@ jobs:
         with:
           name: isol8-prod-container
           template: https://cdk-hnb659fds-assets-877352799272-us-east-1.s3.us-east-1.amazonaws.com/${{
-            needs.Assets-FileAsset19.outputs.asset-hash }}.json
+            needs.Assets-FileAsset20.outputs.asset-hash }}.json
           no-fail-on-empty-changeset: "1"
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
@@ -1240,7 +1345,7 @@ jobs:
       id-token: write
     needs:
       - Build-Synth
-      - Assets-FileAsset20
+      - Assets-FileAsset21
       - Assets-DockerAsset1
       - prod-isol8-prod-network-Deploy
       - prod-isol8-prod-container-Deploy
@@ -1254,6 +1359,7 @@ jobs:
       - dev-isol8-dev-api-Deploy
       - dev-isol8-dev-container-Deploy
       - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
       - dev-DeployVercelDev
     runs-on: ubuntu-latest
     steps:
@@ -1280,7 +1386,58 @@ jobs:
         with:
           name: isol8-prod-service
           template: https://cdk-hnb659fds-assets-877352799272-us-east-1.s3.us-east-1.amazonaws.com/${{
-            needs.Assets-FileAsset20.outputs.asset-hash }}.json
+            needs.Assets-FileAsset21.outputs.asset-hash }}.json
+          no-fail-on-empty-changeset: "1"
+          capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
+          role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
+  prod-isol8-prod-observability-Deploy:
+    name: Deploy prodisol8prodobservability8583B78D
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+      - Build-Synth
+      - Assets-FileAsset22
+      - prod-isol8-prod-network-Deploy
+      - prod-isol8-prod-api-Deploy
+      - prod-isol8-prod-container-Deploy
+      - prod-isol8-prod-service-Deploy
+      - prod-isol8-prod-database-Deploy
+      - dev-isol8-dev-auth-Deploy
+      - dev-isol8-dev-dns-Deploy
+      - dev-isol8-dev-database-Deploy
+      - dev-isol8-dev-network-Deploy
+      - dev-isol8-dev-api-Deploy
+      - dev-isol8-dev-container-Deploy
+      - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
+      - dev-DeployVercelDev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate Via OIDC Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 1800
+          role-skip-session-tagging: true
+          role-to-assume: arn:aws:iam::877352799272:role/isol8-dev-github-actions
+      - name: Assume CDK Deploy Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 1800
+          role-skip-session-tagging: true
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ env.AWS_SESSION_TOKEN }}
+          role-to-assume: arn:aws:iam::877352799272:role/cdk-hnb659fds-deploy-role-877352799272-us-east-1
+          role-external-id: Pipeline
+      - id: Deploy
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          name: isol8-prod-observability
+          template: https://cdk-hnb659fds-assets-877352799272-us-east-1.s3.us-east-1.amazonaws.com/${{
+            needs.Assets-FileAsset22.outputs.asset-hash }}.json
           no-fail-on-empty-changeset: "1"
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws:iam::877352799272:role/cdk-hnb659fds-cfn-exec-role-877352799272-us-east-1
@@ -1297,6 +1454,7 @@ jobs:
       - prod-isol8-prod-api-Deploy
       - prod-isol8-prod-container-Deploy
       - prod-isol8-prod-service-Deploy
+      - prod-isol8-prod-observability-Deploy
       - Build-Synth
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
@@ -1305,6 +1463,7 @@ jobs:
       - dev-isol8-dev-api-Deploy
       - dev-isol8-dev-container-Deploy
       - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
       - dev-DeployVercelDev
     env: {}
     steps:


### PR DESCRIPTION
## Summary

CDK Pipelines requires the generated `.github/workflows/deploy.yml` to match what `cdk synth` produces. Adding the ObservabilityStack changed the pipeline definition, so the workflow file needs to be updated.

This is a generated file — 174 new lines are deployment steps for the new `isol8-{env}-observability` stack in both dev and prod stages.

## Test plan
- [ ] Deploy succeeds (synth step passes now that workflow matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)