### PR TITLE
fix(ui): agent creation, file viewer, org invitation

### DIFF
--- a/apps/backend/routers/webhooks.py
+++ b/apps/backend/routers/webhooks.py
@@ -53,6 +53,7 @@ def _verify_svix_signature(body: bytes, headers: dict) -> None:
     msg_signature = headers.get("svix-signature", "")
 
     if not msg_id or not msg_timestamp or not msg_signature:
+        put_metric("webhook.clerk.sig_fail")
         raise HTTPException(status_code=400, detail="Missing svix signature headers")
 
     signed_content = f"{msg_id}.{msg_timestamp}.".encode() + body

--- a/apps/backend/routers/workspace_files.py
+++ b/apps/backend/routers/workspace_files.py
@@ -17,7 +17,7 @@ def _agent_workspace_path(owner_id: str, agent_id: str) -> str:
     """Build the relative path to an agent's workspace within the user dir."""
     if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
         raise HTTPException(status_code=400, detail="Invalid agent_id")
-    return f"agents/{agent_id}"
+    return f"workspaces/{agent_id}"
 
 
 def _collect_recursive(workspace, owner_id: str, path: str, entries: list, max_depth: int = 10):

--- a/apps/frontend/src/app/onboarding/page.tsx
+++ b/apps/frontend/src/app/onboarding/page.tsx
@@ -11,19 +11,29 @@ import {
 } from "@clerk/nextjs";
 import { useApi } from "@/lib/api";
 import { Button } from "@/components/ui/button";
-import { User, Users } from "lucide-react";
+import { User, Users, Mail } from "lucide-react";
 
 export default function OnboardingPage() {
   const router = useRouter();
   const { isLoaded } = useAuth();
   const { user } = useUser();
   const { organization, isLoaded: orgLoaded } = useOrganization();
-  const { userMemberships, isLoaded: orgsLoaded, setActive } = useOrganizationList({
+  const { userMemberships, userInvitations, isLoaded: orgsLoaded, setActive } = useOrganizationList({
     userMemberships: true,
+    userInvitations: true,
   });
   const api = useApi();
-  const [mode, setMode] = useState<"choose" | "personal" | "org">("choose");
   const [loading, setLoading] = useState(false);
+  const [acceptingId, setAcceptingId] = useState<string | null>(null);
+
+  const pendingInvitations = userInvitations?.data ?? [];
+
+  // Derive initial mode: show invitations if any exist, otherwise "choose".
+  // User can navigate away with setExplicitMode; once they do, we stop
+  // auto-detecting invitations.
+  const [explicitMode, setExplicitMode] = useState<"choose" | "personal" | "org" | "invitations" | null>(null);
+  const mode = explicitMode ?? (isLoaded && orgsLoaded && pendingInvitations.length > 0 ? "invitations" : "choose");
+  const setMode = setExplicitMode;
 
   // Two redirect triggers:
   //
@@ -84,6 +94,29 @@ export default function OnboardingPage() {
   if (mode !== "org" && organization) return null;
   if (mode !== "org" && userMemberships?.data && userMemberships.data.length > 0) return null;
 
+  async function handleAcceptInvitation(invitationId: string) {
+    setAcceptingId(invitationId);
+    try {
+      const inv = pendingInvitations.find((i) => i.id === invitationId);
+      if (inv && typeof (inv as unknown as { accept?: () => Promise<void> }).accept === "function") {
+        await (inv as unknown as { accept: () => Promise<void> }).accept();
+      }
+      await user?.update({ unsafeMetadata: { onboarded: true } });
+      // Small delay for Clerk to propagate the membership
+      await new Promise((r) => setTimeout(r, 500));
+      await userInvitations?.revalidate?.();
+      await userMemberships?.revalidate?.();
+      const memberships = userMemberships?.data;
+      if (memberships && memberships.length > 0 && setActive) {
+        await setActive({ organization: memberships[0].organization.id });
+      }
+      router.push("/chat");
+    } catch (err) {
+      console.error("Failed to accept invitation:", err);
+      setAcceptingId(null);
+    }
+  }
+
   async function handlePersonal() {
     setLoading(true);
     try {
@@ -94,6 +127,53 @@ export default function OnboardingPage() {
     } catch {
       setLoading(false);
     }
+  }
+
+  if (mode === "invitations") {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen gap-6 bg-background">
+        <div className="text-center mb-4">
+          <Mail className="h-10 w-10 mx-auto mb-3 text-primary" />
+          <h1 className="text-2xl font-bold">You have been invited</h1>
+          <p className="text-muted-foreground mt-2">
+            Accept an invitation to join an organization on Isol8.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 w-full max-w-md px-4">
+          {pendingInvitations.map((invitation) => (
+            <div
+              key={invitation.id}
+              className="flex items-center justify-between p-4 rounded-lg border border-border bg-card"
+            >
+              <div className="flex items-center gap-3">
+                <Users className="h-5 w-5 text-muted-foreground" />
+                <div>
+                  <div className="font-medium">
+                    {(invitation as unknown as { publicOrganizationData?: { name?: string } }).publicOrganizationData?.name || "Organization"}
+                  </div>
+                  <div className="text-sm text-muted-foreground">Pending invitation</div>
+                </div>
+              </div>
+              <Button
+                onClick={() => handleAcceptInvitation(invitation.id)}
+                disabled={acceptingId !== null}
+                size="sm"
+              >
+                {acceptingId === invitation.id ? "Accepting..." : "Accept"}
+              </Button>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-col items-center gap-2 mt-4">
+          <p className="text-sm text-muted-foreground">Or set up your own workspace instead</p>
+          <Button variant="ghost" onClick={() => setMode("choose")}>
+            Skip invitations
+          </Button>
+        </div>
+      </div>
+    );
   }
 
   if (mode === "org") {
@@ -158,6 +238,15 @@ export default function OnboardingPage() {
           </span>
         </button>
       </div>
+
+      {pendingInvitations.length > 0 && (
+        <button
+          onClick={() => setMode("invitations")}
+          className="text-sm text-primary underline underline-offset-4 hover:text-primary/80"
+        >
+          You have {pendingInvitations.length} pending invitation{pendingInvitations.length > 1 ? "s" : ""}
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/app/onboarding/page.tsx
+++ b/apps/frontend/src/app/onboarding/page.tsx
@@ -101,16 +101,12 @@ export default function OnboardingPage() {
       if (inv && typeof (inv as unknown as { accept?: () => Promise<void> }).accept === "function") {
         await (inv as unknown as { accept: () => Promise<void> }).accept();
       }
-      await user?.update({ unsafeMetadata: { onboarded: true } });
-      // Small delay for Clerk to propagate the membership
-      await new Promise((r) => setTimeout(r, 500));
+      // Don't redirect or mark onboarded here — the useEffect at the top
+      // watches userMemberships and handles setActive + onboarded + redirect
+      // once Clerk propagates the membership. This avoids racing with Clerk's
+      // eventual consistency.
       await userInvitations?.revalidate?.();
       await userMemberships?.revalidate?.();
-      const memberships = userMemberships?.data;
-      if (memberships && memberships.length > 0 && setActive) {
-        await setActive({ organization: memberships[0].organization.id });
-      }
-      router.push("/chat");
     } catch (err) {
       console.error("Failed to accept invitation:", err);
       setAcceptingId(null);

--- a/apps/frontend/src/components/chat/ChatLayout.tsx
+++ b/apps/frontend/src/components/chat/ChatLayout.tsx
@@ -57,8 +57,9 @@ export function ChatLayout({
   // first one on fresh logins — Clerk doesn't persist active-org state
   // across sessions, so without this a user who created an org on laptop A
   // would land on /onboarding on laptop B despite already being a member.
-  const { userMemberships, setActive, isLoaded: orgListLoaded } = useOrganizationList({
+  const { userMemberships, userInvitations, setActive, isLoaded: orgListLoaded } = useOrganizationList({
     userMemberships: true,
+    userInvitations: true,
   });
   const router = useRouter();
   const api = useApi();
@@ -111,18 +112,24 @@ export function ChatLayout({
   const clerkLoaded = userLoaded && orgLoaded && orgListLoaded;
   const isOnboarded = (user?.unsafeMetadata as Record<string, unknown> | undefined)?.onboarded === true;
   const hasMemberships = (userMemberships?.data?.length ?? 0) > 0;
+  const hasPendingInvitations = (userInvitations?.data?.length ?? 0) > 0;
 
   // A user needs onboarding if they have neither the flag nor any org
-  // memberships. If they have memberships they're effectively already past
-  // the personal/org decision — we just need to activate one.
-  const needsOnboarding = clerkLoaded && isSignedIn === true && !isOnboarded && !hasMemberships && !organization;
+  // memberships AND no pending invitations. If they have memberships they're
+  // effectively already past the personal/org decision — we just need to
+  // activate one. If they have pending invitations, send them to onboarding
+  // where they can accept.
+  const needsOnboarding = clerkLoaded && isSignedIn === true && !isOnboarded && !hasMemberships && !hasPendingInvitations && !organization;
   const needsAutoActivate = clerkLoaded && isSignedIn === true && !organization && hasMemberships;
+  // Users with pending invitations who haven't onboarded should also go to
+  // /onboarding where they'll see the invitation acceptance UI.
+  const needsInvitationFlow = clerkLoaded && isSignedIn === true && !isOnboarded && !hasMemberships && hasPendingInvitations && !organization;
 
   useEffect(() => {
-    if (needsOnboarding) {
+    if (needsOnboarding || needsInvitationFlow) {
       router.replace("/onboarding");
     }
-  }, [needsOnboarding, router]);
+  }, [needsOnboarding, needsInvitationFlow, router]);
 
   useEffect(() => {
     if (!needsAutoActivate || !setActive) return;
@@ -140,9 +147,9 @@ export function ChatLayout({
     // billing rows — the backend no longer does that write, but we gate
     // here too so other context-sensitive endpoints called from sync
     // paths (future-proofing) don't misresolve owner_id either.
-    if (needsAutoActivate || needsOnboarding) return;
+    if (needsAutoActivate || needsOnboarding || needsInvitationFlow) return;
     api.syncUser().catch((err: unknown) => console.error("User sync failed:", err));
-  }, [isSignedIn, api, needsAutoActivate, needsOnboarding]);
+  }, [isSignedIn, api, needsAutoActivate, needsOnboarding, needsInvitationFlow]);
 
   // Dispatch DOM event so page.tsx picks up the current agent (external system sync)
   const lastDispatchedRef = useRef<string | null>(null);
@@ -181,7 +188,7 @@ export function ChatLayout({
   // its final context, it fires POST /container/provision and /billing
   // reads with a stale JWT and we end up with orphan personal rows for a
   // user who was always meant to be an org member.
-  if (!clerkLoaded || isSignedIn !== true || needsOnboarding || needsAutoActivate) {
+  if (!clerkLoaded || isSignedIn !== true || needsOnboarding || needsInvitationFlow || needsAutoActivate) {
     return (
       <div className="app-shell" style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "100vh" }}>
         <div style={{ color: "#6b6b6b", fontSize: 14 }}>Loading…</div>
@@ -389,7 +396,8 @@ export function ChatLayout({
           existingIds={agents.map((a) => a.id)}
           onCancel={() => setCreateFormOpen(false)}
           onCreate={async (name) => {
-            await createAgent({ name });
+            const normalizedId = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+            await createAgent({ name, workspace: "agents/" + normalizedId });
             setCreateFormOpen(false);
           }}
         />

--- a/apps/frontend/src/components/control/panels/AgentCreateForm.tsx
+++ b/apps/frontend/src/components/control/panels/AgentCreateForm.tsx
@@ -38,7 +38,7 @@ export function AgentCreateForm({ existingIds, onCreated, onCancel }: AgentCreat
     setError(null);
 
     try {
-      await callRpc("agents.create", { name: name.trim() });
+      await callRpc("agents.create", { name: name.trim(), workspace: "agents/" + normalizedId });
       onCreated();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));

--- a/apps/frontend/src/hooks/useAgents.ts
+++ b/apps/frontend/src/hooks/useAgents.ts
@@ -46,7 +46,7 @@ export function useAgents() {
   const defaultId = data?.defaultId;
 
   const createAgent = useCallback(
-    async (params: { name: string }) => {
+    async (params: { name: string; workspace: string; emoji?: string }) => {
       await callRpc("agents.create", params);
       mutate();
     },


### PR DESCRIPTION
## Summary
- **Agent creation**: restore missing `workspace` param in `agents.create` RPC (removed in #224)
- **File viewer**: fix path from `agents/{id}` to `workspaces/{id}` — was showing OpenClaw internals instead of user workspace
- **Org invitation**: detect pending Clerk invitations so invited users see Accept UI instead of the Personal/Org onboarding picker

## Test plan
- [ ] Create a new agent — should succeed with correct workspace path
- [ ] Open file viewer — should show user workspace files, not `qmd/sessions/agent`
- [ ] Invite a user to an org, have them log in fresh — should see invitation acceptance screen
- [ ] Verify existing personal and org onboarding flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)