### PR TITLE
security(auth): harden JWKS cache + add JWT clock skew tolerance

### DIFF
--- a/apps/backend/core/auth.py
+++ b/apps/backend/core/auth.py
@@ -15,9 +15,10 @@ logger = logging.getLogger(__name__)
 security = HTTPBearer()
 security_optional = HTTPBearer(auto_error=False)
 
-# JWKS cache with TTL
-_jwks_cache: dict = {"data": None, "expires_at": None}  # TODO: Change this to an actual cache backend
-JWKS_CACHE_TTL = timedelta(hours=1)
+# JWKS cache with TTL — 5 min refresh, 15 min max stale before fail-closed
+_jwks_cache: dict = {"data": None, "expires_at": None}
+JWKS_CACHE_TTL = timedelta(minutes=5)
+_JWKS_MAX_STALE = timedelta(minutes=15)
 
 
 async def _get_cached_jwks(jwks_url: str) -> dict:
@@ -43,10 +44,13 @@ async def _get_cached_jwks(jwks_url: str) -> dict:
         return jwks
     except httpx.HTTPError as e:
         put_metric("auth.jwks.refresh", dimensions={"status": "error"})
-        # If fetch fails but we have stale cached data, use it as fallback
-        if _jwks_cache["data"]:
-            logger.warning(f"JWKS fetch failed, using stale cache: {e}")
-            return _jwks_cache["data"]
+        # Serve stale cache up to _JWKS_MAX_STALE, then fail closed
+        if _jwks_cache["data"] and _jwks_cache["expires_at"]:
+            staleness = now - _jwks_cache["expires_at"]
+            if staleness < _JWKS_MAX_STALE:
+                logger.warning("JWKS fetch failed, using stale cache (age %s): %s", staleness, e)
+                return _jwks_cache["data"]
+        logger.error("JWKS fetch failed and cache too stale (or empty): %s", e)
         raise
 
 
@@ -142,6 +146,7 @@ async def _decode_token(token: str) -> dict:
         algorithms=["RS256"],
         audience=settings.CLERK_AUDIENCE,
         issuer=settings.CLERK_ISSUER,
+        leeway=30,  # tolerate 30s clock skew
     )
 
 

--- a/apps/backend/tests/unit/test_auth_hardening.py
+++ b/apps/backend/tests/unit/test_auth_hardening.py
@@ -1,0 +1,110 @@
+"""Tests for auth.py security hardening — JWKS stale cap + JWT leeway."""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from core import auth
+
+
+class TestJWKSStaleFallback:
+    """JWKS cache should serve stale data up to 15 min, then fail closed."""
+
+    @pytest.mark.asyncio
+    async def test_serves_stale_within_15_min(self):
+        """If JWKS fetch fails and cache is <15 min stale, serve stale."""
+        test_keys = {"keys": [{"kid": "test", "kty": "RSA", "n": "x", "e": "y", "use": "sig"}]}
+        now = datetime.utcnow()
+
+        # Seed cache with data that expired 10 minutes ago (within 15 min limit)
+        original_cache = dict(auth._jwks_cache)
+        auth._jwks_cache["data"] = test_keys
+        auth._jwks_cache["expires_at"] = now - timedelta(minutes=10)
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.ConnectError("network error")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        try:
+            with patch("core.auth.httpx.AsyncClient", return_value=mock_client):
+                result = await auth._get_cached_jwks("https://test/.well-known/jwks.json")
+                assert result == test_keys  # Should serve stale
+        finally:
+            auth._jwks_cache.update(original_cache)
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_after_15_min(self):
+        """If JWKS fetch fails and cache is >15 min stale, raise (fail closed)."""
+        test_keys = {"keys": [{"kid": "test", "kty": "RSA", "n": "x", "e": "y", "use": "sig"}]}
+        now = datetime.utcnow()
+
+        # Seed cache with data that expired 20 minutes ago (beyond 15 min limit)
+        original_cache = dict(auth._jwks_cache)
+        auth._jwks_cache["data"] = test_keys
+        auth._jwks_cache["expires_at"] = now - timedelta(minutes=20)
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.ConnectError("network error")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        try:
+            with patch("core.auth.httpx.AsyncClient", return_value=mock_client):
+                with pytest.raises(httpx.ConnectError):
+                    await auth._get_cached_jwks("https://test/.well-known/jwks.json")
+        finally:
+            auth._jwks_cache.update(original_cache)
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_with_no_cache(self):
+        """If JWKS fetch fails and there's no cached data at all, raise."""
+        original_cache = dict(auth._jwks_cache)
+        auth._jwks_cache["data"] = None
+        auth._jwks_cache["expires_at"] = None
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.ConnectError("network error")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        try:
+            with patch("core.auth.httpx.AsyncClient", return_value=mock_client):
+                with pytest.raises(httpx.ConnectError):
+                    await auth._get_cached_jwks("https://test/.well-known/jwks.json")
+        finally:
+            auth._jwks_cache.update(original_cache)
+
+
+class TestJWKSTTL:
+    """JWKS cache TTL should be 5 minutes, not 1 hour."""
+
+    def test_ttl_is_5_minutes(self):
+        assert auth.JWKS_CACHE_TTL == timedelta(minutes=5)
+
+    def test_max_stale_is_15_minutes(self):
+        assert auth._JWKS_MAX_STALE == timedelta(minutes=15)
+
+
+class TestJWTLeeway:
+    """jwt.decode should be called with leeway=30."""
+
+    @pytest.mark.asyncio
+    async def test_decode_uses_leeway(self):
+        """Verify leeway parameter is passed to jwt.decode."""
+        with (
+            patch("core.auth._get_cached_jwks", new_callable=AsyncMock) as mock_jwks,
+            patch("core.auth.jwt") as mock_jwt,
+        ):
+            mock_jwks.return_value = {"keys": [{"kid": "k1", "kty": "RSA", "n": "x", "e": "y", "use": "sig"}]}
+            mock_jwt.get_unverified_header.return_value = {"kid": "k1"}
+            mock_jwt.PyJWK.return_value.key = "fake-key"
+            mock_jwt.decode.return_value = {"sub": "user_123"}
+
+            await auth._decode_token("fake-token")
+
+            # Verify leeway=30 was passed
+            call_kwargs = mock_jwt.decode.call_args
+            assert call_kwargs.kwargs.get("leeway") == 30 or call_kwargs[1].get("leeway") == 30


### PR DESCRIPTION
## Summary

Three targeted changes to `core/auth.py` — all security hardening, no behavioral changes for valid requests.

| Change | Before | After | Why |
|---|---|---|---|
| JWKS cache TTL | 1 hour | 5 minutes | Rotated keys take effect faster |
| Stale fallback | Infinite | 15 min max, then fail closed | Prevents indefinite use of rotated-out keys |
| JWT leeway | 0 | 30 seconds | Tolerates clock skew, prevents spurious 401s |

### Tests
- 6 new tests in `test_auth_hardening.py`
- Covers: stale within 15min (served), stale beyond 15min (fail closed), no cache (fail closed), TTL value, max stale value, leeway parameter
- 621 total tests pass

## Test plan
- [ ] CI passes
- [ ] After deploy: existing auth still works (no user-visible change for valid tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)