### PR TITLE
security: harden admin endpoints — fleet patch, cross-tenant, debug, proxy, health

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -7,18 +7,14 @@ import logging
 from contextlib import asynccontextmanager
 
 from core.observability.logging import configure_logging
-from core.observability.middleware import RequestContextMiddleware
 
 configure_logging(level="INFO")
 
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
-
-import time
-from collections import defaultdict
 
 from core.auth import get_current_user
 from core.config import settings
@@ -152,6 +148,9 @@ app = FastAPI(
 )
 
 # Request-ID middleware — generates/propagates X-Request-ID for log correlation.
+# Added first so it runs innermost (after CORS and ProxyHeaders).
+from core.observability.middleware import RequestContextMiddleware
+
 app.add_middleware(RequestContextMiddleware)
 
 # Proxy-headers middleware — ALB terminates TLS and forwards X-Forwarded-Proto.
@@ -245,9 +244,6 @@ app.include_router(debug.router, prefix="/api/v1/debug", tags=["debug"])
 
 app.include_router(desktop_auth.router, prefix="/api/v1/auth", tags=["desktop"])
 
-# Health endpoint rate-limit bucket: per-IP, 100 req/min
-_health_buckets: dict[str, list] = defaultdict(list)
-
 
 @app.get(
     "/",
@@ -273,16 +269,8 @@ async def root():
         503: {"description": "DynamoDB connection failed"},
     },
 )
-async def health_check(request: Request):
+async def health_check():
     """Health check for ALB — validates DynamoDB connectivity."""
-    # Rate limit: 100 req/min per IP
-    ip = request.client.host if request.client else "unknown"
-    now = time.time()
-    _health_buckets[ip] = [t for t in _health_buckets[ip] if now - t < 60]
-    if len(_health_buckets[ip]) >= 100:
-        raise HTTPException(status_code=429, detail="Rate limited")
-    _health_buckets[ip].append(now)
-
     try:
         from core.dynamodb import get_table, run_in_thread
 

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -7,14 +7,18 @@ import logging
 from contextlib import asynccontextmanager
 
 from core.observability.logging import configure_logging
+from core.observability.middleware import RequestContextMiddleware
 
 configure_logging(level="INFO")
 
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
+
+import time
+from collections import defaultdict
 
 from core.auth import get_current_user
 from core.config import settings
@@ -148,9 +152,6 @@ app = FastAPI(
 )
 
 # Request-ID middleware — generates/propagates X-Request-ID for log correlation.
-# Added first so it runs innermost (after CORS and ProxyHeaders).
-from core.observability.middleware import RequestContextMiddleware
-
 app.add_middleware(RequestContextMiddleware)
 
 # Proxy-headers middleware — ALB terminates TLS and forwards X-Forwarded-Proto.
@@ -244,6 +245,9 @@ app.include_router(debug.router, prefix="/api/v1/debug", tags=["debug"])
 
 app.include_router(desktop_auth.router, prefix="/api/v1/auth", tags=["desktop"])
 
+# Health endpoint rate-limit bucket: per-IP, 100 req/min
+_health_buckets: dict[str, list] = defaultdict(list)
+
 
 @app.get(
     "/",
@@ -269,8 +273,16 @@ async def root():
         503: {"description": "DynamoDB connection failed"},
     },
 )
-async def health_check():
+async def health_check(request: Request):
     """Health check for ALB — validates DynamoDB connectivity."""
+    # Rate limit: 100 req/min per IP
+    ip = request.client.host if request.client else "unknown"
+    now = time.time()
+    _health_buckets[ip] = [t for t in _health_buckets[ip] if now - t < 60]
+    if len(_health_buckets[ip]) >= 100:
+        raise HTTPException(status_code=429, detail="Rate limited")
+    _health_buckets[ip].append(now)
+
     try:
         from core.dynamodb import get_table, run_in_thread
 

--- a/apps/backend/routers/debug.py
+++ b/apps/backend/routers/debug.py
@@ -11,21 +11,25 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from core.auth import AuthContext, get_current_user, get_owner_type, require_org_admin, resolve_owner_id
 from core.config import settings, TIER_CONFIG
-from core.observability.metrics import put_metric
 from core.containers import get_ecs_manager
 from core.containers.ecs_manager import EcsManagerError
+from core.observability.metrics import put_metric
 from core.repositories import container_repo
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Environments where debug endpoints MUST be disabled
+_PROD_ENVIRONMENTS = {"prod", "production", "staging"}
+
 
 async def require_non_production() -> None:
     """Dependency that blocks access in production environments."""
-    if settings.ENVIRONMENT == "prod":
+    env = (settings.ENVIRONMENT or "").lower().strip()
+    if env in _PROD_ENVIRONMENTS:
         put_metric("debug.endpoint.prod_hit", dimensions={"endpoint": "debug"})
-        raise HTTPException(status_code=403, detail="Not available in production")
+        raise HTTPException(status_code=403, detail="Debug endpoints disabled in production")
 
 
 @router.post(

--- a/apps/backend/routers/proxy.py
+++ b/apps/backend/routers/proxy.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, HTTPException, Request, Response
 from core.config import settings
 from core.observability.metrics import put_metric, timing
 from core.repositories import container_repo, billing_repo
+from core.services.usage_service import check_budget
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -48,16 +49,20 @@ async def _authenticate_and_check_budget(
 
     container = await container_repo.get_by_gateway_token(token)
     if not container:
+        put_metric("proxy.auth.fail")
         raise HTTPException(status_code=401, detail="Invalid gateway token")
 
     account = await billing_repo.get_by_owner_id(container["owner_id"])
     if not account:
         raise HTTPException(status_code=403, detail="No billing account")
 
-    # Enforce budget: block requests when monthly usage exceeds plan budget.
-    # Budget enforcement is simplified during DynamoDB migration — usage tracking
-    # will be re-implemented. For now, allow all requests for paying users.
-    # Free tier users are still gated by the existence of a billing account.
+    # Enforce budget for free tier users
+    tier = account.get("plan_tier", "free")
+    if tier == "free":
+        budget = await check_budget(container["owner_id"])
+        if not budget.get("allowed", True):
+            put_metric("proxy.budget_check.fail")
+            raise HTTPException(status_code=429, detail="Free tier proxy budget exceeded")
 
     return container, account
 
@@ -139,6 +144,7 @@ async def proxy_request(
             upstream_resp.text,
         )
     except Exception as e:
+        put_metric("proxy.upstream", dimensions={"host": service, "status": "error"})
         logger.error("Proxy upstream error for user %s: %s — %s", container["owner_id"], upstream_url, e)
         raise
 

--- a/apps/backend/routers/updates.py
+++ b/apps/backend/routers/updates.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field
 from core.auth import AuthContext, get_current_user, require_org_admin, resolve_owner_id
 from core.dynamodb import get_table, run_in_thread
 from core.observability.metrics import put_metric
-from core.repositories import update_repo, user_repo
+from core.repositories import update_repo
 from core.services.config_patcher import patch_openclaw_config, ConfigPatchError
 from core.services.update_service import apply_update, queue_fleet_image_update
 
@@ -157,14 +157,10 @@ async def patch_single_config(
     if auth.is_org_context:
         require_org_admin(auth)
 
-        # Cross-tenant scoping: verify caller's org owns the target.
-        # owner_id can be an org_id (for org-owned containers) or a user_id.
-        # If owner_id IS the caller's org, it's an org-owned container — allow.
-        # Otherwise, look up the user and verify org membership.
+        # Cross-tenant scoping: in org context, containers are owned by the org
+        # (owner_id == org_id). An org admin can only patch their own org's container.
         if owner_id != auth.org_id:
-            target_user = await user_repo.get(owner_id)
-            if not target_user or target_user.get("org_id") != auth.org_id:
-                raise HTTPException(403, "Cannot patch user outside your organization")
+            raise HTTPException(403, "Cannot patch container outside your organization")
 
     try:
         await patch_openclaw_config(owner_id, body.patch)

--- a/apps/backend/routers/updates.py
+++ b/apps/backend/routers/updates.py
@@ -1,15 +1,19 @@
 """Container updates router -- pending updates, apply/schedule, admin config patches."""
 
+import hashlib
+import json as json_mod
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from core.auth import AuthContext, get_current_user, require_org_admin, resolve_owner_id
+from core.dynamodb import get_table, run_in_thread
 from core.observability.metrics import put_metric
-from core.repositories import update_repo
+from core.repositories import update_repo, user_repo
 from core.services.config_patcher import patch_openclaw_config, ConfigPatchError
 from core.services.update_service import apply_update, queue_fleet_image_update
 
@@ -153,6 +157,15 @@ async def patch_single_config(
     if auth.is_org_context:
         require_org_admin(auth)
 
+        # Cross-tenant scoping: verify caller's org owns the target.
+        # owner_id can be an org_id (for org-owned containers) or a user_id.
+        # If owner_id IS the caller's org, it's an org-owned container — allow.
+        # Otherwise, look up the user and verify org membership.
+        if owner_id != auth.org_id:
+            target_user = await user_repo.get(owner_id)
+            if not target_user or target_user.get("org_id") != auth.org_id:
+                raise HTTPException(403, "Cannot patch user outside your organization")
+
     try:
         await patch_openclaw_config(owner_id, body.patch)
     except ConfigPatchError as e:
@@ -169,17 +182,48 @@ async def patch_single_config(
     "Runs in the request — for large fleets, consider using the async update system instead.",
 )
 async def patch_fleet_config(
+    request: Request,
     body: ConfigPatchRequest,
     auth: AuthContext = Depends(get_current_user),
 ):
     if auth.is_org_context:
         require_org_admin(auth)
 
+    # Require explicit confirmation header
+    confirm = request.headers.get("X-Confirm-Fleet-Patch")
+    if confirm != "yes-i-am-sure":
+        raise HTTPException(400, "Fleet patch requires X-Confirm-Fleet-Patch: yes-i-am-sure header")
+
+    # Audit log
+    payload_hash = hashlib.sha256(json_mod.dumps(body.patch, sort_keys=True).encode()).hexdigest()
+    logger.warning(
+        "Fleet config patch invoked",
+        extra={
+            "action": "fleet_patch",
+            "actor_id": auth.user_id,
+            "payload_hash": payload_hash,
+        },
+    )
+
+    # Emit metric
     put_metric("update.fleet_patch.invoked")
 
-    # Scan all owners from billing-accounts
-    from core.dynamodb import get_table, run_in_thread
+    # SNS notification
+    topic_arn = os.getenv("ALERT_PAGE_TOPIC_ARN")
+    if topic_arn:
+        try:
+            import boto3
 
+            sns = boto3.client("sns")
+            sns.publish(
+                TopicArn=topic_arn,
+                Subject="Fleet Config Patch Invoked",
+                Message=f"Fleet config patch by {auth.user_id}, payload_hash={payload_hash}",
+            )
+        except Exception:
+            logger.exception("Failed to publish fleet patch SNS alert")
+
+    # Scan all owners from billing-accounts
     table = get_table("billing-accounts")
     owners = []
     last_key = None
@@ -198,6 +242,7 @@ async def patch_fleet_config(
     for oid in owners:
         try:
             await patch_openclaw_config(oid, body.patch)
+            put_metric("update.config_patch.applied", dimensions={"scope": "fleet"})
             patched += 1
         except ConfigPatchError:
             failed += 1

--- a/apps/backend/tests/unit/routers/test_proxy.py
+++ b/apps/backend/tests/unit/routers/test_proxy.py
@@ -60,7 +60,9 @@ class TestProxyRouter:
     @patch("routers.proxy.httpx.AsyncClient")
     @patch("routers.proxy.billing_repo")
     @patch("routers.proxy.container_repo")
-    async def test_proxy_forwards_to_upstream(self, mock_container_repo, mock_billing_repo, mock_httpx_client_cls, mock_check_budget, app):
+    async def test_proxy_forwards_to_upstream(
+        self, mock_container_repo, mock_billing_repo, mock_httpx_client_cls, mock_check_budget, app
+    ):
         """Proxy forwards valid request to upstream."""
         mock_container_repo.get_by_gateway_token = AsyncMock(
             return_value={

--- a/apps/backend/tests/unit/routers/test_proxy.py
+++ b/apps/backend/tests/unit/routers/test_proxy.py
@@ -56,10 +56,11 @@ class TestProxyRouter:
         assert resp.status_code == 404
 
     @pytest.mark.asyncio
+    @patch("routers.proxy.check_budget", new_callable=AsyncMock, return_value={"allowed": True})
     @patch("routers.proxy.httpx.AsyncClient")
     @patch("routers.proxy.billing_repo")
     @patch("routers.proxy.container_repo")
-    async def test_proxy_forwards_to_upstream(self, mock_container_repo, mock_billing_repo, mock_httpx_client_cls, app):
+    async def test_proxy_forwards_to_upstream(self, mock_container_repo, mock_billing_repo, mock_httpx_client_cls, mock_check_budget, app):
         """Proxy forwards valid request to upstream."""
         mock_container_repo.get_by_gateway_token = AsyncMock(
             return_value={


### PR DESCRIPTION
## Summary

5 targeted security fixes from #190 §3:

| Fix | File | What changed |
|---|---|---|
| Fleet patch confirmation | `routers/updates.py` | Requires `X-Confirm-Fleet-Patch: yes-i-am-sure` header. Emits structured audit log + SNS page alert. |
| Cross-tenant check | `routers/updates.py` | Org admin can only patch users in their own org. Handles org-owned containers correctly. |
| Debug allow-list | `routers/debug.py` | Blocks `"production"` and `"staging"` too, not just `"prod"`. Case-insensitive. |
| Proxy budget | `routers/proxy.py` | Free-tier users get budget-checked before proxy calls. Previously unmetered. |
| Health rate limit | `main.py` | 100 req/min per IP. ALB does ~2/min, so no impact on health checks. |

### Behavioral changes
- **Fleet patch**: any existing automation calling `PATCH /container/config` without the confirmation header will get 400. This is intentional — fleet patches should be deliberate.
- **Debug endpoints**: staging environment loses debug access. Verify no one depends on this.
- **Proxy**: free-tier users who were making unlimited proxy calls will now get 429 when over budget.

### Tests
- 621 tests pass (1 test updated to mock `check_budget` for proxy)

## Test plan
- [ ] CI passes
- [ ] After deploy: `PATCH /container/config` without header returns 400
- [ ] After deploy: debug endpoints return 403 when ENVIRONMENT=staging
- [ ] After deploy: free-tier proxy calls respect budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)