### PR TITLE
fix(chat): cross-agent message leak + enable tool events

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -328,24 +328,6 @@ class GatewayConnection:
         return None
 
     @staticmethod
-    def _extract_chat_text(payload: dict) -> str | None:
-        """Extract text from a chat event's message.content field."""
-        msg = payload.get("message")
-        if not isinstance(msg, dict):
-            return None
-        content = msg.get("content", [])
-        if isinstance(content, list) and content:
-            # Find the last text block (skip thinking blocks)
-            for block in reversed(content):
-                if isinstance(block, dict) and block.get("type") in ("text", "output_text"):
-                    return block.get("text") or None
-            # Fallback: last block regardless of type
-            block = content[-1]
-            if isinstance(block, dict):
-                return block.get("text") or None
-        return None
-
-    @staticmethod
     def _extract_thinking_text(payload: dict) -> str | None:
         """Extract thinking/reasoning text from a chat event's message.content field."""
         msg = payload.get("message")
@@ -718,20 +700,20 @@ class GatewayConnection:
                 event_agent_id = parsed_key.get("agent_id")
                 if state == "final":
                     put_metric("chat.message.count")
-                    # Send thinking content if present (before visible text)
+                    # Deliver thinking from content blocks for models that
+                    # batch reasoning into the final message (reasoningLevel
+                    # not set to "stream"). Once reasoningLevel:"stream" is
+                    # enabled on the session, this will typically be empty
+                    # because thinking streamed via agent events already.
                     thinking_text = self._extract_thinking_text(payload)
                     if thinking_text:
                         fwd: dict = {"type": "thinking", "content": thinking_text}
                         if event_agent_id:
                             fwd["agent_id"] = event_agent_id
                         self._forward_to_frontends(fwd, target_member)
-                    # Send complete text as safety net before done signal
-                    final_text = self._extract_chat_text(payload)
-                    if final_text:
-                        fwd = {"type": "chunk", "content": final_text}
-                        if event_agent_id:
-                            fwd["agent_id"] = event_agent_id
-                        self._forward_to_frontends(fwd, target_member)
+                    # OpenClaw guarantees the full text reached us via agent
+                    # stream="assistant" events (with flushBufferedChatDeltaIfNeeded
+                    # as a server-side backstop), so no chunk is emitted here.
                     fwd = {"type": "done"}
                     if event_agent_id:
                         fwd["agent_id"] = event_agent_id

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -643,8 +643,10 @@ class GatewayConnection:
             if event_name == "agent":
                 # Unthrottled agent events -- smooth token-by-token streaming
                 stream = payload.get("stream", "")
-                if stream not in ("assistant", ""):
-                    # Log non-assistant events (tool, lifecycle, error) for debugging
+                # Exclude token-level streams (assistant, reasoning, thinking)
+                # from INFO logs — each fires per LLM token, so logging would
+                # blow up CloudWatch volume on long responses.
+                if stream not in ("assistant", "reasoning", "thinking", ""):
                     data = payload.get("data", {})
                     logger.info(
                         "Agent event for user %s: stream=%s phase=%s name=%s keys=%s",

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -215,6 +215,9 @@ class GatewayConnection:
                 "scopes": list(BACKEND_OPERATOR_SCOPES),
                 "auth": {"token": self.token},
                 "device": device,
+                # Opt in to real-time tool events. Without this capability,
+                # OpenClaw silently drops stream:"tool" events for this client.
+                "caps": ["tool-events"],
             },
         }
         await self._ws.send(json.dumps(connect_msg))
@@ -277,11 +280,12 @@ class GatewayConnection:
 
     @staticmethod
     def _transform_agent_event(payload: dict) -> dict | None:
-        """Extract streaming text or tool events from an OpenClaw agent event.
+        """Extract streaming text, thinking, or tool events from an OpenClaw agent event.
 
         Agent events fire for every LLM token (no 150ms throttle).
         - ``stream: "assistant"`` events with text are forwarded as chunks.
-        - ``stream: "tool"`` events are forwarded as tool_start/tool_end.
+        - ``stream: "reasoning"`` / ``"thinking"`` events are forwarded for real-time thinking.
+        - ``stream: "tool"`` events are forwarded as tool_start/tool_end/tool_error.
         """
         stream = payload.get("stream")
         data = payload.get("data")
@@ -294,15 +298,31 @@ class GatewayConnection:
                 return {"type": "chunk", "content": text}
             return None
 
+        if stream in ("reasoning", "thinking"):
+            text = data.get("text", "")
+            if text:
+                return {"type": "thinking", "content": text}
+            return None
+
         if stream == "tool":
             phase = data.get("phase", "")
             name = data.get("name", "")
             if not name:
                 return None
+            tool_call_id = data.get("toolCallId", "")
             if phase == "start":
-                return {"type": "tool_start", "tool": name}
+                msg: dict = {"type": "tool_start", "tool": name}
+                if tool_call_id:
+                    msg["toolCallId"] = tool_call_id
+                return msg
             if phase == "result":
-                return {"type": "tool_end", "tool": name}
+                # OpenClaw signals tool errors via isError flag on the result
+                # phase, not a separate "error" phase.
+                is_error = bool(data.get("isError"))
+                msg = {"type": "tool_error" if is_error else "tool_end", "tool": name}
+                if tool_call_id:
+                    msg["toolCallId"] = tool_call_id
+                return msg
             return None
 
         return None
@@ -670,6 +690,12 @@ class GatewayConnection:
                     return
                 transformed = self._transform_agent_event(payload)
                 if transformed:
+                    # Tag with agent_id so the frontend can route messages
+                    # to the correct agent conversation and prevent cross-
+                    # agent leakage when switching agents mid-stream.
+                    event_agent_id = parsed_key.get("agent_id")
+                    if event_agent_id:
+                        transformed["agent_id"] = event_agent_id
                     self._forward_to_frontends(transformed, target_member)
 
             elif event_name == "chat":
@@ -687,29 +713,47 @@ class GatewayConnection:
                         session_key[:60] if session_key else "-",
                         target_member or "broadcast",
                     )
+                # Tag all chat messages with agent_id so the frontend can
+                # route responses to the correct agent conversation.
+                event_agent_id = parsed_key.get("agent_id")
                 if state == "final":
                     put_metric("chat.message.count")
                     # Send thinking content if present (before visible text)
                     thinking_text = self._extract_thinking_text(payload)
                     if thinking_text:
-                        self._forward_to_frontends({"type": "thinking", "content": thinking_text}, target_member)
+                        fwd: dict = {"type": "thinking", "content": thinking_text}
+                        if event_agent_id:
+                            fwd["agent_id"] = event_agent_id
+                        self._forward_to_frontends(fwd, target_member)
                     # Send complete text as safety net before done signal
                     final_text = self._extract_chat_text(payload)
                     if final_text:
-                        self._forward_to_frontends({"type": "chunk", "content": final_text}, target_member)
-                    self._forward_to_frontends({"type": "done"}, target_member)
+                        fwd = {"type": "chunk", "content": final_text}
+                        if event_agent_id:
+                            fwd["agent_id"] = event_agent_id
+                        self._forward_to_frontends(fwd, target_member)
+                    fwd = {"type": "done"}
+                    if event_agent_id:
+                        fwd["agent_id"] = event_agent_id
+                    self._forward_to_frontends(fwd, target_member)
                 elif state == "error":
                     put_metric("chat.error", dimensions={"reason": "agent_error"})
                     err = payload.get("error", {})
-                    msg = (
+                    err_msg = (
                         err.get("message", "Agent run failed")
                         if isinstance(err, dict)
                         else str(err or "Agent run failed")
                     )
-                    self._forward_to_frontends({"type": "error", "message": msg}, target_member)
+                    fwd = {"type": "error", "message": err_msg}
+                    if event_agent_id:
+                        fwd["agent_id"] = event_agent_id
+                    self._forward_to_frontends(fwd, target_member)
                 elif state == "aborted":
                     put_metric("chat.error", dimensions={"reason": "aborted"})
-                    self._forward_to_frontends({"type": "error", "message": "Agent run was cancelled"}, target_member)
+                    fwd = {"type": "error", "message": "Agent run was cancelled"}
+                    if event_agent_id:
+                        fwd["agent_id"] = event_agent_id
+                    self._forward_to_frontends(fwd, target_member)
 
             else:
                 # Forward other events as-is for SWR revalidation (broadcast to all)

--- a/apps/backend/routers/websocket_chat.py
+++ b/apps/backend/routers/websocket_chat.py
@@ -336,6 +336,9 @@ async def ws_message(
 
         if not agent_id or not message:
             management_api = await get_management_api_client()
+            # No agent_id to tag — this is a client-validation error,
+            # untagged by necessity. Frontend treats untagged errors as
+            # broadcast so they still clear the streaming state.
             management_api.send_message(
                 x_connection_id,
                 {"type": "error", "message": "Missing agent_id or message"},
@@ -358,6 +361,7 @@ async def ws_message(
                 x_connection_id,
                 {
                     "type": "error",
+                    "agent_id": agent_id,
                     "code": "BUDGET_EXCEEDED",
                     "message": (
                         "You've used your included LLM budget for this month."
@@ -562,6 +566,7 @@ async def _process_agent_chat_background(
                 connection_id,
                 {
                     "type": "error",
+                    "agent_id": agent_id,
                     "message": "No container provisioned. Please subscribe to start chatting.",
                 },
             )
@@ -574,6 +579,7 @@ async def _process_agent_chat_background(
                 connection_id,
                 {
                     "type": "error",
+                    "agent_id": agent_id,
                     "message": "Your agent is starting up. Please try again in a moment.",
                 },
             )
@@ -633,7 +639,11 @@ async def _process_agent_chat_background(
     try:
         management_api.send_message(
             connection_id,
-            {"type": "error", "message": f"Failed to send message: {chat_err}"},
+            {
+                "type": "error",
+                "agent_id": agent_id,
+                "message": f"Failed to send message: {chat_err}",
+            },
         )
     except Exception:
         pass

--- a/apps/backend/tests/unit/core/test_chat_event_transform.py
+++ b/apps/backend/tests/unit/core/test_chat_event_transform.py
@@ -1,8 +1,7 @@
 # backend/tests/unit/core/test_chat_event_transform.py
 """Unit tests for GatewayConnection.
 
-Covers _transform_agent_event(), _extract_chat_text(), _handle_message routing,
-and is_connected property.
+Covers _transform_agent_event(), _handle_message routing, and is_connected property.
 """
 
 import pytest
@@ -150,40 +149,6 @@ class TestTransformAgentEvent:
         )
 
 
-class TestExtractChatText:
-    """Tests for _extract_chat_text — extracts text from chat event message field."""
-
-    def test_extracts_text_from_content_block(self):
-        result = GatewayConnection._extract_chat_text(
-            {"message": {"content": [{"type": "text", "text": "Hello world"}]}}
-        )
-        assert result == "Hello world"
-
-    def test_uses_last_content_block(self):
-        result = GatewayConnection._extract_chat_text(
-            {
-                "message": {
-                    "content": [
-                        {"type": "thinking", "text": "internal"},
-                        {"type": "text", "text": "visible"},
-                    ]
-                }
-            }
-        )
-        assert result == "visible"
-
-    def test_no_message_returns_none(self):
-        assert GatewayConnection._extract_chat_text({}) is None
-        assert GatewayConnection._extract_chat_text({"message": "string"}) is None
-
-    def test_empty_content_returns_none(self):
-        assert GatewayConnection._extract_chat_text({"message": {"content": []}}) is None
-        assert GatewayConnection._extract_chat_text({"message": {}}) is None
-
-    def test_empty_text_returns_none(self):
-        assert GatewayConnection._extract_chat_text({"message": {"content": [{"type": "text", "text": ""}]}}) is None
-
-
 class TestHandleMessage:
     """Tests that _handle_message routes events correctly.
 
@@ -277,7 +242,7 @@ class TestHandleMessage:
         )
 
     def test_chat_final_tagged_with_agent_id(self, connection, mock_management_api):
-        """chat.final output also carries agent_id so the frontend can route the done signal."""
+        """chat.final done signal carries agent_id so the frontend can route it."""
         connection._handle_message(
             {
                 "type": "event",
@@ -289,11 +254,7 @@ class TestHandleMessage:
                 },
             }
         )
-        assert mock_management_api.send_message.call_count == 2
-        mock_management_api.send_message.assert_any_call(
-            "conn-1", {"type": "chunk", "content": "Done.", "agent_id": "my-agent-id"}
-        )
-        mock_management_api.send_message.assert_any_call("conn-1", {"type": "done", "agent_id": "my-agent-id"})
+        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "done", "agent_id": "my-agent-id"})
 
     # -- Chat events (terminal states only) --
 
@@ -311,8 +272,8 @@ class TestHandleMessage:
         )
         mock_management_api.send_message.assert_not_called()
 
-    def test_chat_final_sends_complete_text_then_done(self, connection, mock_management_api):
-        """Final event sends the complete response text, then done signal."""
+    def test_chat_final_sends_only_done(self, connection, mock_management_api):
+        """Final sends just the done signal — assistant text streamed via agent events."""
         connection._handle_message(
             {
                 "type": "event",
@@ -326,14 +287,29 @@ class TestHandleMessage:
                 },
             }
         )
-        assert mock_management_api.send_message.call_count == 2
-        mock_management_api.send_message.assert_any_call(
-            "conn-1", {"type": "chunk", "content": "Complete response here."}
+        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "done"})
+
+    def test_chat_final_with_thinking_sends_thinking_then_done(self, connection, mock_management_api):
+        """Thinking blocks in the final message are forwarded for models that batch reasoning."""
+        connection._handle_message(
+            {
+                "type": "event",
+                "event": "chat",
+                "payload": {
+                    "state": "final",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "thinking", "thinking": "Let me reason about this..."},
+                            {"type": "text", "text": "Answer"},
+                        ],
+                    },
+                },
+            }
         )
-        mock_management_api.send_message.assert_any_call("conn-1", {"type": "done"})
-        # Verify order: chunk before done
+        assert mock_management_api.send_message.call_count == 2
         calls = mock_management_api.send_message.call_args_list
-        assert calls[0] == call("conn-1", {"type": "chunk", "content": "Complete response here."})
+        assert calls[0] == call("conn-1", {"type": "thinking", "content": "Let me reason about this..."})
         assert calls[1] == call("conn-1", {"type": "done"})
 
     def test_chat_final_without_text_sends_only_done(self, connection, mock_management_api):

--- a/apps/backend/tests/unit/core/test_chat_event_transform.py
+++ b/apps/backend/tests/unit/core/test_chat_event_transform.py
@@ -88,13 +88,23 @@ class TestTransformAgentEvent:
         result = GatewayConnection._transform_agent_event(
             {"stream": "tool", "data": {"name": "web_search", "phase": "start", "toolCallId": "abc-123"}}
         )
-        assert result == {"type": "tool_start", "tool": "web_search"}
+        assert result == {"type": "tool_start", "tool": "web_search", "toolCallId": "abc-123"}
 
     def test_tool_stream_result_phase(self):
         result = GatewayConnection._transform_agent_event(
             {"stream": "tool", "data": {"name": "web_search", "phase": "result", "toolCallId": "abc-123"}}
         )
-        assert result == {"type": "tool_end", "tool": "web_search"}
+        assert result == {"type": "tool_end", "tool": "web_search", "toolCallId": "abc-123"}
+
+    def test_tool_stream_result_with_is_error(self):
+        """OpenClaw signals tool errors via isError on the result phase."""
+        result = GatewayConnection._transform_agent_event(
+            {
+                "stream": "tool",
+                "data": {"name": "web_search", "phase": "result", "toolCallId": "abc-123", "isError": True},
+            }
+        )
+        assert result == {"type": "tool_error", "tool": "web_search", "toolCallId": "abc-123"}
 
     def test_tool_stream_update_phase_ignored(self):
         """Intermediate tool updates are not forwarded."""
@@ -108,6 +118,22 @@ class TestTransformAgentEvent:
             {"stream": "tool", "data": {"phase": "start", "toolCallId": "abc-123"}}
         )
         assert result is None
+
+    def test_thinking_stream_with_text(self):
+        result = GatewayConnection._transform_agent_event(
+            {"stream": "thinking", "data": {"text": "Let me think...", "delta": "..."}}
+        )
+        assert result == {"type": "thinking", "content": "Let me think..."}
+
+    def test_reasoning_stream_with_text(self):
+        """OpenClaw may emit reasoning events under either stream name."""
+        result = GatewayConnection._transform_agent_event(
+            {"stream": "reasoning", "data": {"text": "Considering options", "delta": "s"}}
+        )
+        assert result == {"type": "thinking", "content": "Considering options"}
+
+    def test_thinking_stream_empty_text_ignored(self):
+        assert GatewayConnection._transform_agent_event({"stream": "thinking", "data": {"text": ""}}) is None
 
     def test_missing_stream_ignored(self):
         assert GatewayConnection._transform_agent_event({"data": {"text": "Hi"}}) is None
@@ -217,7 +243,9 @@ class TestHandleMessage:
                 "payload": {"stream": "tool", "data": {"name": "web_search", "phase": "start", "toolCallId": "t1"}},
             }
         )
-        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "tool_start", "tool": "web_search"})
+        mock_management_api.send_message.assert_called_once_with(
+            "conn-1", {"type": "tool_start", "tool": "web_search", "toolCallId": "t1"}
+        )
 
     def test_agent_tool_end_forwarded(self, connection, mock_management_api):
         connection._handle_message(
@@ -227,7 +255,45 @@ class TestHandleMessage:
                 "payload": {"stream": "tool", "data": {"name": "web_search", "phase": "result", "toolCallId": "t1"}},
             }
         )
-        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "tool_end", "tool": "web_search"})
+        mock_management_api.send_message.assert_called_once_with(
+            "conn-1", {"type": "tool_end", "tool": "web_search", "toolCallId": "t1"}
+        )
+
+    def test_agent_events_tagged_with_agent_id_from_session_key(self, connection, mock_management_api):
+        """sessionKey in the payload populates agent_id so the frontend can filter cross-agent messages."""
+        connection._handle_message(
+            {
+                "type": "event",
+                "event": "agent",
+                "payload": {
+                    "stream": "assistant",
+                    "data": {"text": "Hello"},
+                    "sessionKey": "agent:my-agent-id:main",
+                },
+            }
+        )
+        mock_management_api.send_message.assert_called_once_with(
+            "conn-1", {"type": "chunk", "content": "Hello", "agent_id": "my-agent-id"}
+        )
+
+    def test_chat_final_tagged_with_agent_id(self, connection, mock_management_api):
+        """chat.final output also carries agent_id so the frontend can route the done signal."""
+        connection._handle_message(
+            {
+                "type": "event",
+                "event": "chat",
+                "payload": {
+                    "state": "final",
+                    "sessionKey": "agent:my-agent-id:main",
+                    "message": {"role": "assistant", "content": [{"type": "text", "text": "Done."}]},
+                },
+            }
+        )
+        assert mock_management_api.send_message.call_count == 2
+        mock_management_api.send_message.assert_any_call(
+            "conn-1", {"type": "chunk", "content": "Done.", "agent_id": "my-agent-id"}
+        )
+        mock_management_api.send_message.assert_any_call("conn-1", {"type": "done", "agent_id": "my-agent-id"})
 
     # -- Chat events (terminal states only) --
 

--- a/apps/backend/tests/unit/core/test_connection_pool.py
+++ b/apps/backend/tests/unit/core/test_connection_pool.py
@@ -390,39 +390,6 @@ class TestTransformAgentEvent:
         assert GatewayConnection._transform_agent_event(payload) is None
 
 
-class TestExtractChatText:
-    """Test static helper for extracting text from chat event payloads."""
-
-    def test_extracts_text_from_last_content_block(self):
-        payload = {
-            "message": {
-                "content": [
-                    {"type": "text", "text": "first"},
-                    {"type": "text", "text": "last"},
-                ]
-            }
-        }
-        assert GatewayConnection._extract_chat_text(payload) == "last"
-
-    def test_returns_none_when_no_message(self):
-        assert GatewayConnection._extract_chat_text({}) is None
-
-    def test_returns_none_when_message_not_dict(self):
-        assert GatewayConnection._extract_chat_text({"message": "plain string"}) is None
-
-    def test_returns_none_when_content_empty(self):
-        payload = {"message": {"content": []}}
-        assert GatewayConnection._extract_chat_text(payload) is None
-
-    def test_returns_none_when_last_block_has_no_text(self):
-        payload = {"message": {"content": [{"type": "tool_use", "id": "tu-1"}]}}
-        assert GatewayConnection._extract_chat_text(payload) is None
-
-    def test_returns_none_when_text_is_empty_string(self):
-        payload = {"message": {"content": [{"type": "text", "text": ""}]}}
-        assert GatewayConnection._extract_chat_text(payload) is None
-
-
 class TestHandleMessageChatEvents:
     """Test _handle_message routing for chat event states."""
 
@@ -453,8 +420,9 @@ class TestHandleMessageChatEvents:
         calls = [c.args[1] for c in mgmt.send_message.call_args_list]
         assert {"type": "done"} in calls
 
-    def test_chat_final_sends_text_chunk_if_present(self, connection):
-        """chat state=final with text forwards a chunk before done."""
+    def test_chat_final_does_not_emit_text_chunk(self, connection):
+        """chat state=final emits only the done signal — assistant text already
+        streamed via agent events, so re-sending would be redundant."""
         conn, mgmt = connection
         conn._handle_message(
             {
@@ -467,7 +435,7 @@ class TestHandleMessageChatEvents:
             }
         )
         calls = [c.args[1] for c in mgmt.send_message.call_args_list]
-        assert {"type": "chunk", "content": "complete answer"} in calls
+        assert all(c.get("type") != "chunk" for c in calls)
         assert {"type": "done"} in calls
 
     def test_chat_error_sends_error_message(self, connection):

--- a/apps/frontend/src/components/chat/AgentChatWindow.tsx
+++ b/apps/frontend/src/components/chat/AgentChatWindow.tsx
@@ -403,7 +403,8 @@ export function AgentChatWindow({
   const { userId } = useAuth();
   // Every user gets their own session — isolates chat history from cron,
   // channels, and other system activity. Matches backend (websocket_chat.py).
-  const sessionName = userId ?? "main";
+  // userId is always defined here — ChatLayout gates on clerkLoaded && isSignedIn.
+  const sessionName = userId!;
   const {
     messages: chatMessages,
     isStreaming,

--- a/apps/frontend/src/components/chat/MessageList.tsx
+++ b/apps/frontend/src/components/chat/MessageList.tsx
@@ -11,7 +11,8 @@ import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 
 interface ToolUse {
   tool: string;
-  status: "running" | "done";
+  toolCallId?: string;
+  status: "running" | "done" | "error";
 }
 
 interface Message {
@@ -154,28 +155,41 @@ function ThinkingBlock({ content }: { content: string }) {
   );
 }
 
+const TOOL_STYLES = {
+  running: {
+    pill: "bg-[#e8f5e9] text-[#2d8a4e] border-[#c8e6c9]",
+    dot: "bg-[#2d8a4e] animate-pulse",
+  },
+  done: {
+    pill: "bg-[#f3efe6] text-[#8a8578] border-[#e0dbd0]",
+    dot: "bg-[#cdc7ba]",
+  },
+  error: {
+    pill: "bg-[#fce4ec] text-[#a5311f] border-[#f8bbd0]",
+    dot: "bg-[#c62828]",
+  },
+} as const;
+
 function ToolUseIndicator({ toolUses }: { toolUses: ToolUse[] }) {
   if (toolUses.length === 0) return null;
   return (
     <div className="mb-3 flex flex-wrap gap-2">
-      {toolUses.map((t, i) => (
-        <span
-          key={`${t.tool}-${i}`}
-          className={cn(
-            "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border",
-            t.status === "running"
-              ? "bg-[#e8f5e9] text-[#2d8a4e] border-[#c8e6c9]"
-              : "bg-[#f3efe6] text-[#8a8578] border-[#e0dbd0]",
-          )}
-        >
-          {t.status === "running" ? (
-            <span className="w-1.5 h-1.5 rounded-full bg-[#2d8a4e] animate-pulse" />
-          ) : (
-            <span className="w-1.5 h-1.5 rounded-full bg-[#cdc7ba]" />
-          )}
-          {t.tool}
-        </span>
-      ))}
+      {toolUses.map((t, i) => {
+        const s = TOOL_STYLES[t.status];
+        return (
+          <span
+            key={t.toolCallId ?? `${t.tool}-${i}`}
+            className={cn(
+              "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border",
+              s.pill,
+            )}
+          >
+            <span className={cn("w-1.5 h-1.5 rounded-full", s.dot)} />
+            {t.tool}
+            {t.status === "error" && " failed"}
+          </span>
+        );
+      })}
     </div>
   );
 }

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -225,11 +225,14 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       if (!currentAssistantIdRef.current) return;
 
       // Drop messages meant for a different agent. Heartbeat and
-      // update_available don't carry agent_id because they aren't tied to
-      // a specific run; everything else must match the active agent.
+      // update_available aren't tied to a specific run. Errors are
+      // allowed through even without agent_id as a safety valve —
+      // some failure paths (client-side validation, etc.) have no
+      // agent context but still need to clear the streaming state.
       const isUntaggedBroadcast =
         msg.type === "heartbeat" || msg.type === "update_available";
-      if (!isUntaggedBroadcast && msg.agent_id !== agentIdRef.current) return;
+      const isUntaggedError = msg.type === "error" && msg.agent_id === undefined;
+      if (!isUntaggedBroadcast && !isUntaggedError && msg.agent_id !== agentIdRef.current) return;
 
       if (msg.type === "chunk") {
         // OpenClaw sends cumulative text (full response so far) in each

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -71,7 +71,8 @@ function extractThinkingContent(content: ContentBlock[]): string {
 
 export interface ToolUse {
   tool: string;
-  status: "running" | "done";
+  toolCallId?: string;
+  status: "running" | "done" | "error";
 }
 
 export interface AgentMessage {
@@ -223,6 +224,13 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       // Only process if we're currently streaming
       if (!currentAssistantIdRef.current) return;
 
+      // Drop messages meant for a different agent. Heartbeat and
+      // update_available don't carry agent_id because they aren't tied to
+      // a specific run; everything else must match the active agent.
+      const isUntaggedBroadcast =
+        msg.type === "heartbeat" || msg.type === "update_available";
+      if (!isUntaggedBroadcast && msg.agent_id !== agentIdRef.current) return;
+
       if (msg.type === "chunk") {
         // OpenClaw sends cumulative text (full response so far) in each
         // chunk, so we replace rather than append — matching how OpenClaw's
@@ -289,11 +297,14 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "thinking") {
+        // Streamed thinking events carry the cumulative thinking text, so
+        // replace rather than append. The chat.final batch sends a single
+        // event with the full text — replace works for that too.
         if (currentAssistantIdRef.current) {
           setMessages((prev) =>
             prev.map((m) =>
               m.id === currentAssistantIdRef.current
-                ? { ...m, thinking: (m.thinking ? m.thinking + "\n\n" : "") + msg.content }
+                ? { ...m, thinking: msg.content }
                 : m,
             ),
           );
@@ -310,7 +321,11 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
                     ...m,
                     toolUses: [
                       ...(m.toolUses || []),
-                      { tool: msg.tool, status: "running" as const },
+                      {
+                        tool: msg.tool,
+                        toolCallId: msg.toolCallId,
+                        status: "running" as const,
+                      },
                     ],
                   }
                 : m,
@@ -320,16 +335,23 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         return;
       }
 
-      if (msg.type === "tool_end") {
+      if (msg.type === "tool_end" || msg.type === "tool_error") {
+        const nextStatus = msg.type === "tool_end" ? "done" : "error";
         if (currentAssistantIdRef.current) {
           setMessages((prev) =>
             prev.map((m) => {
               if (m.id !== currentAssistantIdRef.current) return m;
-              const toolUses = (m.toolUses || []).map((t) =>
-                t.tool === msg.tool && t.status === "running"
-                  ? { ...t, status: "done" as const }
-                  : t,
-              );
+              const toolUses = (m.toolUses || []).map((t) => {
+                const matchesCallId =
+                  msg.toolCallId !== undefined &&
+                  t.toolCallId === msg.toolCallId;
+                const matchesName =
+                  msg.toolCallId === undefined && t.tool === msg.tool;
+                const isRunning = t.status === "running";
+                return isRunning && (matchesCallId || matchesName)
+                  ? { ...t, status: nextStatus as "done" | "error" }
+                  : t;
+              });
               return { ...m, toolUses };
             }),
           );

--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -41,13 +41,14 @@ export interface BudgetExceededPayload {
 }
 
 export type ChatIncomingMessage =
-  | { type: "chunk"; content: string }
-  | { type: "thinking"; content: string }
-  | { type: "done" }
-  | { type: "error"; message: string; code?: string } & Partial<BudgetExceededPayload>
+  | { type: "chunk"; content: string; agent_id?: string }
+  | { type: "thinking"; content: string; agent_id?: string }
+  | { type: "done"; agent_id?: string }
+  | { type: "error"; message: string; code?: string; agent_id?: string } & Partial<BudgetExceededPayload>
   | { type: "heartbeat" }
-  | { type: "tool_start"; tool: string }
-  | { type: "tool_end"; tool: string }
+  | { type: "tool_start"; tool: string; toolCallId?: string; agent_id?: string }
+  | { type: "tool_end"; tool: string; toolCallId?: string; agent_id?: string }
+  | { type: "tool_error"; tool: string; toolCallId?: string; agent_id?: string }
   | { type: "update_available" };
 
 /** Gateway event forwarded from OpenClaw */
@@ -181,6 +182,7 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
       msgType === "heartbeat" ||
       msgType === "tool_start" ||
       msgType === "tool_end" ||
+      msgType === "tool_error" ||
       msgType === "update_available"
     ) {
       const chatMsg = data as unknown as ChatIncomingMessage;


### PR DESCRIPTION
## Summary
- Tags every forwarded chat message with `agent_id` and filters by it on the frontend, so streaming responses can no longer leak into a different agent's conversation when the user switches mid-stream
- Opts into OpenClaw's `tool-events` capability during the handshake — without this, OpenClaw silently drops `stream: "tool"` events, which is why tool pills never appeared in the UI
- Accepts `stream: "reasoning"` / `"thinking"` for real-time thinking, adds `toolCallId` correlation, maps `phase: "result"` with `isError: true` to `tool_error`
- Drops the redundant safety-net chunk from `chat.final` (OpenClaw already delivers the complete text via agent stream events + flushBufferedChatDeltaIfNeeded)

## Why
Reported bug: replying to one agent and switching to another mid-stream caused the first agent's response to bleed into the new conversation.

Root cause: forwarded chat messages had no agent identifier, so `useAgentChat` applied any in-flight event to whichever agent was currently active.

While investigating I also confirmed that OpenClaw's tool events are opt-in via a `caps` field during connect — the handshake was missing that, so tool lifecycle events have never reached the UI.

## Test plan
- [x] `pytest tests/unit` — 563 passing
- [x] `ruff check` + `tsc --noEmit` + `eslint` — clean
- [ ] Dev deploy: confirm tool pills render during agent runs that use tools
- [ ] Dev deploy: confirm switching agents mid-stream no longer leaks
- [ ] Dev deploy: confirm thinking still appears on chat.final for reasoning-capable models (real-time streaming needs separate `reasoningLevel: "stream"` config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)