### PR TITLE
fix(gateway): cron session isolation, heartbeat filtering, auto-reconnect

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -717,120 +717,27 @@ class GatewayConnection:
             return
 
     async def _reader_loop(self) -> None:
-        """Background task: read all messages from gateway WebSocket.
-
-        On transient disconnects (e.g. code 1012 service restart from cron or
-        config reload), automatically reconnects with exponential backoff so
-        chat doesn't permanently die.
-
-        The reconnect budget resets after each successful reconnect so that
-        long-lived sessions can survive more than ``max_reconnect_attempts``
-        transient drops over their lifetime.
-        """
-        max_reconnect_attempts = 5
-        reconnect_delay = 3  # seconds, doubles each attempt
-        attempt = 0
-
-        while attempt <= max_reconnect_attempts:
-            try:
-                async for raw in self._ws:
-                    try:
-                        data = json.loads(raw)
-                        self._handle_message(data)
-                    except json.JSONDecodeError:
-                        logger.warning("Non-JSON message from gateway for user %s", self.user_id)
-                # WebSocket closed cleanly — try reconnect if not shutting down
-                if self._closed:
-                    return
-                logger.warning(
-                    "Gateway WebSocket closed for user %s (attempt %d/%d), reconnecting in %ds",
-                    self.user_id,
-                    attempt + 1,
-                    max_reconnect_attempts,
-                    reconnect_delay,
-                )
-            except asyncio.CancelledError:
+        """Background task: read all messages from gateway WebSocket."""
+        try:
+            async for raw in self._ws:
+                try:
+                    data = json.loads(raw)
+                    self._handle_message(data)
+                except json.JSONDecodeError:
+                    logger.warning("Non-JSON message from gateway for user %s", self.user_id)
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            if self._closed:
                 return
-            except Exception as e:
-                if self._closed:
-                    return
-                put_metric("gateway.connection", dimensions={"event": "error"})
-                logger.error(
-                    "Gateway reader loop error for user %s (attempt %d/%d): %s",
-                    self.user_id,
-                    attempt + 1,
-                    max_reconnect_attempts,
-                    e,
-                )
-
-            # Reject pending RPCs from the broken connection — callers will
-            # retry on the next send_rpc which creates a fresh connection.
+            put_metric("gateway.connection", dimensions={"event": "error"})
+            logger.error("Gateway reader loop error for user %s: %s", self.user_id, e)
+            self._emit_status_change("GATEWAY_DOWN", "Gateway connection lost")
+            # Reject all pending RPCs
             for req_id, future in list(self._pending_rpcs.items()):
                 if not future.done():
-                    future.set_exception(RuntimeError("Gateway connection lost — reconnecting"))
+                    future.set_exception(RuntimeError("Gateway connection lost"))
             self._pending_rpcs.clear()
-
-            if attempt >= max_reconnect_attempts:
-                break
-
-            # Exponential backoff reconnection
-            self._emit_status_change("RECONNECTING", "Gateway reconnecting...")
-            await asyncio.sleep(reconnect_delay)
-            reconnect_delay = min(reconnect_delay * 2, 30)
-
-            # Connect to a local variable first — don't assign to self._ws
-            # until handshake + health check succeed. Otherwise an RPC
-            # arriving via send_rpc sees is_connected=True and sends on
-            # an unauthenticated socket.
-            new_ws = None
-            try:
-                uri = f"ws://{self.ip}:{GATEWAY_PORT}"
-                new_ws = await ws_connect(
-                    uri,
-                    open_timeout=_HANDSHAKE_TIMEOUT,
-                    close_timeout=5,
-                )
-                # Temporarily assign so _handshake/_verify_health can
-                # use self._ws.send/recv.
-                old_ws = self._ws
-                self._ws = new_ws
-                await self._handshake()
-                await self._verify_health()
-                self._emit_status_change("HEALTHY", "Gateway reconnected")
-                logger.info("Gateway reconnected for user %s (attempt %d)", self.user_id, attempt + 1)
-                # Reset budget and backoff after a successful reconnect so
-                # long-lived sessions survive more than max_reconnect_attempts
-                # total transient drops.
-                attempt = 0
-                reconnect_delay = 3
-                continue  # re-enter the reader loop
-            except Exception as reconnect_err:
-                # Handshake or health check failed — close the new socket
-                # so the next iteration doesn't read from a half-initialized
-                # connection, and restore the old (dead) ws reference.
-                if new_ws is not None:
-                    try:
-                        await new_ws.close()
-                    except Exception:
-                        pass
-                    # Don't leave self._ws pointing at the failed socket
-                    self._ws = None
-                logger.warning(
-                    "Gateway reconnect failed for user %s (attempt %d/%d): %s",
-                    self.user_id,
-                    attempt + 1,
-                    max_reconnect_attempts,
-                    reconnect_err,
-                )
-
-            attempt += 1
-
-        # All reconnect attempts exhausted
-        if not self._closed:
-            logger.error(
-                "Gateway permanently lost for user %s after %d reconnect attempts", self.user_id, max_reconnect_attempts
-            )
-            self._emit_status_change("GATEWAY_DOWN", "Gateway connection lost")
 
     @property
     def has_frontend_connections(self) -> bool:

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -616,18 +616,18 @@ class GatewayConnection:
             # overwrite or intermix with the user's web conversation.
             session_source = parsed_key.get("source", "")
             is_channel_session = session_source in ("dm", "group", "channel")
+            is_cron_session = session_source == "cron"
 
-            # Demote noisy periodic events (health, tick) to DEBUG so they
-            # don't drown actual chat/agent signals in the logs. Log
-            # meaningful non-agent events (chat state changes, sessions,
-            # etc.) at INFO.
+            # Drop noisy periodic events (health, tick) entirely — they are
+            # OpenClaw-internal keep-alives and should never reach frontends.
             if event_name in ("health", "tick"):
                 logger.debug(
                     "Gateway heartbeat for %s: event=%s",
                     self.user_id,
                     event_name,
                 )
-            elif event_name != "agent":
+                return
+            if event_name != "agent":
                 state = payload.get("state", "") if isinstance(payload, dict) else ""
                 logger.info(
                     "[%s] gateway event=%s state=%s sessionKey=%s target=%s",
@@ -662,16 +662,19 @@ class GatewayConnection:
                     and payload["data"].get("phase") == "end"
                 ):
                     self._record_usage_from_session(payload)
-                # Skip forwarding channel events to the web UI.
-                if is_channel_session:
+                # Skip forwarding channel and cron events to the web UI.
+                # Cron jobs run in isolated sessions inside OpenClaw — their
+                # streaming events must not leak into a user's active web chat
+                # (a cron "done" would terminate the user's streaming session).
+                if is_channel_session or is_cron_session:
                     return
                 transformed = self._transform_agent_event(payload)
                 if transformed:
                     self._forward_to_frontends(transformed, target_member)
 
             elif event_name == "chat":
-                # Skip forwarding channel chat events to the web UI.
-                if is_channel_session:
+                # Skip forwarding channel and cron chat events to the web UI.
+                if is_channel_session or is_cron_session:
                     return
                 # Chat events -- only terminal states.
                 # Delta states are skipped; agent events handle streaming.
@@ -714,27 +717,90 @@ class GatewayConnection:
             return
 
     async def _reader_loop(self) -> None:
-        """Background task: read all messages from gateway WebSocket."""
-        try:
-            async for raw in self._ws:
-                try:
-                    data = json.loads(raw)
-                    self._handle_message(data)
-                except json.JSONDecodeError:
-                    logger.warning("Non-JSON message from gateway for user %s", self.user_id)
-        except asyncio.CancelledError:
-            return
-        except Exception as e:
-            if self._closed:
+        """Background task: read all messages from gateway WebSocket.
+
+        On transient disconnects (e.g. code 1012 service restart from cron or
+        config reload), automatically reconnects with exponential backoff so
+        chat doesn't permanently die.
+        """
+        max_reconnect_attempts = 5
+        reconnect_delay = 3  # seconds, doubles each attempt
+
+        for attempt in range(max_reconnect_attempts + 1):
+            try:
+                async for raw in self._ws:
+                    try:
+                        data = json.loads(raw)
+                        self._handle_message(data)
+                    except json.JSONDecodeError:
+                        logger.warning("Non-JSON message from gateway for user %s", self.user_id)
+                # WebSocket closed cleanly — try reconnect if not shutting down
+                if self._closed:
+                    return
+                logger.warning(
+                    "Gateway WebSocket closed for user %s (attempt %d/%d), reconnecting in %ds",
+                    self.user_id,
+                    attempt + 1,
+                    max_reconnect_attempts,
+                    reconnect_delay,
+                )
+            except asyncio.CancelledError:
                 return
-            put_metric("gateway.connection", dimensions={"event": "error"})
-            logger.error("Gateway reader loop error for user %s: %s", self.user_id, e)
-            self._emit_status_change("GATEWAY_DOWN", "Gateway connection lost")
-            # Reject all pending RPCs
+            except Exception as e:
+                if self._closed:
+                    return
+                put_metric("gateway.connection", dimensions={"event": "error"})
+                logger.error(
+                    "Gateway reader loop error for user %s (attempt %d/%d): %s",
+                    self.user_id,
+                    attempt + 1,
+                    max_reconnect_attempts,
+                    e,
+                )
+
+            # Reject pending RPCs from the broken connection — callers will
+            # retry on the next send_rpc which creates a fresh connection.
             for req_id, future in list(self._pending_rpcs.items()):
                 if not future.done():
-                    future.set_exception(RuntimeError("Gateway connection lost"))
+                    future.set_exception(RuntimeError("Gateway connection lost — reconnecting"))
             self._pending_rpcs.clear()
+
+            if attempt >= max_reconnect_attempts:
+                break
+
+            # Exponential backoff reconnection
+            self._emit_status_change("RECONNECTING", "Gateway reconnecting...")
+            await asyncio.sleep(reconnect_delay)
+            reconnect_delay = min(reconnect_delay * 2, 30)
+
+            try:
+                uri = f"ws://{self.ip}:{GATEWAY_PORT}"
+                self._ws = await ws_connect(
+                    uri,
+                    open_timeout=_HANDSHAKE_TIMEOUT,
+                    close_timeout=5,
+                )
+                await self._handshake()
+                await self._verify_health()
+                self._emit_status_change("HEALTHY", "Gateway reconnected")
+                logger.info("Gateway reconnected for user %s (attempt %d)", self.user_id, attempt + 1)
+                reconnect_delay = 3
+                continue  # re-enter the reader loop
+            except Exception as reconnect_err:
+                logger.warning(
+                    "Gateway reconnect failed for user %s (attempt %d/%d): %s",
+                    self.user_id,
+                    attempt + 1,
+                    max_reconnect_attempts,
+                    reconnect_err,
+                )
+
+        # All reconnect attempts exhausted
+        if not self._closed:
+            logger.error(
+                "Gateway permanently lost for user %s after %d reconnect attempts", self.user_id, max_reconnect_attempts
+            )
+            self._emit_status_change("GATEWAY_DOWN", "Gateway connection lost")
 
     @property
     def has_frontend_connections(self) -> bool:
@@ -970,6 +1036,8 @@ def _parse_session_key(session_key: str) -> dict:
     Shapes (from openclaw/src/routing/session-key.ts with dmScope=per-account-channel-peer):
       Personal webchat:  agent:<agentId>:main
       Org webchat:       agent:<agentId>:<clerk_user_id>
+      Cron chat:         agent:<agentId>:cron:<cronId>
+      Cron run event:    agent:<agentId>:cron:<cronId>:run:<runId>
       Channel DM:        agent:<agentId>:<channel>:<accountId>:direct:<peerId>
       Channel group:     agent:<agentId>:<channel>:group:<id>(:topic:<topicId>)?
       Channel room:      agent:<agentId>:<channel>:channel:<id>(:thread:<threadId>)?
@@ -978,6 +1046,7 @@ def _parse_session_key(session_key: str) -> dict:
       - empty {} for malformed input
       - {agent_id, source} for webchat personal
       - {agent_id, source, member_id} for org webchat (member_id is the clerk user_id)
+      - {agent_id, source, cron_id} for cron sessions (source="cron")
       - {agent_id, source, channel, peer_id} for channel DMs (source="dm")
       - {agent_id, source, channel, group_id} for channel groups (source="group")
       - {agent_id, source, channel, channel_id} for channel rooms (source="channel")
@@ -986,6 +1055,18 @@ def _parse_session_key(session_key: str) -> dict:
     if len(parts) < 3 or parts[0] != "agent":
         return {}
     agent_id = parts[1]
+
+    # Cron sessions: agent:<agentId>:cron:<cronId>(:run:<runId>)?
+    # Must check BEFORE webchat since 4-part cron keys would otherwise
+    # fall through to channel parsing.
+    if parts[2] == "cron":
+        result = {
+            "agent_id": agent_id,
+            "source": "cron",
+        }
+        if len(parts) >= 4:
+            result["cron_id"] = parts[3]
+        return result
 
     # Webchat: 3 parts (agent:<agentId>:<sessionName>)
     if len(parts) == 3:

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -722,11 +722,16 @@ class GatewayConnection:
         On transient disconnects (e.g. code 1012 service restart from cron or
         config reload), automatically reconnects with exponential backoff so
         chat doesn't permanently die.
+
+        The reconnect budget resets after each successful reconnect so that
+        long-lived sessions can survive more than ``max_reconnect_attempts``
+        transient drops over their lifetime.
         """
         max_reconnect_attempts = 5
         reconnect_delay = 3  # seconds, doubles each attempt
+        attempt = 0
 
-        for attempt in range(max_reconnect_attempts + 1):
+        while attempt <= max_reconnect_attempts:
             try:
                 async for raw in self._ws:
                     try:
@@ -773,20 +778,43 @@ class GatewayConnection:
             await asyncio.sleep(reconnect_delay)
             reconnect_delay = min(reconnect_delay * 2, 30)
 
+            # Connect to a local variable first — don't assign to self._ws
+            # until handshake + health check succeed. Otherwise an RPC
+            # arriving via send_rpc sees is_connected=True and sends on
+            # an unauthenticated socket.
+            new_ws = None
             try:
                 uri = f"ws://{self.ip}:{GATEWAY_PORT}"
-                self._ws = await ws_connect(
+                new_ws = await ws_connect(
                     uri,
                     open_timeout=_HANDSHAKE_TIMEOUT,
                     close_timeout=5,
                 )
+                # Temporarily assign so _handshake/_verify_health can
+                # use self._ws.send/recv.
+                old_ws = self._ws
+                self._ws = new_ws
                 await self._handshake()
                 await self._verify_health()
                 self._emit_status_change("HEALTHY", "Gateway reconnected")
                 logger.info("Gateway reconnected for user %s (attempt %d)", self.user_id, attempt + 1)
+                # Reset budget and backoff after a successful reconnect so
+                # long-lived sessions survive more than max_reconnect_attempts
+                # total transient drops.
+                attempt = 0
                 reconnect_delay = 3
                 continue  # re-enter the reader loop
             except Exception as reconnect_err:
+                # Handshake or health check failed — close the new socket
+                # so the next iteration doesn't read from a half-initialized
+                # connection, and restore the old (dead) ws reference.
+                if new_ws is not None:
+                    try:
+                        await new_ws.close()
+                    except Exception:
+                        pass
+                    # Don't leave self._ws pointing at the failed socket
+                    self._ws = None
                 logger.warning(
                     "Gateway reconnect failed for user %s (attempt %d/%d): %s",
                     self.user_id,
@@ -794,6 +822,8 @@ class GatewayConnection:
                     max_reconnect_attempts,
                     reconnect_err,
                 )
+
+            attempt += 1
 
         # All reconnect attempts exhausted
         if not self._closed:

--- a/apps/backend/tests/unit/core/test_chat_event_transform.py
+++ b/apps/backend/tests/unit/core/test_chat_event_transform.py
@@ -327,9 +327,15 @@ class TestHandleMessage:
     # -- Other events (forwarded as-is) --
 
     def test_non_chat_non_agent_event_forwarded_as_is(self, connection, mock_management_api):
-        raw_event = {"type": "event", "event": "health", "payload": {"status": "ok"}}
+        raw_event = {"type": "event", "event": "sessions.updated", "payload": {"status": "ok"}}
         connection._handle_message(raw_event)
         mock_management_api.send_message.assert_called_once_with("conn-1", raw_event)
+
+    def test_health_tick_events_dropped(self, connection, mock_management_api):
+        """Health/tick heartbeat events should never reach frontends."""
+        connection._handle_message({"type": "event", "event": "health", "payload": {}})
+        connection._handle_message({"type": "event", "event": "tick", "payload": {}})
+        mock_management_api.send_message.assert_not_called()
 
     # -- Multi-connection forwarding --
 

--- a/apps/backend/tests/unit/core/test_connection_pool.py
+++ b/apps/backend/tests/unit/core/test_connection_pool.py
@@ -58,7 +58,8 @@ class TestGatewayConnection:
         """_handle_message with type=event should forward to all frontend connections."""
         connection._frontend_connections.add("conn-abc")
         connection._frontend_connections.add("conn-def")
-        connection._handle_message({"type": "event", "event": "health", "payload": {"status": "ok"}})
+        # Use sessions.updated — health/tick events are now intentionally dropped.
+        connection._handle_message({"type": "event", "event": "sessions.updated", "payload": {"status": "ok"}})
         assert mock_management_api.send_message.call_count == 2
 
     def test_shared_frontend_connections(self, connection):

--- a/apps/backend/tests/unit/gateway/test_session_key_parser.py
+++ b/apps/backend/tests/unit/gateway/test_session_key_parser.py
@@ -72,6 +72,21 @@ from core.gateway.connection_pool import _parse_session_key  # noqa: E402
                 "channel_id": "C123ABC",
             },
         ),
+        # Cron chat session
+        (
+            "agent:main:cron:dfb80362-1cdb-4089-b778-27a5f51d765a",
+            {"agent_id": "main", "source": "cron", "cron_id": "dfb80362-1cdb-4089-b778-27a5f51d765a"},
+        ),
+        # Cron run event (longer key)
+        (
+            "agent:main:cron:dfb80362-1cdb-4089-b778-27a5f51d765a:run:d89",
+            {"agent_id": "main", "source": "cron", "cron_id": "dfb80362-1cdb-4089-b778-27a5f51d765a"},
+        ),
+        # Cron with no ID (just "cron" at position 2)
+        (
+            "agent:sales:cron",
+            {"agent_id": "sales", "source": "cron"},
+        ),
         # Malformed
         ("garbage", {}),
         ("", {}),
@@ -82,6 +97,16 @@ from core.gateway.connection_pool import _parse_session_key  # noqa: E402
 def test_parse_session_key(session_key, expected):
     result = _parse_session_key(session_key)
     assert result == expected
+
+
+def test_cron_session_is_not_webchat():
+    """Cron sessions must not be classified as webchat — their events should
+    not be forwarded to frontends (a cron chat.final would terminate an
+    active user's streaming session)."""
+    result = _parse_session_key("agent:main:cron:dfb80362-1cdb-4089-b778-27a5f51d765a")
+    assert result["source"] == "cron"
+    assert result["source"] not in ("webchat", "dm", "group", "channel")
+    assert "member_id" not in result
 
 
 def test_group_key_does_not_return_literal_channel_as_member_id():


### PR DESCRIPTION
## Summary
- **Cron session isolation**: parse `agent:X:cron:<uuid>` session keys so cron agent/chat events don't leak to web frontends. A cron `chat.final` was broadcasting `{type:"done"}` to all connections, terminating active user chat sessions.
- **Heartbeat filtering**: drop `health`/`tick` events early — they were leaking to frontends via the catch-all `else` branch (the "main:main" messages users were seeing).
- **Auto-reconnect**: `_reader_loop` now retries with exponential backoff (3s→30s, 5 attempts) when the gateway WebSocket drops (e.g. code 1012 service restart). Previously it just died, killing all chat permanently.

## Root cause (from prod logs)
Org container `org_3CEZQVnTYCSGBIy6drnSLWJ8jjC` had a cron job ("Hourly Weather in Berwyn PA") producing session keys like `agent:main:cron:dfb80362-...` which fell through `_parse_session_key` as `source:"unknown"` → `target_member=None` → broadcast to ALL frontends. The cron's `chat.final` terminated active user chat sessions.

Additionally, the cron's delivery config has `lastError: "Delivering to Telegram requires target <chatId>"` — a separate config issue the user needs to fix in CronPanel.

## Test plan
- [x] 15 unit tests pass (3 new cron session key tests + regression test)
- [ ] Deploy to dev, create a cron job, verify it runs without disrupting web chat
- [ ] Verify heartbeat events no longer appear in frontend
- [ ] Simulate gateway restart (kill OpenClaw container), verify auto-reconnect works

🤖 Generated with [Claude Code](https://claude.com/claude-code)