### PR TITLE
fix(chat): per-user session keys for all users

### DIFF
--- a/apps/backend/routers/websocket_chat.py
+++ b/apps/backend/routers/websocket_chat.py
@@ -582,10 +582,10 @@ async def _process_agent_chat_background(
         pool = get_gateway_pool()
         req_id = str(uuid4())
 
-        # Session key format: agent:{agentId}:{sessionName}
-        # Org members get per-user sessions; personal users keep :main (no history breakage)
-        is_org = owner_id != user_id
-        session_key = f"agent:{agent_id}:{user_id}" if is_org else f"agent:{agent_id}:main"
+        # Session key format: agent:{agentId}:{userId}
+        # Every user gets their own session, isolating their chat history
+        # from cron jobs, channels, and other system activity.
+        session_key = f"agent:{agent_id}:{user_id}"
 
         logger.info(
             "[%s] chat.send RPC agent=%s sessionKey=%s ip=%s",

--- a/apps/backend/tests/unit/gateway/test_session_key_parser.py
+++ b/apps/backend/tests/unit/gateway/test_session_key_parser.py
@@ -17,6 +17,11 @@ from core.gateway.connection_pool import _parse_session_key  # noqa: E402
             "agent:main:main",
             {"agent_id": "main", "source": "webchat"},
         ),
+        # Personal webchat — per-user session (all users now use userId)
+        (
+            "agent:luna:user_3CEahsu949Q9",
+            {"agent_id": "luna", "source": "webchat", "member_id": "user_3CEahsu949Q9"},
+        ),
         # Org webchat — parts[2] is a Clerk user_id
         (
             "agent:main:user_2abc123",

--- a/apps/backend/tests/unit/routers/test_websocket_agent_chat.py
+++ b/apps/backend/tests/unit/routers/test_websocket_agent_chat.py
@@ -268,7 +268,7 @@ class TestProcessAgentChatBackground:
         assert call_kwargs["user_id"] == "user-1"
         assert call_kwargs["method"] == "chat.send"
         params = call_kwargs["params"]
-        assert params["sessionKey"] == "agent:luna:main"
+        assert params["sessionKey"] == "agent:luna:user-1"
         assert params["message"] == "Hello!"
         assert "idempotencyKey" in params  # UUID, just check it's present
         assert call_kwargs["ip"] == "10.0.1.5"

--- a/apps/frontend/src/components/chat/AgentChatWindow.tsx
+++ b/apps/frontend/src/components/chat/AgentChatWindow.tsx
@@ -7,7 +7,7 @@ import { MessageList, MessageListHandle } from "./MessageList";
 import { useAgentChat, BOOTSTRAP_MESSAGE } from "@/hooks/useAgentChat";
 import { useApi } from "@/lib/api";
 import { useBilling } from "@/hooks/useBilling";
-import { useOrganization } from "@clerk/nextjs";
+import { useAuth, useOrganization } from "@clerk/nextjs";
 import { Loader2, AlertTriangle, ArrowDownCircle, RefreshCw, Clock, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useGateway } from "@/hooks/useGateway";
@@ -400,6 +400,10 @@ export function AgentChatWindow({
   agentId,
   onOpenFile,
 }: AgentChatWindowProps): React.ReactElement {
+  const { userId } = useAuth();
+  // Every user gets their own session — isolates chat history from cron,
+  // channels, and other system activity. Matches backend (websocket_chat.py).
+  const sessionName = userId ?? "main";
   const {
     messages: chatMessages,
     isStreaming,
@@ -410,7 +414,7 @@ export function AgentChatWindow({
     clearMessages,
     isLoadingHistory,
     needsBootstrap,
-  } = useAgentChat(agentId);
+  } = useAgentChat(agentId, sessionName);
 
   const api = useApi();
   const [isUploading, setIsUploading] = useState(false);

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -125,11 +125,14 @@ const _needsBootstrap = new Set<string>();
 // this by rendering a single AgentChatWindow.
 // =============================================================================
 
-export function useAgentChat(agentId: string | null): UseAgentChatReturn {
+export function useAgentChat(agentId: string | null, sessionName: string = "main"): UseAgentChatReturn {
   const { isConnected, sendChat, onChatMessage, sendReq } = useGateway();
 
+  // Cache key includes session name so org members don't share history cache
+  const cacheKey = agentId ? `${agentId}:${sessionName}` : null;
+
   const [messages, setMessages] = useState<InternalMessage[]>(
-    () => (agentId ? _messageCache.get(agentId) ?? [] : []),
+    () => (cacheKey ? _messageCache.get(cacheKey) ?? [] : []),
   );
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -146,24 +149,26 @@ export function useAgentChat(agentId: string | null): UseAgentChatReturn {
 
   // ---- Sync messages to module-level cache ----
   useEffect(() => {
-    if (agentId && messages.length > 0) {
-      _messageCache.set(agentId, messages);
+    if (cacheKey && messages.length > 0) {
+      _messageCache.set(cacheKey, messages);
     }
-  }, [agentId, messages]);
+  }, [cacheKey, messages]);
 
   // ---- Fetch history on mount / agent change ----
   const historyLoadedRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    if (!agentId || !isConnected) return;
-    if (historyLoadedRef.current.has(agentId)) return;
+    if (!agentId || !cacheKey || !isConnected) return;
+    if (historyLoadedRef.current.has(cacheKey)) return;
     // Don't fetch if we already have cached messages
-    if (_messageCache.has(agentId)) {
-      historyLoadedRef.current.add(agentId);
+    if (_messageCache.has(cacheKey)) {
+      historyLoadedRef.current.add(cacheKey);
       return;
     }
 
-    const sessionKey = `agent:${agentId}:main`;
+    // Session key must match the backend's convention (websocket_chat.py:588):
+    // org members get agent:{agentId}:{userId}, personal users get agent:{agentId}:main
+    const sessionKey = `agent:${agentId}:${sessionName}`;
 
     // Use Promise.resolve to move setState into a callback (satisfies react-hooks/set-state-in-effect)
     Promise.resolve().then(() => setHistoryLoadState("loading"));
@@ -173,12 +178,12 @@ export function useAgentChat(agentId: string | null): UseAgentChatReturn {
         const historyResult = result as {
           messages?: Array<{ role: string; content: Array<{ type: string; text?: string }> }>;
         };
-        historyLoadedRef.current.add(agentId);
+        historyLoadedRef.current.add(cacheKey);
         setHistoryLoadState("done");
 
         if (!historyResult?.messages?.length) {
           // No history = first time. Flag for bootstrap suggestion in chat input.
-          _needsBootstrap.add(agentId);
+          _needsBootstrap.add(cacheKey);
           return;
         }
 
@@ -199,15 +204,15 @@ export function useAgentChat(agentId: string | null): UseAgentChatReturn {
 
         if (loaded.length > 0) {
           setMessages(loaded);
-          _messageCache.set(agentId, loaded);
+          _messageCache.set(cacheKey, loaded);
         }
       })
       .catch((err: unknown) => {
         console.warn("Failed to fetch chat history:", err);
-        historyLoadedRef.current.add(agentId);
+        historyLoadedRef.current.add(cacheKey);
         setHistoryLoadState("done");
       });
-  }, [agentId, isConnected, sendReq]);
+  }, [agentId, cacheKey, sessionName, isConnected, sendReq]);
 
   // ---- Chat message handler ----
   // Dependencies are intentionally minimal ([onChatMessage]) because all
@@ -363,7 +368,8 @@ export function useAgentChat(agentId: string | null): UseAgentChatReturn {
       setBudgetError(null);
 
       // Clear bootstrap flag once user sends their first message
-      if (agentIdRef.current) _needsBootstrap.delete(agentIdRef.current);
+      const key = agentIdRef.current ? `${agentIdRef.current}:${sessionName}` : null;
+      if (key) _needsBootstrap.delete(key);
 
       const userMsgId = `user-${crypto.randomUUID()}`;
       const assistantMsgId = `assistant-${crypto.randomUUID()}`;
@@ -397,7 +403,7 @@ export function useAgentChat(agentId: string | null): UseAgentChatReturn {
         streamContentRef.current = "";
       }
     },
-    [sendChat, isConnected],
+    [sendChat, isConnected, sessionName],
   );
 
   // ---- Cancel / stop agent ----
@@ -445,8 +451,8 @@ export function useAgentChat(agentId: string | null): UseAgentChatReturn {
   );
 
   const needsBootstrap = !!(
-    agentId &&
-    _needsBootstrap.has(agentId) &&
+    cacheKey &&
+    _needsBootstrap.has(cacheKey) &&
     messages.length === 0 &&
     historyLoadState === "done"
   );

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -125,7 +125,7 @@ const _needsBootstrap = new Set<string>();
 // this by rendering a single AgentChatWindow.
 // =============================================================================
 
-export function useAgentChat(agentId: string | null, sessionName: string = "main"): UseAgentChatReturn {
+export function useAgentChat(agentId: string | null, sessionName: string): UseAgentChatReturn {
   const { isConnected, sendChat, onChatMessage, sendReq } = useGateway();
 
   // Cache key includes session name so org members don't share history cache
@@ -167,7 +167,7 @@ export function useAgentChat(agentId: string | null, sessionName: string = "main
     }
 
     // Session key must match the backend's convention (websocket_chat.py:588):
-    // org members get agent:{agentId}:{userId}, personal users get agent:{agentId}:main
+    // all users get agent:{agentId}:{userId} to isolate from cron/system activity
     const sessionKey = `agent:${agentId}:${sessionName}`;
 
     // Use Promise.resolve to move setState into a callback (satisfies react-hooks/set-state-in-effect)
@@ -411,7 +411,7 @@ export function useAgentChat(agentId: string | null, sessionName: string = "main
   const cancelMessage = useCallback(async () => {
     if (!agentIdRef.current || !isStreaming) return;
 
-    const sessionKey = `agent:${agentIdRef.current}:main`;
+    const sessionKey = `agent:${agentIdRef.current}:${sessionName}`;
     try {
       await sendReq("chat.abort", { sessionKey });
     } catch (err) {
@@ -422,20 +422,21 @@ export function useAgentChat(agentId: string | null, sessionName: string = "main
     setIsStreaming(false);
     currentAssistantIdRef.current = null;
     streamContentRef.current = "";
-  }, [isStreaming, sendReq]);
+  }, [isStreaming, sendReq, sessionName]);
 
   // ---- Clear messages ----
 
   const clearMessages = useCallback(() => {
     setMessages([]);
-    if (agentIdRef.current) {
-      _messageCache.delete(agentIdRef.current);
+    const key = agentIdRef.current ? `${agentIdRef.current}:${sessionName}` : null;
+    if (key) {
+      _messageCache.delete(key);
     }
     setError(null);
     setIsStreaming(false);
     currentAssistantIdRef.current = null;
     streamContentRef.current = "";
-  }, []);
+  }, [sessionName]);
 
   // ---- External interface ----
 


### PR DESCRIPTION
## Summary
- Both backend (`chat.send`) and frontend (`chat.history`) now use `agent:{agentId}:{userId}` for **every user**, not just org members
- Previously personal users used `agent:{agentId}:main` which shared a session namespace with cron jobs and system activity — users saw cron outputs and heartbeat artifacts in their chat history
- Cache keys in `useAgentChat` include the session name to prevent cross-contamination

## Changes
- `websocket_chat.py`: removed `is_org` branch, always uses `{userId}` in session key
- `AgentChatWindow.tsx`: passes `userId` as `sessionName` to `useAgentChat`
- `useAgentChat.ts`: accepts `sessionName` param, uses it for `chat.history` RPC and message cache

## Note
Existing personal users will see a fresh chat on first load — their old history lives under the `main` session key in OpenClaw. New messages go to the per-user session.

## Test plan
- [ ] Personal user: send a message, refresh — should see own history, not cron/system noise
- [ ] Org member: send a message, refresh — should see own history, not other members' messages
- [ ] Cron job fires — output should NOT appear in any user's chat history
- [ ] Switch between agents — history loads correctly per agent per user

🤖 Generated with [Claude Code](https://claude.com/claude-code)