### PR TITLE
feat(chat): replace assistant avatar + model name with agent name + r…

### DIFF
--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -137,20 +137,49 @@
 }
 
 /* ═══════════════════════════════════════════════
-   THINKING INFINITY ANIMATION
+   AGENT GLYPH
+   Rotates between upright 8 (idle) and horizontal ∞ (thinking).
+   Back-out easing gives the rotation a subtle overshoot so the
+   state change feels purposeful rather than mechanical.
    ═══════════════════════════════════════════════ */
 
-.thinking-infinity .infinity-base {
-  opacity: 0.35;
+.agent-glyph {
+  transform-origin: center center;
+  transform: rotate(90deg);
+  transition: transform 650ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.agent-glyph.agent-glyph--thinking {
+  transform: rotate(0deg);
 }
 
-.thinking-infinity .infinity-tracer {
+/* Two-path composition:
+   - base   = the full, solid figure-eight stroke (100% drawn when idle)
+   - tracer = a short segment that chases around the loop while thinking
+   Idle: base at full opacity, tracer hidden.
+   Thinking: base dims so the tracer reads as the moving element. */
+.agent-glyph .agent-glyph-base {
+  stroke: #302d28;
+  opacity: 1;
+  transition: opacity 350ms ease;
+}
+.agent-glyph .agent-glyph-tracer {
+  stroke: #302d28;
   stroke-dasharray: 12 36;
-  animation: infinity-trace 2s linear infinite;
+  stroke-dashoffset: 48;
+  opacity: 0;
+  transition: opacity 250ms ease;
+}
+.agent-glyph.agent-glyph--thinking .agent-glyph-base {
+  opacity: 0.3;
+}
+.agent-glyph.agent-glyph--thinking .agent-glyph-tracer {
+  opacity: 1;
+  animation: agent-glyph-trace 1.8s linear infinite;
+  animation-delay: 250ms; /* let rotation + base-fade finish before tracing begins */
 }
 
-@keyframes infinity-trace {
-  0% { stroke-dashoffset: 48; }
+@keyframes agent-glyph-trace {
+  0%   { stroke-dashoffset: 48; }
   100% { stroke-dashoffset: 0; }
 }
 

--- a/apps/frontend/src/components/chat/AgentChatWindow.tsx
+++ b/apps/frontend/src/components/chat/AgentChatWindow.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChatInput } from "./ChatInput";
 import { MessageList, MessageListHandle } from "./MessageList";
 import { useAgentChat, BOOTSTRAP_MESSAGE } from "@/hooks/useAgentChat";
+import { useAgents } from "@/hooks/useAgents";
 import { useApi } from "@/lib/api";
 import { useBilling } from "@/hooks/useBilling";
 import { useAuth, useOrganization } from "@clerk/nextjs";
@@ -416,6 +417,10 @@ export function AgentChatWindow({
     needsBootstrap,
   } = useAgentChat(agentId, sessionName);
 
+  const { agents } = useAgents();
+  const activeAgent = agents.find((a) => a.id === agentId);
+  const agentName = activeAgent?.identity?.name ?? activeAgent?.name ?? agentId ?? undefined;
+
   const api = useApi();
   const [isUploading, setIsUploading] = useState(false);
   const messageListRef = useRef<MessageListHandle>(null);
@@ -488,7 +493,7 @@ export function AgentChatWindow({
       <div className="flex flex-col h-full bg-[#faf7f2]">
         <div className="flex-1 flex flex-col">
           {messages.length > 0 && (
-            <MessageList ref={messageListRef} messages={messages} isTyping={isTyping} onOpenFile={onOpenFile} />
+            <MessageList ref={messageListRef} messages={messages} isTyping={isTyping} agentName={agentName} onOpenFile={onOpenFile} />
           )}
           <div className="p-4 m-4 bg-[#fce4ec] border border-[#f8bbd0] text-[#a5311f] rounded-lg">
             <p className="font-medium">Error</p>
@@ -548,7 +553,7 @@ export function AgentChatWindow({
 
   return (
     <div className="flex flex-col h-full min-h-0 bg-[#faf7f2]">
-      <MessageList ref={messageListRef} messages={messages} isTyping={isTyping} onOpenFile={onOpenFile} />
+      <MessageList ref={messageListRef} messages={messages} isTyping={isTyping} agentName={agentName} onOpenFile={onOpenFile} />
       <UpdateBanner />
       <DowngradeBanner />
       <ApproachLimitBanner />

--- a/apps/frontend/src/components/chat/MessageList.tsx
+++ b/apps/frontend/src/components/chat/MessageList.tsx
@@ -26,6 +26,7 @@ interface Message {
 interface MessageListProps {
   messages: Message[];
   isTyping?: boolean;
+  agentName?: string;
   onRetry?: (assistantMsgId: string) => void;
   onOpenFile?: (path: string) => void;
 }
@@ -180,19 +181,48 @@ function ToolUseIndicator({ toolUses }: { toolUses: ToolUse[] }) {
   );
 }
 
-function MessageToolbar({ modelName }: { modelName?: string }) {
+const AGENT_GLYPH_PATH =
+    "M11.2 6 C10.4 4.2 8.8 2.5 7 2.5 C5.2 2.5 4 4 4 6 C4 8 5.2 9.5 7 9.5 C8.8 9.5 10.4 7.8 11.2 6 C12 4.2 13.6 2.5 15.4 2.5 C17.2 2.5 18.4 4 18.4 6 C18.4 8 17.2 9.5 15.4 9.5 C13.6 9.5 12 7.8 11.2 6Z";
+
+function AgentHead({ name, state }: { name: string; state: "idle" | "thinking" }) {
     return (
-        <div className="flex items-center gap-1 mb-2 opacity-0 group-hover:opacity-100 transition-opacity">
-            <span className="text-xs font-medium text-[#8a8578] mr-2 flex items-center gap-1">
-                {modelName || "Assistant"}
+        <div className="flex items-center gap-2 mb-2">
+            <span className="text-xs font-semibold text-[#302d28] tracking-tight">
+                {name}
             </span>
-            <Button variant="ghost" size="icon" className="h-6 w-6 text-[#8a8578] hover:text-[#1a1a1a] hover:bg-[#f3efe6]">
+            <span className="inline-flex items-center justify-center w-5 h-5">
+                <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 12"
+                    fill="none"
+                    className={cn("agent-glyph", state === "thinking" && "agent-glyph--thinking")}
+                >
+                    <path
+                        className="agent-glyph-base"
+                        d={AGENT_GLYPH_PATH}
+                        strokeWidth="1.6"
+                        fill="none"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    />
+                    <path
+                        className="agent-glyph-tracer"
+                        d={AGENT_GLYPH_PATH}
+                        strokeWidth="1.6"
+                        fill="none"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    />
+                </svg>
+            </span>
+            <Button variant="ghost" size="icon" className="h-6 w-6 text-[#8a8578] hover:text-[#1a1a1a] hover:bg-[#f3efe6] opacity-0 group-hover:opacity-100 transition-opacity ml-1">
                 <Copy className="h-3 w-3" />
             </Button>
-            <Button variant="ghost" size="icon" className="h-6 w-6 text-[#8a8578] hover:text-[#1a1a1a] hover:bg-[#f3efe6]">
+            <Button variant="ghost" size="icon" className="h-6 w-6 text-[#8a8578] hover:text-[#1a1a1a] hover:bg-[#f3efe6] opacity-0 group-hover:opacity-100 transition-opacity">
                 <RefreshCw className="h-3 w-3" />
             </Button>
-            <Button variant="ghost" size="icon" className="h-6 w-6 text-[#8a8578] hover:text-[#1a1a1a] hover:bg-[#f3efe6]">
+            <Button variant="ghost" size="icon" className="h-6 w-6 text-[#8a8578] hover:text-[#1a1a1a] hover:bg-[#f3efe6] opacity-0 group-hover:opacity-100 transition-opacity">
                 <Share2 className="h-3 w-3" />
             </Button>
         </div>
@@ -222,7 +252,7 @@ export interface MessageListHandle {
 }
 
 export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>(
-  function MessageList({ messages, isTyping, onRetry, onOpenFile }, ref) {
+  function MessageList({ messages, isTyping, agentName, onRetry, onOpenFile }, ref) {
     const { containerRef, endRef, scrollToBottom } = useScrollToBottom();
 
     React.useImperativeHandle(ref, () => ({
@@ -247,23 +277,17 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
               data-role={msg.role}
               className={cn(
                 "flex w-full group relative",
-                msg.role === "user" ? "justify-end" : "justify-start gap-3"
+                msg.role === "user" ? "justify-end" : "justify-start"
               )}
             >
-              {/* Assistant avatar */}
-              {msg.role === "assistant" && (
-                <div className="w-8 h-8 rounded-full bg-[#06402B] flex items-center justify-center flex-shrink-0 mt-1">
-                  <svg width="14" height="8" viewBox="0 0 24 12" fill="none">
-                    <path d="M12 6C9.5 2 7 1 5 3C3 5 3 7 5 9C7 11 9.5 10 12 6C14.5 2 17 1 19 3C21 5 21 7 19 9C17 11 14.5 10 12 6Z" stroke="white" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                </div>
-              )}
-
               <div className="flex flex-col min-w-0 max-w-[85%]">
                 {msg.role === "assistant" && (
                   msg.content.startsWith("Error: ")
                     ? <ErrorToolbar messageId={msg.id} onRetry={onRetry} />
-                    : <MessageToolbar modelName={msg.model} />
+                    : <AgentHead
+                        name={agentName || "Assistant"}
+                        state={isTyping && isLastAssistant ? "thinking" : "idle"}
+                      />
                 )}
 
                 <div
@@ -291,25 +315,8 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
                     ? msg.content.slice(7)
                     : msg.role === "assistant" && msg.content
                       ? <MarkdownContent content={msg.content} onOpenFile={onOpenFile} />
-                      : msg.content || (isTyping && msg.role === "assistant" && !msg.thinking ? (
-                          <span className="inline-flex items-center h-5">
-                            <svg width="24" height="12" viewBox="0 0 24 12" fill="none" className="thinking-infinity">
-                              <path className="infinity-base" d="M11.2 6 C10.4 4.2 8.8 2.5 7 2.5 C5.2 2.5 4 4 4 6 C4 8 5.2 9.5 7 9.5 C8.8 9.5 10.4 7.8 11.2 6 C12 4.2 13.6 2.5 15.4 2.5 C17.2 2.5 18.4 4 18.4 6 C18.4 8 17.2 9.5 15.4 9.5 C13.6 9.5 12 7.8 11.2 6Z" stroke="#8a8578" strokeWidth="1.3" fill="none" />
-                              <path className="infinity-tracer" d="M11.2 6 C10.4 4.2 8.8 2.5 7 2.5 C5.2 2.5 4 4 4 6 C4 8 5.2 9.5 7 9.5 C8.8 9.5 10.4 7.8 11.2 6 C12 4.2 13.6 2.5 15.4 2.5 C17.2 2.5 18.4 4 18.4 6 C18.4 8 17.2 9.5 15.4 9.5 C13.6 9.5 12 7.8 11.2 6Z" stroke="#5a5549" strokeWidth="1.3" fill="none" />
-                            </svg>
-                          </span>
-                        ) : null)}
+                      : msg.content || null}
                 </div>
-
-                {isTyping && isLastAssistant && msg.content && (
-                  <div className="mt-3 flex items-center gap-2 text-xs text-[#8a8578]">
-                    <svg width="18" height="10" viewBox="0 0 24 12" fill="none" className="thinking-infinity">
-                      <path className="infinity-base" d="M11.2 6 C10.4 4.2 8.8 2.5 7 2.5 C5.2 2.5 4 4 4 6 C4 8 5.2 9.5 7 9.5 C8.8 9.5 10.4 7.8 11.2 6 C12 4.2 13.6 2.5 15.4 2.5 C17.2 2.5 18.4 4 18.4 6 C18.4 8 17.2 9.5 15.4 9.5 C13.6 9.5 12 7.8 11.2 6Z" stroke="#8a8578" strokeWidth="1.3" fill="none" />
-                      <path className="infinity-tracer" d="M11.2 6 C10.4 4.2 8.8 2.5 7 2.5 C5.2 2.5 4 4 4 6 C4 8 5.2 9.5 7 9.5 C8.8 9.5 10.4 7.8 11.2 6 C12 4.2 13.6 2.5 15.4 2.5 C17.2 2.5 18.4 4 18.4 6 C18.4 8 17.2 9.5 15.4 9.5 C13.6 9.5 12 7.8 11.2 6Z" stroke="#5a5549" strokeWidth="1.3" fill="none" />
-                    </svg>
-                    <span>Agent is working</span>
-                  </div>
-                )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
…otating figure-8

Removes the dark-green circle avatar (w-8 h-8 rounded-full bg-[#06402B]) with its static figure-eight from every assistant message. Replaces the model-name label ("qwen3.5-plus") above each assistant message with the agent's display name (e.g. "Ember") alongside a single animated glyph that carries the pending-state signal.

The glyph is a figure-8/infinity stroke that rotates 90 degrees between two positions driven by useAgentChat's isStreaming flag:
  idle     -> upright "8"  (the agent's resting identity mark)
  thinking -> horizontal infinity (tracer animates around the loop)

Back-out easing (cubic-bezier overshoot) on the 650ms rotation gives the transition purposeful showmanship. Tracer starts 250ms after the rotation begins so the motion reads as a staged reveal.

The idle state renders the base path at full opacity, solid, 100% drawn figure-8. Only in thinking state does the base dim to 30% so the moving tracer reads as the figure in motion.

Also removes the now-redundant "Agent is working" inline footer beneath streaming messages and the empty-message tracer-only placeholder -- the glyph in the agent head covers both cases.

Changes:
- globals.css: replaces .thinking-infinity CSS with .agent-glyph set (rotation + idle/thinking state transitions + trace keyframe)
- MessageList.tsx: new AgentHead component, removes avatar block, swaps MessageToolbar for AgentHead, drops empty-message and "Agent is working" fragments, adds agentName prop
- AgentChatWindow.tsx: sources displayName via useAgents lookup (identity.name -> name -> id fallback), passes agentName to both MessageList instances