### PR TITLE
feat: file viewer v2 — Workspace/Config tabs, inline editing, upload fix

### DIFF
--- a/apps/backend/routers/container_rpc.py
+++ b/apps/backend/routers/container_rpc.py
@@ -17,7 +17,7 @@ import re
 import uuid
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
 from pydantic import BaseModel, Field
 from websockets import connect as ws_connect
 
@@ -240,8 +240,9 @@ def _sanitize_filename(name: str) -> str:
     summary="Upload files to the user's agent workspace",
     description=(
         "Uploads one or more files to the user's workspace on EFS. "
-        "Files are placed in the `uploads/` directory and are accessible "
-        "to the user's OpenClaw agent. Max 10MB per file, 10 files per request."
+        "Files are placed in the agent's `workspaces/{agent_id}/uploads/` directory "
+        "and are accessible to the user's OpenClaw agent. "
+        "Max 10MB per file, 10 files per request."
     ),
     operation_id="upload_files",
     responses={
@@ -251,6 +252,7 @@ def _sanitize_filename(name: str) -> str:
 )
 async def upload_files(
     files: List[UploadFile] = File(..., description="Files to upload"),
+    agent_id: str = Query(..., description="Target agent ID"),
     auth: AuthContext = Depends(get_current_user),
 ):
     if len(files) > MAX_FILES_PER_REQUEST:
@@ -258,6 +260,9 @@ async def upload_files(
             status_code=400,
             detail=f"Too many files. Maximum {MAX_FILES_PER_REQUEST} per request.",
         )
+
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
 
     owner_id = resolve_owner_id(auth)
 
@@ -280,10 +285,10 @@ async def upload_files(
             )
 
         safe_name = _sanitize_filename(f.filename or "upload")
-        dest_path = f"uploads/{safe_name}"
+        dest_path = f"workspaces/{agent_id}/uploads/{safe_name}"
         workspace.write_bytes(owner_id, dest_path, data)
         # The agent's working dir is $HOME (/home/node) but EFS is mounted
-        # at $HOME/.openclaw, so the agent path is .openclaw/uploads/filename
+        # at $HOME/.openclaw, so the agent sees uploads relative to that mount.
         agent_path = f".openclaw/{dest_path}"
         uploaded.append({"filename": safe_name, "path": agent_path, "size": len(data)})
         logger.info("Uploaded %s (%d bytes) for user %s", dest_path, len(data), owner_id)

--- a/apps/backend/routers/workspace_files.py
+++ b/apps/backend/routers/workspace_files.py
@@ -36,6 +36,28 @@ def _validate_relative_path(path: str) -> None:
         raise ValueError("path must not contain '..' segments")
 
 
+def _ensure_within_subtree(workspace, owner_id: str, full_path: str, subtree: str) -> None:
+    """Resolve full_path (following symlinks) and verify it remains within
+    {user_root}/{subtree}.
+
+    This blocks symlink-based escapes that would otherwise pass
+    `Workspace._resolve_user_file`, which only pins writes to the user root.
+
+    Raises:
+        ValueError: if the resolved target escapes the subtree.
+    """
+    user_root = workspace.user_path(owner_id).resolve()
+    subtree_root = (user_root / subtree).resolve()
+    # strict=False lets us resolve paths whose leaf doesn't exist yet (the file
+    # being created). Intermediate symlinks in the parent chain are still
+    # resolved.
+    target = (user_root / full_path).resolve(strict=False)
+    try:
+        target.relative_to(subtree_root)
+    except ValueError:
+        raise ValueError(f"path escapes agent subtree: {full_path!r}")
+
+
 def _agent_workspace_path(owner_id: str, agent_id: str) -> str:
     """Build the relative path to an agent's workspace within the user dir."""
     if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
@@ -232,11 +254,14 @@ def _write_file(workspace, owner_id: str, agent_id: str, path: str, content: str
     if tab == "config":
         if path not in CONFIG_ALLOWLIST:
             raise ValueError(f"File not in allowlist: {path}")
-        full_path = f"agents/{agent_id}/{path}"
+        subtree = f"agents/{agent_id}"
     elif tab == "workspace":
-        full_path = f"workspaces/{agent_id}/{path}"
+        subtree = f"workspaces/{agent_id}"
     else:
         raise ValueError(f"Invalid tab: {tab!r}")
+
+    full_path = f"{subtree}/{path}"
+    _ensure_within_subtree(workspace, owner_id, full_path, subtree)
 
     workspace.write_file(owner_id, full_path, content)
     return full_path

--- a/apps/backend/routers/workspace_files.py
+++ b/apps/backend/routers/workspace_files.py
@@ -34,6 +34,35 @@ def _collect_recursive(workspace, owner_id: str, path: str, entries: list, max_d
             _collect_recursive(workspace, owner_id, item["path"], entries, max_depth - 1)
 
 
+CONFIG_ALLOWLIST: set[str] = {
+    "SOUL.md", "MEMORY.md", "TOOLS.md", "IDENTITY.md",
+    "USER.md", "HEARTBEAT.md", "BOOTSTRAP.md", "AGENTS.md",
+}
+
+
+def _list_config_files(workspace, owner_id: str, agent_id: str) -> list[dict]:
+    """List only allowlisted config files from agents/{agent_id}/."""
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        return []
+    user_root = workspace.user_path(owner_id)
+    agent_dir = user_root / "agents" / agent_id
+    if not agent_dir.exists() or not agent_dir.is_dir():
+        return []
+    results = []
+    for name in sorted(CONFIG_ALLOWLIST):
+        fpath = agent_dir / name
+        if fpath.exists() and fpath.is_file():
+            stat = fpath.stat()
+            results.append({
+                "name": name,
+                "path": name,
+                "type": "file",
+                "size": stat.st_size,
+                "modified_at": stat.st_mtime,
+            })
+    return results
+
+
 @router.get("/workspace/{agent_id}/tree")
 async def list_workspace_tree(
     agent_id: str,
@@ -87,4 +116,40 @@ async def read_workspace_file(
             raise HTTPException(status_code=403, detail="Access denied")
         raise HTTPException(status_code=500, detail=str(exc))
 
+    return info
+
+
+@router.get("/workspace/{agent_id}/config-files")
+async def list_config_files(
+    agent_id: str,
+    auth: AuthContext = Depends(get_current_user),
+):
+    """List allowlisted agent config files (SOUL.md, MEMORY.md, etc.)."""
+    owner_id = resolve_owner_id(auth)
+    workspace = get_workspace()
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
+    return {"files": _list_config_files(workspace, owner_id, agent_id)}
+
+
+@router.get("/workspace/{agent_id}/config-file")
+async def read_config_file(
+    agent_id: str,
+    path: str = Query(..., description="Config filename (must be allowlisted)"),
+    auth: AuthContext = Depends(get_current_user),
+):
+    """Read a single allowlisted agent config file."""
+    owner_id = resolve_owner_id(auth)
+    if path not in CONFIG_ALLOWLIST:
+        raise HTTPException(status_code=400, detail=f"File not in allowlist: {path}")
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
+    workspace = get_workspace()
+    full_path = f"agents/{agent_id}/{path}"
+    try:
+        info = workspace.read_file_info(owner_id, full_path)
+    except WorkspaceError as exc:
+        if "not found" in str(exc).lower():
+            raise HTTPException(status_code=404, detail=str(exc))
+        raise HTTPException(status_code=500, detail=str(exc))
     return info

--- a/apps/backend/routers/workspace_files.py
+++ b/apps/backend/routers/workspace_files.py
@@ -51,6 +51,30 @@ def _collect_recursive(workspace, owner_id: str, path: str, entries: list, max_d
             _collect_recursive(workspace, owner_id, item["path"], entries, max_depth - 1)
 
 
+def _strip_agent_prefix(entries: list[dict], agent_id: str) -> list[dict]:
+    """Rewrite entry paths from user-root-relative to agent-workspace-relative.
+
+    Input paths look like `workspaces/{agent_id}/foo/bar.md`. Output paths
+    strip the `workspaces/{agent_id}/` prefix so they match the contract
+    expected by the read/write endpoints.
+    """
+    prefix = f"workspaces/{agent_id}/"
+    out = []
+    for entry in entries:
+        p = entry["path"]
+        if p == f"workspaces/{agent_id}":
+            # The agent root itself — present when the workspace dir is listed at depth 0.
+            new_path = ""
+        elif p.startswith(prefix):
+            new_path = p[len(prefix) :]
+        else:
+            # Shouldn't happen — log and keep as-is.
+            logger.warning("Unexpected workspace path %r for agent %s", p, agent_id)
+            new_path = p
+        out.append({**entry, "path": new_path})
+    return out
+
+
 CONFIG_ALLOWLIST: set[str] = {
     "SOUL.md",
     "MEMORY.md",
@@ -107,7 +131,7 @@ async def list_workspace_tree(
     if recursive:
         all_entries: list = []
         _collect_recursive(workspace, owner_id, full_path, all_entries)
-        return {"files": all_entries}
+        return {"files": _strip_agent_prefix(all_entries, agent_id)}
     else:
         try:
             entries = workspace.list_directory(owner_id, full_path)
@@ -118,7 +142,7 @@ async def list_workspace_tree(
                 raise HTTPException(status_code=403, detail="Access denied")
             raise HTTPException(status_code=500, detail=str(exc))
 
-        return {"files": entries}
+        return {"files": _strip_agent_prefix(entries, agent_id)}
 
 
 @router.get("/workspace/{agent_id}/file")

--- a/apps/backend/routers/workspace_files.py
+++ b/apps/backend/routers/workspace_files.py
@@ -1,6 +1,7 @@
 """REST endpoints for browsing agent workspace files on EFS."""
 
 import logging
+from pathlib import PurePosixPath
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -12,6 +13,21 @@ from core.containers.workspace import WorkspaceError
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _validate_relative_path(path: str) -> None:
+    """Reject empty paths, absolute paths, and any segment equal to '..'.
+
+    Raises ValueError with a message suitable for surfacing as a 400 detail.
+    """
+    if not path or path.startswith(("/", "\\")):
+        raise ValueError("path must be a non-empty relative path")
+    parts = PurePosixPath(path).parts
+    if any(part in ("..", "") for part in parts):
+        raise ValueError("path must not contain '..' segments")
+    # Also reject backslash-separated traversal on Windows-style paths
+    if ".." in path.replace("\\", "/").split("/"):
+        raise ValueError("path must not contain '..' segments")
 
 
 def _agent_workspace_path(owner_id: str, agent_id: str) -> str:
@@ -45,6 +61,8 @@ CONFIG_ALLOWLIST: set[str] = {
     "BOOTSTRAP.md",
     "AGENTS.md",
 }
+
+MAX_WRITE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 def _list_config_files(workspace, owner_id: str, agent_id: str) -> list[dict]:
@@ -172,8 +190,14 @@ class WriteFileRequest(BaseModel):
 
 def _write_file(workspace, owner_id: str, agent_id: str, path: str, content: str, tab: str) -> str:
     """Write a file to workspace or config directory. Returns the written path."""
+    encoded = content.encode("utf-8")
+    if len(encoded) > MAX_WRITE_SIZE:
+        raise ValueError(f"content exceeds {MAX_WRITE_SIZE // (1024 * 1024)}MB limit")
+
     if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
         raise ValueError(f"Invalid agent_id: {agent_id!r}")
+
+    _validate_relative_path(path)
 
     if tab == "config":
         if path not in CONFIG_ALLOWLIST:
@@ -207,6 +231,8 @@ async def write_workspace_file(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     except WorkspaceError as exc:
+        if "traversal" in str(exc).lower():
+            raise HTTPException(status_code=403, detail="Access denied")
         raise HTTPException(status_code=500, detail=str(exc))
 
     logger.info("Wrote %s for user %s (tab=%s)", written_path, owner_id, body.tab)

--- a/apps/backend/routers/workspace_files.py
+++ b/apps/backend/routers/workspace_files.py
@@ -16,17 +16,23 @@ router = APIRouter()
 
 
 def _validate_relative_path(path: str) -> None:
-    """Reject empty paths, absolute paths, and any segment equal to '..'.
+    """Reject empty paths, absolute paths, dot-only paths, and any segment equal to '..'.
 
     Raises ValueError with a message suitable for surfacing as a 400 detail.
     """
     if not path or path.startswith(("/", "\\")):
         raise ValueError("path must be a non-empty relative path")
+
+    normalized = path.replace("\\", "/")
+    # Reject dot-only paths: '.', './', './.', etc. collapse to empty parts.
+    segments = [s for s in normalized.split("/") if s != ""]
+    if not segments or all(s == "." for s in segments):
+        raise ValueError("path must not be a dot-only path")
+    if any(s == ".." for s in segments):
+        raise ValueError("path must not contain '..' segments")
+    # Existing PurePosixPath-based checks are still useful as belt-and-suspenders
     parts = PurePosixPath(path).parts
     if any(part in ("..", "") for part in parts):
-        raise ValueError("path must not contain '..' segments")
-    # Also reject backslash-separated traversal on Windows-style paths
-    if ".." in path.replace("\\", "/").split("/"):
         raise ValueError("path must not contain '..' segments")
 
 

--- a/apps/backend/routers/workspace_files.py
+++ b/apps/backend/routers/workspace_files.py
@@ -3,6 +3,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 
 from core.auth import AuthContext, get_current_user, resolve_owner_id
 from core.containers import get_workspace
@@ -35,8 +36,14 @@ def _collect_recursive(workspace, owner_id: str, path: str, entries: list, max_d
 
 
 CONFIG_ALLOWLIST: set[str] = {
-    "SOUL.md", "MEMORY.md", "TOOLS.md", "IDENTITY.md",
-    "USER.md", "HEARTBEAT.md", "BOOTSTRAP.md", "AGENTS.md",
+    "SOUL.md",
+    "MEMORY.md",
+    "TOOLS.md",
+    "IDENTITY.md",
+    "USER.md",
+    "HEARTBEAT.md",
+    "BOOTSTRAP.md",
+    "AGENTS.md",
 }
 
 
@@ -53,13 +60,15 @@ def _list_config_files(workspace, owner_id: str, agent_id: str) -> list[dict]:
         fpath = agent_dir / name
         if fpath.exists() and fpath.is_file():
             stat = fpath.stat()
-            results.append({
-                "name": name,
-                "path": name,
-                "type": "file",
-                "size": stat.st_size,
-                "modified_at": stat.st_mtime,
-            })
+            results.append(
+                {
+                    "name": name,
+                    "path": name,
+                    "type": "file",
+                    "size": stat.st_size,
+                    "modified_at": stat.st_mtime,
+                }
+            )
     return results
 
 
@@ -153,3 +162,52 @@ async def read_config_file(
             raise HTTPException(status_code=404, detail=str(exc))
         raise HTTPException(status_code=500, detail=str(exc))
     return info
+
+
+class WriteFileRequest(BaseModel):
+    path: str
+    content: str
+    tab: str  # "workspace" or "config"
+
+
+def _write_file(workspace, owner_id: str, agent_id: str, path: str, content: str, tab: str) -> str:
+    """Write a file to workspace or config directory. Returns the written path."""
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise ValueError(f"Invalid agent_id: {agent_id!r}")
+
+    if tab == "config":
+        if path not in CONFIG_ALLOWLIST:
+            raise ValueError(f"File not in allowlist: {path}")
+        full_path = f"agents/{agent_id}/{path}"
+    elif tab == "workspace":
+        full_path = f"workspaces/{agent_id}/{path}"
+    else:
+        raise ValueError(f"Invalid tab: {tab!r}")
+
+    workspace.write_file(owner_id, full_path, content)
+    return full_path
+
+
+@router.put("/workspace/{agent_id}/file")
+async def write_workspace_file(
+    agent_id: str,
+    body: WriteFileRequest,
+    auth: AuthContext = Depends(get_current_user),
+):
+    """Write a file to the agent's workspace or config directory."""
+    owner_id = resolve_owner_id(auth)
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
+    if body.tab not in ("workspace", "config"):
+        raise HTTPException(status_code=400, detail="tab must be 'workspace' or 'config'")
+
+    workspace = get_workspace()
+    try:
+        written_path = _write_file(workspace, owner_id, agent_id, body.path, body.content, body.tab)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except WorkspaceError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    logger.info("Wrote %s for user %s (tab=%s)", written_path, owner_id, body.tab)
+    return {"status": "ok", "path": written_path}

--- a/apps/backend/tests/test_workspace_files.py
+++ b/apps/backend/tests/test_workspace_files.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import HTTPException
 
 from core.auth import AuthContext
+from core.config import settings
 from core.containers.workspace import Workspace, WorkspaceError
 
 USER_ID = "user_test_abc"
@@ -58,6 +59,12 @@ def _minimal_png() -> bytes:
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _local_environment(monkeypatch):
+    """Force ENVIRONMENT=local so os.chown is skipped on macOS during tests."""
+    monkeypatch.setattr(settings, "ENVIRONMENT", "local")
 
 
 @pytest.fixture()
@@ -334,6 +341,7 @@ class TestConfigFilesEndpoint:
         (agent_dir / "secret.json").write_text("{}", encoding="utf-8")  # not allowlisted
 
         from routers.workspace_files import _list_config_files
+
         result = _list_config_files(ws, USER_ID, AGENT_ID)
         names = {f["name"] for f in result}
         assert names == {"SOUL.md", "MEMORY.md"}
@@ -344,6 +352,7 @@ class TestConfigFilesEndpoint:
         ws = _make_workspace(tmp_path)
         (tmp_path / USER_ID).mkdir(parents=True)
         from routers.workspace_files import _list_config_files
+
         result = _list_config_files(ws, USER_ID, AGENT_ID)
         assert result == []
 
@@ -354,6 +363,7 @@ class TestConfigFilesEndpoint:
         agent_dir.mkdir(parents=True)
         (agent_dir / "BOOTSTRAP.md").write_text("# Bootstrap", encoding="utf-8")
         from routers.workspace_files import _list_config_files
+
         result = _list_config_files(ws, USER_ID, AGENT_ID)
         assert len(result) == 1
         entry = result[0]
@@ -420,4 +430,96 @@ class TestConfigFileReadEndpoint:
         workspace.ensure_user_dir(USER_ID)
         with pytest.raises(HTTPException) as exc:
             await list_config_files(agent_id="../../other", auth=_auth())
+        assert exc.value.status_code == 400
+
+
+# ===========================================================================
+# TestWriteFileEndpoint
+# ===========================================================================
+
+
+class TestWriteFileEndpoint:
+    """Tests for the _write_file helper used by the PUT endpoint."""
+
+    def test_write_workspace_file(self, tmp_path):
+        """Writing a workspace file creates it on disk."""
+        ws = _make_workspace(tmp_path)
+        user_root = tmp_path / USER_ID
+        user_root.mkdir(parents=True)
+        ws_dir = user_root / "workspaces" / AGENT_ID
+        ws_dir.mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        _write_file(ws, USER_ID, AGENT_ID, "plan.md", "# My Plan", "workspace")
+        assert (ws_dir / "plan.md").read_text() == "# My Plan"
+
+    def test_write_config_file_allowlisted(self, tmp_path):
+        """Writing an allowlisted config file succeeds."""
+        ws = _make_workspace(tmp_path)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        _write_file(ws, USER_ID, AGENT_ID, "SOUL.md", "I am kind", "config")
+        assert (agent_dir / "SOUL.md").read_text() == "I am kind"
+
+    def test_write_config_file_not_allowlisted_raises(self, tmp_path):
+        """Writing a non-allowlisted config file raises ValueError."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        with pytest.raises(ValueError, match="not in allowlist"):
+            _write_file(ws, USER_ID, AGENT_ID, "secret.json", "{}", "config")
+
+    def test_write_creates_parent_dirs(self, tmp_path):
+        """Writing to a nested path creates intermediate directories."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        _write_file(ws, USER_ID, AGENT_ID, "deep/nested/file.txt", "hello", "workspace")
+        assert (tmp_path / USER_ID / "workspaces" / AGENT_ID / "deep" / "nested" / "file.txt").read_text() == "hello"
+
+    @pytest.mark.asyncio
+    async def test_endpoint_rejects_traversal_in_agent_id(self, workspace, monkeypatch):
+        """PUT endpoint returns 400 for traversal in agent_id."""
+        from fastapi import HTTPException
+        from routers.workspace_files import WriteFileRequest, write_workspace_file
+
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        workspace.ensure_user_dir(USER_ID)
+        body = WriteFileRequest(path="plan.md", content="x", tab="workspace")
+        with pytest.raises(HTTPException) as exc:
+            await write_workspace_file(agent_id="../other", body=body, auth=_auth())
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_endpoint_rejects_invalid_tab(self, workspace, monkeypatch):
+        """PUT endpoint returns 400 for a tab value that is neither workspace nor config."""
+        from fastapi import HTTPException
+        from routers.workspace_files import WriteFileRequest, write_workspace_file
+
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        workspace.ensure_user_dir(USER_ID)
+        body = WriteFileRequest(path="plan.md", content="x", tab="bogus")
+        with pytest.raises(HTTPException) as exc:
+            await write_workspace_file(agent_id=AGENT_ID, body=body, auth=_auth())
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_endpoint_rejects_non_allowlisted_config_filename(self, workspace, monkeypatch):
+        """PUT endpoint returns 400 when writing a non-allowlisted config file."""
+        from fastapi import HTTPException
+        from routers.workspace_files import WriteFileRequest, write_workspace_file
+
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        workspace.ensure_user_dir(USER_ID)
+        body = WriteFileRequest(path="secret.json", content="{}", tab="config")
+        with pytest.raises(HTTPException) as exc:
+            await write_workspace_file(agent_id=AGENT_ID, body=body, auth=_auth())
         assert exc.value.status_code == 400

--- a/apps/backend/tests/test_workspace_files.py
+++ b/apps/backend/tests/test_workspace_files.py
@@ -615,3 +615,78 @@ class TestUploadPath:
         dest_path = f"workspaces/{agent_id}/uploads/{filename}"
         agent_path = f".openclaw/{dest_path}"
         assert agent_path == f".openclaw/workspaces/{agent_id}/uploads/{filename}"
+
+
+# ===========================================================================
+# TestWorkspaceTreeRoundTrip
+# ===========================================================================
+
+
+class TestWorkspaceTreeRoundTrip:
+    """Verify list → read uses the same agent-relative path contract."""
+
+    @pytest.mark.asyncio
+    async def test_tree_path_feeds_back_to_read(self, workspace, monkeypatch):
+        """A path returned by the tree endpoint reads successfully via the file endpoint."""
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        ws_dir = workspace._mount / USER_ID / "workspaces" / AGENT_ID
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "plan.md").write_text("# Plan\nstep 1", encoding="utf-8")
+        (ws_dir / "uploads").mkdir()
+        (ws_dir / "uploads" / "data.csv").write_text("a,b\n1,2", encoding="utf-8")
+
+        from routers.workspace_files import list_workspace_tree, read_workspace_file
+
+        tree = await list_workspace_tree(
+            agent_id=AGENT_ID,
+            path="",
+            recursive=True,
+            auth=_auth(),
+        )
+        paths = {f["path"] for f in tree["files"]}
+        # Paths must be agent-relative (no `workspaces/{agent_id}/` prefix)
+        assert "plan.md" in paths
+        assert "uploads" in paths
+        assert "uploads/data.csv" in paths
+        assert not any(p.startswith("workspaces/") for p in paths if p)
+
+        # Every file path should read successfully via the file endpoint
+        for entry in tree["files"]:
+            if entry["type"] == "file":
+                info = await read_workspace_file(
+                    agent_id=AGENT_ID,
+                    path=entry["path"],
+                    auth=_auth(),
+                )
+                assert info["name"] == entry["name"]
+                assert info["size"] == entry["size"]
+
+    @pytest.mark.asyncio
+    async def test_write_then_tree_then_read(self, workspace, monkeypatch):
+        """After saveWorkspaceFile writes a workspace file, tree lists it and read returns content."""
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        (workspace._mount / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import (
+            WriteFileRequest,
+            list_workspace_tree,
+            read_workspace_file,
+            write_workspace_file,
+        )
+
+        body = WriteFileRequest(path="notes.txt", content="hello world", tab="workspace")
+        result = await write_workspace_file(agent_id=AGENT_ID, body=body, auth=_auth())
+        assert result["status"] == "ok"
+        # Backend returned path is user-root-relative; tree will show agent-relative
+        assert result["path"] == f"workspaces/{AGENT_ID}/notes.txt"
+
+        tree = await list_workspace_tree(
+            agent_id=AGENT_ID,
+            path="",
+            recursive=True,
+            auth=_auth(),
+        )
+        assert any(f["path"] == "notes.txt" and f["type"] == "file" for f in tree["files"])
+
+        info = await read_workspace_file(agent_id=AGENT_ID, path="notes.txt", auth=_auth())
+        assert info["content"] == "hello world"

--- a/apps/backend/tests/test_workspace_files.py
+++ b/apps/backend/tests/test_workspace_files.py
@@ -4,19 +4,21 @@ import base64
 import struct
 import zlib
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
+from fastapi import HTTPException
 
+from core.auth import AuthContext
 from core.containers.workspace import Workspace, WorkspaceError
 
 USER_ID = "user_test_abc"
 AGENT_ID = "agent-abc-123"
-ALLOWLISTED_FILES = [
-    "SOUL.md", "MEMORY.md", "TOOLS.md", "IDENTITY.md",
-    "USER.md", "HEARTBEAT.md", "BOOTSTRAP.md", "AGENTS.md",
-]
+
+
+def _auth(owner_id: str = USER_ID) -> AuthContext:
+    """Build a minimal AuthContext for direct handler calls (personal mode)."""
+    return AuthContext(user_id=owner_id)
 
 
 # ---------------------------------------------------------------------------
@@ -375,7 +377,47 @@ class TestConfigFileReadEndpoint:
         assert info["content"] == "I am helpful"
         assert info["binary"] is False
 
-    def test_rejects_non_allowlisted_filename(self, tmp_path):
-        """Non-allowlisted filenames are rejected."""
-        from routers.workspace_files import CONFIG_ALLOWLIST
-        assert "secret.json" not in CONFIG_ALLOWLIST
+    @pytest.mark.asyncio
+    async def test_read_rejects_non_allowlisted_path(self, workspace, monkeypatch):
+        """read_config_file returns 400 for a path not in the allowlist."""
+        from routers.workspace_files import read_config_file
+
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        workspace.ensure_user_dir(USER_ID)
+        with pytest.raises(HTTPException) as exc:
+            await read_config_file(agent_id=AGENT_ID, path="secret.json", auth=_auth())
+        assert exc.value.status_code == 400
+        assert "allowlist" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_rejects_traversal_in_path(self, workspace, monkeypatch):
+        """read_config_file rejects a path with traversal sequences."""
+        from routers.workspace_files import read_config_file
+
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        workspace.ensure_user_dir(USER_ID)
+        with pytest.raises(HTTPException) as exc:
+            await read_config_file(agent_id=AGENT_ID, path="../../etc/passwd", auth=_auth())
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_read_rejects_traversal_in_agent_id(self, workspace, monkeypatch):
+        """read_config_file rejects a traversal sequence in agent_id."""
+        from routers.workspace_files import read_config_file
+
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        workspace.ensure_user_dir(USER_ID)
+        with pytest.raises(HTTPException) as exc:
+            await read_config_file(agent_id="../other", path="SOUL.md", auth=_auth())
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_list_rejects_traversal_in_agent_id(self, workspace, monkeypatch):
+        """list_config_files returns 400 for an agent_id containing '..'."""
+        from routers.workspace_files import list_config_files
+
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        workspace.ensure_user_dir(USER_ID)
+        with pytest.raises(HTTPException) as exc:
+            await list_config_files(agent_id="../../other", auth=_auth())
+        assert exc.value.status_code == 400

--- a/apps/backend/tests/test_workspace_files.py
+++ b/apps/backend/tests/test_workspace_files.py
@@ -588,3 +588,30 @@ class TestWriteFileEndpoint:
         with pytest.raises(HTTPException) as exc:
             await write_workspace_file(agent_id=AGENT_ID, body=body, auth=_auth())
         assert exc.value.status_code == 400
+
+
+# ===========================================================================
+# TestUploadPath
+# ===========================================================================
+
+
+class TestUploadPath:
+    """Verify upload destination path construction."""
+
+    def test_upload_writes_to_agent_workspace(self, tmp_path):
+        """Uploads should go to workspaces/{agent_id}/uploads/."""
+        ws = _make_workspace(tmp_path)
+        ws_dir = tmp_path / USER_ID / "workspaces" / AGENT_ID / "uploads"
+        (tmp_path / USER_ID).mkdir(parents=True)
+
+        dest_path = f"workspaces/{AGENT_ID}/uploads/test.pdf"
+        ws.write_bytes(USER_ID, dest_path, b"fake pdf content")
+        assert (ws_dir / "test.pdf").read_bytes() == b"fake pdf content"
+
+    def test_agent_visible_path(self):
+        """Agent-visible path should include workspaces/{agent_id}."""
+        agent_id = "my-agent"
+        filename = "data.csv"
+        dest_path = f"workspaces/{agent_id}/uploads/{filename}"
+        agent_path = f".openclaw/{dest_path}"
+        assert agent_path == f".openclaw/workspaces/{agent_id}/uploads/{filename}"

--- a/apps/backend/tests/test_workspace_files.py
+++ b/apps/backend/tests/test_workspace_files.py
@@ -523,3 +523,68 @@ class TestWriteFileEndpoint:
         with pytest.raises(HTTPException) as exc:
             await write_workspace_file(agent_id=AGENT_ID, body=body, auth=_auth())
         assert exc.value.status_code == 400
+
+    def test_write_rejects_traversal_in_path(self, tmp_path):
+        """`..` in path raises ValueError (regression for allowlist bypass)."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        with pytest.raises(ValueError, match=r"\.\."):
+            _write_file(
+                ws,
+                USER_ID,
+                AGENT_ID,
+                "../../agents/" + AGENT_ID + "/SOUL.md",
+                "hacked",
+                "workspace",
+            )
+
+    def test_write_rejects_absolute_path(self, tmp_path):
+        """Absolute paths are rejected."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        with pytest.raises(ValueError, match="relative"):
+            _write_file(ws, USER_ID, AGENT_ID, "/etc/passwd", "x", "workspace")
+
+    def test_write_rejects_empty_path(self, tmp_path):
+        """Empty path is rejected."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        with pytest.raises(ValueError):
+            _write_file(ws, USER_ID, AGENT_ID, "", "x", "workspace")
+
+    def test_write_rejects_oversized_content(self, tmp_path):
+        """Content over 10MB is rejected."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        big = "a" * (10 * 1024 * 1024 + 1)
+        with pytest.raises(ValueError, match="10MB"):
+            _write_file(ws, USER_ID, AGENT_ID, "big.txt", big, "workspace")
+
+    @pytest.mark.asyncio
+    async def test_endpoint_rejects_traversal_in_path(self, workspace, monkeypatch):
+        """PUT endpoint returns 400 for `..` in body.path (regression test)."""
+        from fastapi import HTTPException
+        from routers.workspace_files import WriteFileRequest, write_workspace_file
+
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        workspace.ensure_user_dir(USER_ID)
+        body = WriteFileRequest(
+            path=f"../../agents/{AGENT_ID}/SOUL.md",
+            content="hacked",
+            tab="workspace",
+        )
+        with pytest.raises(HTTPException) as exc:
+            await write_workspace_file(agent_id=AGENT_ID, body=body, auth=_auth())
+        assert exc.value.status_code == 400

--- a/apps/backend/tests/test_workspace_files.py
+++ b/apps/backend/tests/test_workspace_files.py
@@ -561,6 +561,17 @@ class TestWriteFileEndpoint:
         with pytest.raises(ValueError):
             _write_file(ws, USER_ID, AGENT_ID, "", "x", "workspace")
 
+    def test_write_rejects_dot_only_path(self, tmp_path):
+        """Dot-only paths (., ./, .) are rejected with ValueError."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        for bad in [".", "./", "./.", "././"]:
+            with pytest.raises(ValueError, match=r"dot-only"):
+                _write_file(ws, USER_ID, AGENT_ID, bad, "x", "workspace")
+
     def test_write_rejects_oversized_content(self, tmp_path):
         """Content over 10MB is rejected."""
         ws = _make_workspace(tmp_path)

--- a/apps/backend/tests/test_workspace_files.py
+++ b/apps/backend/tests/test_workspace_files.py
@@ -4,13 +4,19 @@ import base64
 import struct
 import zlib
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi.testclient import TestClient
 
 from core.containers.workspace import Workspace, WorkspaceError
 
 USER_ID = "user_test_abc"
+AGENT_ID = "agent-abc-123"
+ALLOWLISTED_FILES = [
+    "SOUL.md", "MEMORY.md", "TOOLS.md", "IDENTITY.md",
+    "USER.md", "HEARTBEAT.md", "BOOTSTRAP.md", "AGENTS.md",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -305,3 +311,71 @@ class TestReadFileInfo:
         ws, _ = populated_workspace
         info = ws.read_file_info(USER_ID, "image.png")
         assert info["mime_type"] == "image/png"
+
+
+# ===========================================================================
+# TestConfigFilesEndpoint / TestConfigFileReadEndpoint
+# ===========================================================================
+
+
+class TestConfigFilesEndpoint:
+    """Tests for GET /workspace/{agent_id}/config-files."""
+
+    def test_returns_only_allowlisted_files(self, tmp_path):
+        """Only allowlisted files that exist on disk are returned."""
+        ws = _make_workspace(tmp_path)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "SOUL.md").write_text("I am helpful", encoding="utf-8")
+        (agent_dir / "MEMORY.md").write_text("Remember this", encoding="utf-8")
+        (agent_dir / "sessions").mkdir()  # should be excluded
+        (agent_dir / "secret.json").write_text("{}", encoding="utf-8")  # not allowlisted
+
+        from routers.workspace_files import _list_config_files
+        result = _list_config_files(ws, USER_ID, AGENT_ID)
+        names = {f["name"] for f in result}
+        assert names == {"SOUL.md", "MEMORY.md"}
+        assert all(f["type"] == "file" for f in result)
+
+    def test_empty_when_no_agent_dir(self, tmp_path):
+        """Returns empty list when agent dir doesn't exist."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID).mkdir(parents=True)
+        from routers.workspace_files import _list_config_files
+        result = _list_config_files(ws, USER_ID, AGENT_ID)
+        assert result == []
+
+    def test_file_entries_have_required_fields(self, tmp_path):
+        """Each entry has name, path, type, size, modified_at."""
+        ws = _make_workspace(tmp_path)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "BOOTSTRAP.md").write_text("# Bootstrap", encoding="utf-8")
+        from routers.workspace_files import _list_config_files
+        result = _list_config_files(ws, USER_ID, AGENT_ID)
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["name"] == "BOOTSTRAP.md"
+        assert entry["path"] == "BOOTSTRAP.md"
+        assert entry["type"] == "file"
+        assert isinstance(entry["size"], int)
+        assert isinstance(entry["modified_at"], float)
+
+
+class TestConfigFileReadEndpoint:
+    """Tests for GET /workspace/{agent_id}/config-file."""
+
+    def test_reads_allowlisted_file(self, tmp_path):
+        """Can read an allowlisted config file."""
+        ws = _make_workspace(tmp_path)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "SOUL.md").write_text("I am helpful", encoding="utf-8")
+        info = ws.read_file_info(USER_ID, f"agents/{AGENT_ID}/SOUL.md")
+        assert info["content"] == "I am helpful"
+        assert info["binary"] is False
+
+    def test_rejects_non_allowlisted_filename(self, tmp_path):
+        """Non-allowlisted filenames are rejected."""
+        from routers.workspace_files import CONFIG_ALLOWLIST
+        assert "secret.json" not in CONFIG_ALLOWLIST

--- a/apps/backend/tests/test_workspace_files.py
+++ b/apps/backend/tests/test_workspace_files.py
@@ -600,6 +600,62 @@ class TestWriteFileEndpoint:
             await write_workspace_file(agent_id=AGENT_ID, body=body, auth=_auth())
         assert exc.value.status_code == 400
 
+    def test_write_rejects_symlink_escape_workspace(self, tmp_path):
+        """Symlink in workspaces/{id}/ pointing outside must be rejected."""
+        import os
+
+        ws = _make_workspace(tmp_path)
+        ws_dir = tmp_path / USER_ID / "workspaces" / AGENT_ID
+        ws_dir.mkdir(parents=True)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "SOUL.md").write_text("original", encoding="utf-8")
+
+        # Symlink workspaces/{id}/evil -> ../../agents/{id}/SOUL.md
+        os.symlink(
+            "../../agents/" + AGENT_ID + "/SOUL.md",
+            ws_dir / "evil",
+        )
+
+        from routers.workspace_files import _write_file
+
+        with pytest.raises(ValueError, match="escapes"):
+            _write_file(ws, USER_ID, AGENT_ID, "evil", "hacked", "workspace")
+
+        # SOUL.md must be untouched
+        assert (agent_dir / "SOUL.md").read_text() == "original"
+
+    def test_write_rejects_symlink_escape_config(self, tmp_path):
+        """Symlink in agents/{id}/ pointing outside must be rejected."""
+        import os
+
+        ws = _make_workspace(tmp_path)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+        target = tmp_path / USER_ID / "elsewhere.txt"
+        target.write_text("original", encoding="utf-8")
+
+        # Symlink agents/{id}/SOUL.md -> ../../elsewhere.txt
+        os.symlink("../../elsewhere.txt", agent_dir / "SOUL.md")
+
+        from routers.workspace_files import _write_file
+
+        with pytest.raises(ValueError, match="escapes"):
+            _write_file(ws, USER_ID, AGENT_ID, "SOUL.md", "hacked", "config")
+
+        assert target.read_text() == "original"
+
+    def test_write_allows_nested_dirs_within_workspace(self, tmp_path):
+        """Subtree check allows legitimate nested paths inside the workspace."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+
+        written = _write_file(ws, USER_ID, AGENT_ID, "deep/nested/notes.md", "ok", "workspace")
+        assert written == f"workspaces/{AGENT_ID}/deep/nested/notes.md"
+        assert (tmp_path / USER_ID / "workspaces" / AGENT_ID / "deep" / "nested" / "notes.md").read_text() == "ok"
+
 
 # ===========================================================================
 # TestUploadPath

--- a/apps/backend/tests/unit/routers/test_file_upload.py
+++ b/apps/backend/tests/unit/routers/test_file_upload.py
@@ -165,3 +165,36 @@ async def test_upload_sanitizes_filename(app, auth_override, mock_container, moc
             assert "/" not in body["uploaded"][0]["filename"]
     finally:
         app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.mark.asyncio
+async def test_upload_missing_agent_id_returns_422(app, auth_override):
+    """Upload without agent_id query param fails FastAPI validation with 422."""
+    app.dependency_overrides[get_current_user] = auth_override
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/container/files",
+                files=[("files", ("test.txt", b"hi", "text/plain"))],
+            )
+
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.mark.asyncio
+async def test_upload_traversal_agent_id_returns_400(app, auth_override):
+    """Upload with agent_id containing a traversal sequence is rejected with 400."""
+    app.dependency_overrides[get_current_user] = auth_override
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/container/files?agent_id=../other",
+                files=[("files", ("test.txt", b"hi", "text/plain"))],
+            )
+
+        assert resp.status_code == 400
+        assert "Invalid agent_id" in resp.json()["detail"]
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)

--- a/apps/backend/tests/unit/routers/test_file_upload.py
+++ b/apps/backend/tests/unit/routers/test_file_upload.py
@@ -34,6 +34,9 @@ def auth_override():
     return _override
 
 
+AGENT_ID = "agent-xyz"
+
+
 @pytest.mark.asyncio
 async def test_upload_single_file(app, auth_override, mock_container, mock_workspace):
     """Upload a single file writes to workspace."""
@@ -47,7 +50,7 @@ async def test_upload_single_file(app, auth_override, mock_container, mock_works
 
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                 resp = await client.post(
-                    "/api/v1/container/files",
+                    f"/api/v1/container/files?agent_id={AGENT_ID}",
                     files=[("files", ("test.txt", b"hello world", "text/plain"))],
                 )
 
@@ -55,10 +58,12 @@ async def test_upload_single_file(app, auth_override, mock_container, mock_works
             body = resp.json()
             assert len(body["uploaded"]) == 1
             assert body["uploaded"][0]["filename"] == "test.txt"
-            assert body["uploaded"][0]["path"] == ".openclaw/uploads/test.txt"
+            assert body["uploaded"][0]["path"] == f".openclaw/workspaces/{AGENT_ID}/uploads/test.txt"
             assert body["uploaded"][0]["size"] == 11
 
-            mock_workspace.write_bytes.assert_called_once_with("user_123", "uploads/test.txt", b"hello world")
+            mock_workspace.write_bytes.assert_called_once_with(
+                "user_123", f"workspaces/{AGENT_ID}/uploads/test.txt", b"hello world"
+            )
     finally:
         app.dependency_overrides.pop(get_current_user, None)
 
@@ -76,7 +81,7 @@ async def test_upload_multiple_files(app, auth_override, mock_container, mock_wo
 
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                 resp = await client.post(
-                    "/api/v1/container/files",
+                    f"/api/v1/container/files?agent_id={AGENT_ID}",
                     files=[
                         ("files", ("a.txt", b"aaa", "text/plain")),
                         ("files", ("b.csv", b"1,2,3", "text/csv")),
@@ -105,7 +110,7 @@ async def test_upload_rejects_oversized_file(app, auth_override, mock_container,
             big_data = b"x" * (10 * 1024 * 1024 + 1)
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                 resp = await client.post(
-                    "/api/v1/container/files",
+                    f"/api/v1/container/files?agent_id={AGENT_ID}",
                     files=[("files", ("big.bin", big_data, "application/octet-stream"))],
                 )
 
@@ -128,7 +133,7 @@ async def test_upload_no_container(app, auth_override, mock_workspace):
 
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                 resp = await client.post(
-                    "/api/v1/container/files",
+                    f"/api/v1/container/files?agent_id={AGENT_ID}",
                     files=[("files", ("test.txt", b"hello", "text/plain"))],
                 )
 
@@ -150,7 +155,7 @@ async def test_upload_sanitizes_filename(app, auth_override, mock_container, moc
 
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                 resp = await client.post(
-                    "/api/v1/container/files",
+                    f"/api/v1/container/files?agent_id={AGENT_ID}",
                     files=[("files", ("../../etc/passwd", b"nope", "text/plain"))],
                 )
 

--- a/apps/frontend/src/components/chat/AgentChatWindow.tsx
+++ b/apps/frontend/src/components/chat/AgentChatWindow.tsx
@@ -440,7 +440,8 @@ export function AgentChatWindow({
         if (files && files.length > 0) {
           setIsUploading(true);
           try {
-            const result = await api.uploadFiles(files);
+            if (!agentId) throw new Error("No agent selected");
+            const result = await api.uploadFiles(files, agentId);
             const fileList = result.uploaded
               .map((f) => `- ${f.filename} → ${f.path}`)
               .join("\n");
@@ -464,7 +465,7 @@ export function AgentChatWindow({
         console.error("Failed to send message:", err);
       }
     },
-    [sendMessage, api],
+    [sendMessage, api, agentId],
   );
 
   const messages: Message[] = useMemo(

--- a/apps/frontend/src/components/chat/ChatInput.tsx
+++ b/apps/frontend/src/components/chat/ChatInput.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import { SendHorizontal, Paperclip, X, FileIcon, Loader2, Square } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
 interface PendingFile {
   file: File;
   id: string;
@@ -30,7 +32,25 @@ function formatFileSize(bytes: number): string {
 export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isStreaming, suggestedMessage, budgetExceeded }: ChatInputProps) {
   const [input, setInput] = React.useState("");
   const [pendingFiles, setPendingFiles] = React.useState<PendingFile[]>([]);
+  const [sizeError, setSizeError] = React.useState<string | null>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const filterOversizedFiles = React.useCallback((files: File[]): File[] => {
+    const valid: File[] = [];
+    const rejected: string[] = [];
+    for (const file of files) {
+      if (file.size > MAX_FILE_SIZE) {
+        rejected.push(file.name);
+      } else {
+        valid.push(file);
+      }
+    }
+    if (rejected.length > 0) {
+      setSizeError(`${rejected.join(", ")} exceed${rejected.length === 1 ? "s" : ""} the 10MB limit`);
+      setTimeout(() => setSizeError(null), 5000);
+    }
+    return valid;
+  }, []);
 
   const handleSend = () => {
     if (input.trim() || pendingFiles.length > 0) {
@@ -57,7 +77,8 @@ export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isS
     const selected = e.target.files;
     if (!selected) return;
 
-    const newFiles: PendingFile[] = Array.from(selected).map((file) => ({
+    const valid = filterOversizedFiles(Array.from(selected));
+    const newFiles: PendingFile[] = valid.map((file) => ({
       file,
       id: crypto.randomUUID(),
     }));
@@ -76,7 +97,8 @@ export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isS
     const dropped = e.dataTransfer.files;
     if (!dropped.length) return;
 
-    const newFiles: PendingFile[] = Array.from(dropped).map((file) => ({
+    const valid = filterOversizedFiles(Array.from(dropped));
+    const newFiles: PendingFile[] = valid.map((file) => ({
       file,
       id: crypto.randomUUID(),
     }));
@@ -116,6 +138,20 @@ export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isS
                 </button>
               </div>
             ))}
+          </div>
+        )}
+
+        {sizeError && (
+          <div className="flex items-center gap-1.5 mb-2 px-2 py-1.5 bg-red-50 border border-red-200 rounded-lg text-xs text-red-600">
+            <span>{sizeError}</span>
+            <button
+              type="button"
+              onClick={() => setSizeError(null)}
+              className="ml-auto text-red-400 hover:text-red-600"
+              aria-label="Dismiss size error"
+            >
+              <X className="h-3 w-3" />
+            </button>
           </div>
         )}
 

--- a/apps/frontend/src/components/chat/ChatInput.tsx
+++ b/apps/frontend/src/components/chat/ChatInput.tsx
@@ -32,8 +32,40 @@ function formatFileSize(bytes: number): string {
 export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isStreaming, suggestedMessage, budgetExceeded }: ChatInputProps) {
   const [input, setInput] = React.useState("");
   const [pendingFiles, setPendingFiles] = React.useState<PendingFile[]>([]);
-  const [sizeError, setSizeError] = React.useState<string | null>(null);
+  const [sizeError, setSizeError] = React.useState<{ id: number; message: string } | null>(null);
+  const sizeErrorTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sizeErrorIdRef = React.useRef(0);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Clear timer on unmount
+  React.useEffect(() => {
+    return () => {
+      if (sizeErrorTimerRef.current) {
+        clearTimeout(sizeErrorTimerRef.current);
+      }
+    };
+  }, []);
+
+  const showSizeError = React.useCallback((message: string) => {
+    if (sizeErrorTimerRef.current) {
+      clearTimeout(sizeErrorTimerRef.current);
+      sizeErrorTimerRef.current = null;
+    }
+    sizeErrorIdRef.current += 1;
+    setSizeError({ id: sizeErrorIdRef.current, message });
+    sizeErrorTimerRef.current = setTimeout(() => {
+      setSizeError(null);
+      sizeErrorTimerRef.current = null;
+    }, 5000);
+  }, []);
+
+  const dismissSizeError = React.useCallback(() => {
+    if (sizeErrorTimerRef.current) {
+      clearTimeout(sizeErrorTimerRef.current);
+      sizeErrorTimerRef.current = null;
+    }
+    setSizeError(null);
+  }, []);
 
   const filterOversizedFiles = React.useCallback((files: File[]): File[] => {
     const valid: File[] = [];
@@ -46,11 +78,12 @@ export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isS
       }
     }
     if (rejected.length > 0) {
-      setSizeError(`${rejected.join(", ")} exceed${rejected.length === 1 ? "s" : ""} the 10MB limit`);
-      setTimeout(() => setSizeError(null), 5000);
+      showSizeError(
+        `${rejected.join(", ")} exceed${rejected.length === 1 ? "s" : ""} the 10MB limit`,
+      );
     }
     return valid;
-  }, []);
+  }, [showSizeError]);
 
   const handleSend = () => {
     if (input.trim() || pendingFiles.length > 0) {
@@ -143,10 +176,10 @@ export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isS
 
         {sizeError && (
           <div className="flex items-center gap-1.5 mb-2 px-2 py-1.5 bg-red-50 border border-red-200 rounded-lg text-xs text-red-600">
-            <span>{sizeError}</span>
+            <span>{sizeError.message}</span>
             <button
               type="button"
-              onClick={() => setSizeError(null)}
+              onClick={dismissSizeError}
               className="ml-auto text-red-400 hover:text-red-600"
               aria-label="Dismiss size error"
             >

--- a/apps/frontend/src/components/chat/ChatLayout.css
+++ b/apps/frontend/src/components/chat/ChatLayout.css
@@ -1,11 +1,17 @@
 .app-shell {
   display: grid;
   grid-template-columns: 260px 1fr;
+  grid-template-areas: "sidebar main";
   height: 100vh;
   overflow: hidden;
+  transition: grid-template-columns 200ms ease;
 }
 .app-shell.with-file-viewer {
-  grid-template-columns: 260px 1fr 1fr;
+  grid-template-columns: 0px 380px 1fr;
+  grid-template-areas: "sidebar main viewer";
+}
+.file-viewer-panel {
+  grid-area: viewer;
 }
 .cream-sidebar {
   background: #f3efe6;
@@ -13,6 +19,12 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  transition: opacity 150ms ease;
+}
+.app-shell.with-file-viewer .cream-sidebar {
+  opacity: 0;
+  pointer-events: none;
+  border-right: none;
 }
 .sidebar-header {
   display: flex;
@@ -306,9 +318,14 @@
 @media (max-width: 768px) {
   .app-shell {
     grid-template-columns: 1fr;
+    grid-template-areas: "main";
   }
   .app-shell.with-file-viewer {
     grid-template-columns: 1fr;
+    grid-template-areas: "viewer";
+  }
+  .app-shell.with-file-viewer .main-area {
+    display: none;
   }
   .cream-sidebar {
     display: none;

--- a/apps/frontend/src/components/chat/ChatLayout.css
+++ b/apps/frontend/src/components/chat/ChatLayout.css
@@ -1,17 +1,17 @@
 .app-shell {
   display: grid;
-  grid-template-columns: 260px 1fr;
-  grid-template-areas: "sidebar main";
+  grid-template-columns: 260px 1fr 0px;
+  grid-template-areas: "sidebar main viewer";
   height: 100vh;
   overflow: hidden;
   transition: grid-template-columns 200ms ease;
 }
 .app-shell.with-file-viewer {
   grid-template-columns: 0px 380px 1fr;
-  grid-template-areas: "sidebar main viewer";
 }
 .file-viewer-panel {
   grid-area: viewer;
+  min-width: 0;
 }
 .cream-sidebar {
   background: #f3efe6;
@@ -19,12 +19,14 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition: opacity 150ms ease;
+  transition: opacity 150ms ease, visibility 0s linear 0s;
 }
 .app-shell.with-file-viewer .cream-sidebar {
   opacity: 0;
   pointer-events: none;
   border-right: none;
+  visibility: hidden;
+  transition: opacity 150ms ease, visibility 0s linear 150ms;
 }
 .sidebar-header {
   display: flex;
@@ -254,6 +256,7 @@
   background: #faf7f2;
   display: flex;
   flex-direction: column;
+  min-width: 0;
   min-height: 0;
   position: relative;
 }

--- a/apps/frontend/src/components/chat/ChatLayout.tsx
+++ b/apps/frontend/src/components/chat/ChatLayout.tsx
@@ -336,7 +336,7 @@ export function ChatLayout({
           </div>
         </div>
 
-        <div className="main-area">
+        <div className="main-area" style={{ gridArea: "main" }}>
           <div className="main-header">
             <button className="mobile-hamburger" onClick={() => setSidebarOpen(true)} aria-label="Open menu">
               <Menu size={22} />

--- a/apps/frontend/src/components/chat/FileContentViewer.tsx
+++ b/apps/frontend/src/components/chat/FileContentViewer.tsx
@@ -9,9 +9,10 @@ interface FileContentViewerProps {
   isLoading: boolean;
   error: Error | null;
   onSave?: (content: string) => Promise<void>;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
-export function FileContentViewer({ file, isLoading, error, onSave }: FileContentViewerProps) {
+export function FileContentViewer({ file, isLoading, error, onSave, onDirtyChange }: FileContentViewerProps) {
   const [editContent, setEditContent] = React.useState("");
   const [originalContent, setOriginalContent] = React.useState("");
   const [saving, setSaving] = React.useState(false);
@@ -20,34 +21,19 @@ export function FileContentViewer({ file, isLoading, error, onSave }: FileConten
 
   const dirty = editContent !== originalContent;
 
-  // Sync editor content when a new file loads; warn if unsaved changes.
-  // Use a ref to read the latest dirty state without re-subscribing the effect.
-  const dirtyRef = React.useRef(false);
-  dirtyRef.current = editContent !== originalContent;
-
-  const previousPathRef = React.useRef<string | null>(null);
-
+  // Report dirty state to parent so it can guard selection changes
   React.useEffect(() => {
-    if (file?.content == null || file.binary) {
-      previousPathRef.current = file?.path ?? null;
-      return;
-    }
+    onDirtyChange?.(dirty);
+  }, [dirty, onDirtyChange]);
 
-    const samePath = previousPathRef.current === file.path;
-    if (!samePath && dirtyRef.current) {
-      const proceed = window.confirm(
-        "You have unsaved changes. Discard them and load the new file?",
-      );
-      if (!proceed) {
-        // Keep editing the previous file — do not sync.
-        return;
-      }
+  // Sync editor content when a new file loads. Parent is responsible for
+  // prompting the user about unsaved changes BEFORE changing the file prop.
+  React.useEffect(() => {
+    if (file?.content != null && !file.binary) {
+      setEditContent(file.content);
+      setOriginalContent(file.content);
+      setSaveError(null);
     }
-
-    setEditContent(file.content);
-    setOriginalContent(file.content);
-    setSaveError(null);
-    previousPathRef.current = file.path;
   }, [file?.path, file?.content, file?.binary]);
 
   const handleSave = React.useCallback(async () => {

--- a/apps/frontend/src/components/chat/FileContentViewer.tsx
+++ b/apps/frontend/src/components/chat/FileContentViewer.tsx
@@ -20,13 +20,34 @@ export function FileContentViewer({ file, isLoading, error, onSave }: FileConten
 
   const dirty = editContent !== originalContent;
 
-  // Sync editor content when a new file loads
+  // Sync editor content when a new file loads; warn if unsaved changes.
+  // Use a ref to read the latest dirty state without re-subscribing the effect.
+  const dirtyRef = React.useRef(false);
+  dirtyRef.current = editContent !== originalContent;
+
+  const previousPathRef = React.useRef<string | null>(null);
+
   React.useEffect(() => {
-    if (file?.content != null && !file.binary) {
-      setEditContent(file.content);
-      setOriginalContent(file.content);
-      setSaveError(null);
+    if (file?.content == null || file.binary) {
+      previousPathRef.current = file?.path ?? null;
+      return;
     }
+
+    const samePath = previousPathRef.current === file.path;
+    if (!samePath && dirtyRef.current) {
+      const proceed = window.confirm(
+        "You have unsaved changes. Discard them and load the new file?",
+      );
+      if (!proceed) {
+        // Keep editing the previous file — do not sync.
+        return;
+      }
+    }
+
+    setEditContent(file.content);
+    setOriginalContent(file.content);
+    setSaveError(null);
+    previousPathRef.current = file.path;
   }, [file?.path, file?.content, file?.binary]);
 
   const handleSave = React.useCallback(async () => {
@@ -43,13 +64,18 @@ export function FileContentViewer({ file, isLoading, error, onSave }: FileConten
     }
   }, [onSave, editContent, originalContent]);
 
-  // Cmd/Ctrl+S save shortcut — use ref to avoid stale closure
+  // Cmd/Ctrl+S save shortcut — refs avoid stale closure
   const handleSaveRef = React.useRef(handleSave);
   handleSaveRef.current = handleSave;
 
+  const canSaveRef = React.useRef(false);
+  canSaveRef.current = Boolean(
+    onSave && file && !file.binary && file.content != null,
+  );
+
   React.useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s" && canSaveRef.current) {
         e.preventDefault();
         handleSaveRef.current();
       }

--- a/apps/frontend/src/components/chat/FileContentViewer.tsx
+++ b/apps/frontend/src/components/chat/FileContentViewer.tsx
@@ -1,61 +1,63 @@
 "use client";
 
 import * as React from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
-import { Copy, Loader2 } from "lucide-react";
+import { Loader2, Save } from "lucide-react";
 import type { FileInfo } from "@/hooks/useWorkspaceFiles";
-
-const REMARK_PLUGINS = [remarkGfm];
-
-const LANGUAGE_MAP: Record<string, string> = {
-  py: "python", js: "javascript", ts: "typescript", tsx: "tsx", jsx: "jsx",
-  json: "json", yaml: "yaml", yml: "yaml", toml: "toml", sh: "bash",
-  bash: "bash", css: "css", html: "html", xml: "xml", sql: "sql",
-  rs: "rust", go: "go", java: "java", c: "c", cpp: "cpp", h: "c",
-  hpp: "cpp", rb: "ruby", php: "php", swift: "swift", kt: "kotlin",
-  r: "r", lua: "lua",
-};
-
-function CsvTable({ content }: { content: string }) {
-  const rows = content.trim().split("\n").map((row) => row.split(","));
-  if (rows.length === 0) return null;
-  const headers = rows[0];
-  const body = rows.slice(1);
-
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full border-collapse border border-[#e0dbd0] text-sm">
-        <thead className="bg-[#f3efe6]">
-          <tr>
-            {headers.map((h, i) => (
-              <th key={i} className="border border-[#e0dbd0] px-3 py-2 text-left font-medium">{h.trim()}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {body.map((row, ri) => (
-            <tr key={ri} className="even:bg-[#f3efe6]">
-              {row.map((cell, ci) => (
-                <td key={ci} className="border border-[#e0dbd0] px-3 py-2">{cell.trim()}</td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
 
 interface FileContentViewerProps {
   file: FileInfo | null;
   isLoading: boolean;
   error: Error | null;
+  onSave?: (content: string) => Promise<void>;
 }
 
-export function FileContentViewer({ file, isLoading, error }: FileContentViewerProps) {
+export function FileContentViewer({ file, isLoading, error, onSave }: FileContentViewerProps) {
+  const [editContent, setEditContent] = React.useState("");
+  const [originalContent, setOriginalContent] = React.useState("");
+  const [saving, setSaving] = React.useState(false);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  const dirty = editContent !== originalContent;
+
+  // Sync editor content when a new file loads
+  React.useEffect(() => {
+    if (file?.content != null && !file.binary) {
+      setEditContent(file.content);
+      setOriginalContent(file.content);
+      setSaveError(null);
+    }
+  }, [file?.path, file?.content, file?.binary]);
+
+  const handleSave = React.useCallback(async () => {
+    if (!onSave || editContent === originalContent) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onSave(editContent);
+      setOriginalContent(editContent);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }, [onSave, editContent, originalContent]);
+
+  // Cmd/Ctrl+S save shortcut — use ref to avoid stale closure
+  const handleSaveRef = React.useRef(handleSave);
+  handleSaveRef.current = handleSave;
+
+  React.useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault();
+        handleSaveRef.current();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-full text-[#8a8578]">
@@ -81,6 +83,7 @@ export function FileContentViewer({ file, isLoading, error }: FileContentViewerP
     );
   }
 
+  // Image preview (read-only)
   if (file.binary && file.mime_type.startsWith("image/") && file.content) {
     return (
       <div className="p-4 flex items-center justify-center">
@@ -93,6 +96,7 @@ export function FileContentViewer({ file, isLoading, error }: FileContentViewerP
     );
   }
 
+  // Binary file (read-only)
   if (file.binary || file.content === null) {
     return (
       <div className="flex items-center justify-center h-full text-[#8a8578] text-sm">
@@ -101,57 +105,32 @@ export function FileContentViewer({ file, isLoading, error }: FileContentViewerP
     );
   }
 
-  const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
-
-  if (ext === "csv") {
-    return (
-      <div className="p-4 overflow-auto h-full">
-        <CsvTable content={file.content} />
-      </div>
-    );
-  }
-
-  if (ext === "md") {
-    return (
-      <div className="p-6 prose prose-sm max-w-none overflow-auto h-full">
-        <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>
-          {file.content}
-        </ReactMarkdown>
-      </div>
-    );
-  }
-
-  const language = LANGUAGE_MAP[ext];
-  if (language) {
-    return (
-      <div className="overflow-auto h-full">
-        <div className="flex items-center justify-between px-4 py-2 bg-[#f3efe6] border-b border-[#e0dbd0]">
-          <span className="text-xs text-[#8a8578]">{language}</span>
+  // Editable text file
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-3 py-1.5 bg-[#f3efe6] border-b border-[#e0dbd0] flex-shrink-0">
+        <span className="text-xs text-[#8a8578]">{file.name}</span>
+        <div className="flex items-center gap-2">
+          {dirty && <span className="text-[10px] text-amber-500 font-medium">unsaved</span>}
+          {saveError && <span className="text-[10px] text-red-500">{saveError}</span>}
           <button
-            onClick={() => { navigator.clipboard.writeText(file.content!).catch(() => {}); }}
-            className="text-xs text-[#8a8578] hover:text-[#1a1a1a] transition-colors flex items-center gap-1"
+            onClick={handleSave}
+            disabled={!dirty || saving || !onSave}
+            className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-[#06402B] text-white hover:bg-[#0a5c3e] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           >
-            <Copy className="h-3 w-3" />
-            Copy
+            {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+            Save
           </button>
         </div>
-        <SyntaxHighlighter
-          style={oneDark}
-          language={language}
-          PreTag="div"
-          customStyle={{ margin: 0, borderRadius: 0, background: "#f8f5f0" }}
-        >
-          {file.content}
-        </SyntaxHighlighter>
       </div>
-    );
-  }
 
-  return (
-    <div className="p-4 overflow-auto h-full">
-      <pre className="text-sm font-mono whitespace-pre-wrap text-[#1a1a1a]">
-        {file.content}
-      </pre>
+      <textarea
+        ref={textareaRef}
+        value={editContent}
+        onChange={(e) => setEditContent(e.target.value)}
+        className="flex-1 w-full p-4 text-sm font-mono bg-white text-[#1a1a1a] resize-none focus:outline-none"
+        spellCheck={false}
+      />
     </div>
   );
 }

--- a/apps/frontend/src/components/chat/FileTree.tsx
+++ b/apps/frontend/src/components/chat/FileTree.tsx
@@ -90,9 +90,10 @@ interface FileTreeProps {
   onSelect: (path: string) => void;
   onRefresh: () => void;
   isLoading: boolean;
+  emptyMessage?: string;
 }
 
-export function FileTree({ files, selectedPath, onSelect, onRefresh, isLoading }: FileTreeProps) {
+export function FileTree({ files, selectedPath, onSelect, onRefresh, isLoading, emptyMessage }: FileTreeProps) {
   const rootEntries = React.useMemo(() => {
     if (files.length === 0) return [];
     const depths = files.map((f) => f.path.split("/").length);
@@ -114,7 +115,9 @@ export function FileTree({ files, selectedPath, onSelect, onRefresh, isLoading }
       </div>
       <div className="flex-1 overflow-y-auto p-2">
         {files.length === 0 && !isLoading ? (
-          <div className="text-xs text-[#8a8578] text-center py-4">No files in workspace</div>
+          <div className="text-xs text-[#8a8578] text-center py-4 px-3">
+            {emptyMessage ?? "No files in workspace"}
+          </div>
         ) : (
           rootEntries.map((entry) => (
             <FileTreeNode

--- a/apps/frontend/src/components/chat/FileViewer.tsx
+++ b/apps/frontend/src/components/chat/FileViewer.tsx
@@ -47,6 +47,7 @@ function formatDate(timestamp: number): string {
 export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProps) {
   const [activeTab, setActiveTab] = React.useState<ViewerTab>("workspace");
   const [selectedPath, setSelectedPath] = React.useState<string | null>(initialFilePath ?? null);
+  const [editorDirty, setEditorDirty] = React.useState(false);
 
   const relativeFilePath = selectedPath;
 
@@ -90,11 +91,31 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
     [agentId, relativeFilePath, activeTab, api, refresh],
   );
 
+  const confirmDiscardIfDirty = React.useCallback((): boolean => {
+    if (!editorDirty) return true;
+    return window.confirm("You have unsaved changes. Discard them?");
+  }, [editorDirty]);
+
+  const handleSelectFile = React.useCallback(
+    (path: string) => {
+      if (path === selectedPath) return;
+      if (!confirmDiscardIfDirty()) return;
+      setSelectedPath(path);
+    },
+    [selectedPath, confirmDiscardIfDirty],
+  );
+
   function handleTabChange(tab: ViewerTab) {
     if (tab === activeTab) return;
+    if (!confirmDiscardIfDirty()) return;
     setActiveTab(tab);
     setSelectedPath(null);
   }
+
+  const handleCloseRequested = React.useCallback(() => {
+    if (!confirmDiscardIfDirty()) return;
+    onClose();
+  }, [confirmDiscardIfDirty, onClose]);
 
   function handleCopyContent() {
     if (file?.content) {
@@ -193,7 +214,7 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
         )}
 
         <button
-          onClick={onClose}
+          onClick={handleCloseRequested}
           className="text-[#8a8578] hover:text-[#1a1a1a] transition-colors flex-shrink-0 ml-2"
           title="Close file viewer"
         >
@@ -215,7 +236,7 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
           <FileTree
             files={files}
             selectedPath={selectedPath}
-            onSelect={setSelectedPath}
+            onSelect={handleSelectFile}
             onRefresh={() => refresh()}
             isLoading={treeLoading}
             emptyMessage={
@@ -231,6 +252,7 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
             isLoading={fileLoading}
             error={fileError ?? null}
             onSave={selectedPath ? handleSave : undefined}
+            onDirtyChange={setEditorDirty}
           />
         </div>
       </div>

--- a/apps/frontend/src/components/chat/FileViewer.tsx
+++ b/apps/frontend/src/components/chat/FileViewer.tsx
@@ -132,8 +132,12 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
       `}</style>
 
       <div className="file-viewer-header">
-        <div className="flex items-center gap-1">
+        <div role="tablist" aria-label="File viewer tabs" className="flex items-center gap-1">
           <button
+            id="file-viewer-tab-workspace"
+            role="tab"
+            aria-selected={activeTab === "workspace"}
+            aria-controls="file-viewer-tabpanel"
             onClick={() => handleTabChange("workspace")}
             className={`px-3 py-1 text-sm rounded-md transition-colors ${
               activeTab === "workspace"
@@ -144,6 +148,10 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
             Workspace
           </button>
           <button
+            id="file-viewer-tab-config"
+            role="tab"
+            aria-selected={activeTab === "config"}
+            aria-controls="file-viewer-tabpanel"
             onClick={() => handleTabChange("config")}
             className={`px-3 py-1 text-sm rounded-md transition-colors ${
               activeTab === "config"
@@ -184,7 +192,16 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
         </button>
       </div>
 
-      <div className="file-viewer-body">
+      <div
+        className="file-viewer-body"
+        id="file-viewer-tabpanel"
+        role="tabpanel"
+        aria-labelledby={
+          activeTab === "workspace"
+            ? "file-viewer-tab-workspace"
+            : "file-viewer-tab-config"
+        }
+      >
         <div className="file-viewer-tree">
           <FileTree
             files={files}

--- a/apps/frontend/src/components/chat/FileViewer.tsx
+++ b/apps/frontend/src/components/chat/FileViewer.tsx
@@ -5,6 +5,7 @@ import { X, Copy } from "lucide-react";
 import { FileTree } from "@/components/chat/FileTree";
 import { FileContentViewer } from "@/components/chat/FileContentViewer";
 import { useWorkspaceTree, useWorkspaceFile, useConfigFiles, useConfigFile } from "@/hooks/useWorkspaceFiles";
+import { useApi } from "@/lib/api";
 
 interface FileViewerProps {
   agentId: string | null;
@@ -80,6 +81,18 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
       setActiveTab("workspace"); // chat-detected paths are always workspace paths
     }
   }, [initialFilePath]);
+
+  const api = useApi();
+
+  const handleSave = React.useCallback(
+    async (content: string) => {
+      if (!agentId || !relativeFilePath) return;
+      await api.saveWorkspaceFile(agentId, relativeFilePath, content, activeTab);
+      // Refresh the tree to pick up size/date changes
+      refresh();
+    },
+    [agentId, relativeFilePath, activeTab, api, refresh],
+  );
 
   function handleTabChange(tab: ViewerTab) {
     if (tab === activeTab) return;
@@ -221,6 +234,7 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
             file={file}
             isLoading={fileLoading}
             error={fileError ?? null}
+            onSave={selectedPath ? handleSave : undefined}
           />
         </div>
       </div>

--- a/apps/frontend/src/components/chat/FileViewer.tsx
+++ b/apps/frontend/src/components/chat/FileViewer.tsx
@@ -48,11 +48,7 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
   const [activeTab, setActiveTab] = React.useState<ViewerTab>("workspace");
   const [selectedPath, setSelectedPath] = React.useState<string | null>(initialFilePath ?? null);
 
-  const relativeFilePath = React.useMemo(() => {
-    if (!selectedPath) return null;
-    const prefix = `agents/${agentId}/`;
-    return selectedPath.startsWith(prefix) ? selectedPath.slice(prefix.length) : selectedPath;
-  }, [selectedPath, agentId]);
+  const relativeFilePath = selectedPath;
 
   // Workspace tab data
   const { files: wsFiles, isLoading: wsTreeLoading, refresh: wsRefresh } = useWorkspaceTree(agentId);

--- a/apps/frontend/src/components/chat/FileViewer.tsx
+++ b/apps/frontend/src/components/chat/FileViewer.tsx
@@ -72,13 +72,6 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
   const fileLoading = activeTab === "workspace" ? wsFileLoading : cfgFileLoading;
   const fileError = activeTab === "workspace" ? wsFileError : cfgFileError;
 
-  React.useEffect(() => {
-    if (initialFilePath) {
-      setSelectedPath(initialFilePath);
-      setActiveTab("workspace"); // chat-detected paths are always workspace paths
-    }
-  }, [initialFilePath]);
-
   const api = useApi();
 
   const handleSave = React.useCallback(
@@ -95,6 +88,21 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
     if (!editorDirty) return true;
     return window.confirm("You have unsaved changes. Discard them?");
   }, [editorDirty]);
+
+  // Ref-guard against prompting on the initial mount when editorDirty is
+  // already false; we still want to prompt on prop-driven switches that
+  // happen AFTER the user has unsaved edits.
+  const confirmDiscardIfDirtyRef = React.useRef(confirmDiscardIfDirty);
+  confirmDiscardIfDirtyRef.current = confirmDiscardIfDirty;
+
+  React.useEffect(() => {
+    if (!initialFilePath) return;
+    if (initialFilePath === selectedPath) return;
+    if (!confirmDiscardIfDirtyRef.current()) return;
+    setSelectedPath(initialFilePath);
+    setActiveTab("workspace"); // chat-detected paths are always workspace paths
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialFilePath]); // intentionally omitting selectedPath to preserve original trigger semantics
 
   const handleSelectFile = React.useCallback(
     (path: string) => {

--- a/apps/frontend/src/components/chat/FileViewer.tsx
+++ b/apps/frontend/src/components/chat/FileViewer.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import * as React from "react";
-import { X, Copy, FolderOpen } from "lucide-react";
+import { X, Copy } from "lucide-react";
 import { FileTree } from "@/components/chat/FileTree";
 import { FileContentViewer } from "@/components/chat/FileContentViewer";
-import { useWorkspaceTree, useWorkspaceFile } from "@/hooks/useWorkspaceFiles";
+import { useWorkspaceTree, useWorkspaceFile, useConfigFiles, useConfigFile } from "@/hooks/useWorkspaceFiles";
 
 interface FileViewerProps {
   agentId: string | null;
   initialFilePath?: string | null;
   onClose: () => void;
 }
+
+type ViewerTab = "workspace" | "config";
 
 function Breadcrumbs({ path, onNavigate }: { path: string; onNavigate: (segment: string) => void }) {
   const segments = path.split("/");
@@ -42,6 +44,7 @@ function formatDate(timestamp: number): string {
 }
 
 export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProps) {
+  const [activeTab, setActiveTab] = React.useState<ViewerTab>("workspace");
   const [selectedPath, setSelectedPath] = React.useState<string | null>(initialFilePath ?? null);
 
   const relativeFilePath = React.useMemo(() => {
@@ -50,14 +53,39 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
     return selectedPath.startsWith(prefix) ? selectedPath.slice(prefix.length) : selectedPath;
   }, [selectedPath, agentId]);
 
-  const { files, isLoading: treeLoading, refresh } = useWorkspaceTree(agentId);
-  const { file, isLoading: fileLoading, error: fileError } = useWorkspaceFile(agentId, relativeFilePath);
+  // Workspace tab data
+  const { files: wsFiles, isLoading: wsTreeLoading, refresh: wsRefresh } = useWorkspaceTree(agentId);
+  const { file: wsFile, isLoading: wsFileLoading, error: wsFileError } = useWorkspaceFile(
+    activeTab === "workspace" ? agentId : null,
+    activeTab === "workspace" ? relativeFilePath : null,
+  );
+
+  // Config tab data
+  const { files: cfgFiles, isLoading: cfgTreeLoading, refresh: cfgRefresh } = useConfigFiles(agentId);
+  const { file: cfgFile, isLoading: cfgFileLoading, error: cfgFileError } = useConfigFile(
+    activeTab === "config" ? agentId : null,
+    activeTab === "config" ? relativeFilePath : null,
+  );
+
+  const files = activeTab === "workspace" ? wsFiles : cfgFiles;
+  const treeLoading = activeTab === "workspace" ? wsTreeLoading : cfgTreeLoading;
+  const refresh = activeTab === "workspace" ? wsRefresh : cfgRefresh;
+  const file = activeTab === "workspace" ? wsFile : cfgFile;
+  const fileLoading = activeTab === "workspace" ? wsFileLoading : cfgFileLoading;
+  const fileError = activeTab === "workspace" ? wsFileError : cfgFileError;
 
   React.useEffect(() => {
     if (initialFilePath) {
       setSelectedPath(initialFilePath);
+      setActiveTab("workspace"); // chat-detected paths are always workspace paths
     }
   }, [initialFilePath]);
+
+  function handleTabChange(tab: ViewerTab) {
+    if (tab === activeTab) return;
+    setActiveTab(tab);
+    setSelectedPath(null);
+  }
 
   function handleCopyContent() {
     if (file?.content) {
@@ -104,38 +132,52 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
       `}</style>
 
       <div className="file-viewer-header">
-        <FolderOpen className="h-4 w-4 text-[#8a8578] flex-shrink-0" />
-        {selectedPath ? (
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => handleTabChange("workspace")}
+            className={`px-3 py-1 text-sm rounded-md transition-colors ${
+              activeTab === "workspace"
+                ? "bg-white text-[#1a1a1a] shadow-sm font-medium"
+                : "text-[#8a8578] hover:text-[#1a1a1a]"
+            }`}
+          >
+            Workspace
+          </button>
+          <button
+            onClick={() => handleTabChange("config")}
+            className={`px-3 py-1 text-sm rounded-md transition-colors ${
+              activeTab === "config"
+                ? "bg-white text-[#1a1a1a] shadow-sm font-medium"
+                : "text-[#8a8578] hover:text-[#1a1a1a]"
+            }`}
+          >
+            Config
+          </button>
+        </div>
+
+        <div className="flex-1" />
+
+        {selectedPath && file && (
           <>
-            <Breadcrumbs
-              path={relativeFilePath ?? selectedPath}
-              onNavigate={() => {}}
-            />
-            <div className="flex-1" />
-            {file && (
-              <span className="text-xs text-[#8a8578] flex-shrink-0">
-                {formatFileSize(file.size)} · {formatDate(file.modified_at)}
-              </span>
-            )}
-            {file?.content && (
+            <Breadcrumbs path={relativeFilePath ?? selectedPath} onNavigate={() => {}} />
+            <span className="text-xs text-[#8a8578] flex-shrink-0 ml-2">
+              {formatFileSize(file.size)} · {formatDate(file.modified_at)}
+            </span>
+            {file.content && (
               <button
                 onClick={handleCopyContent}
-                className="text-[#8a8578] hover:text-[#1a1a1a] transition-colors flex-shrink-0"
+                className="text-[#8a8578] hover:text-[#1a1a1a] transition-colors flex-shrink-0 ml-2"
                 title="Copy file content"
               >
                 <Copy className="h-4 w-4" />
               </button>
             )}
           </>
-        ) : (
-          <>
-            <span className="text-sm text-[#8a8578]">Workspace</span>
-            <div className="flex-1" />
-          </>
         )}
+
         <button
           onClick={onClose}
-          className="text-[#8a8578] hover:text-[#1a1a1a] transition-colors flex-shrink-0"
+          className="text-[#8a8578] hover:text-[#1a1a1a] transition-colors flex-shrink-0 ml-2"
           title="Close file viewer"
         >
           <X className="h-4 w-4" />
@@ -150,6 +192,11 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
             onSelect={setSelectedPath}
             onRefresh={() => refresh()}
             isLoading={treeLoading}
+            emptyMessage={
+              activeTab === "workspace"
+                ? "No files yet. Your agent will create files here as it works."
+                : "No config files found."
+            }
           />
         </div>
         <div className="file-viewer-content">

--- a/apps/frontend/src/hooks/useWorkspaceFiles.ts
+++ b/apps/frontend/src/hooks/useWorkspaceFiles.ts
@@ -55,3 +55,38 @@ export function useWorkspaceFile(agentId: string | null, filePath: string | null
     isLoading,
   };
 }
+
+export function useConfigFiles(agentId: string | null) {
+  const api = useApi();
+  const key = agentId ? `/container/workspace/${agentId}/config-files` : null;
+
+  const { data, error, isLoading, mutate } = useSWR<{ files: FileEntry[] }>(
+    key,
+    () => api.get(key!) as Promise<{ files: FileEntry[] }>,
+  );
+
+  return {
+    files: data?.files ?? [],
+    error,
+    isLoading,
+    refresh: mutate,
+  };
+}
+
+export function useConfigFile(agentId: string | null, filePath: string | null) {
+  const api = useApi();
+  const key = agentId && filePath
+    ? `/container/workspace/${agentId}/config-file?path=${encodeURIComponent(filePath)}`
+    : null;
+
+  const { data, error, isLoading } = useSWR<FileInfo>(
+    key,
+    () => api.get(key!) as Promise<FileInfo>,
+  );
+
+  return {
+    file: data ?? null,
+    error,
+    isLoading,
+  };
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -54,7 +54,8 @@ interface ApiMethods {
   put: (endpoint: string, body: unknown) => Promise<unknown>;
   del: (endpoint: string) => Promise<unknown>;
   patchConfig: (patch: Record<string, unknown>) => Promise<{ status: string; owner_id: string }>;
-  uploadFiles: (files: File[]) => Promise<UploadResponse>;
+  uploadFiles: (files: File[], agentId: string) => Promise<UploadResponse>;
+  saveWorkspaceFile: (agentId: string, path: string, content: string, tab: "workspace" | "config") => Promise<{ status: string; path: string }>;
 }
 
 export function useApi(): ApiMethods {
@@ -124,7 +125,7 @@ export function useApi(): ApiMethods {
           body: JSON.stringify({ patch }),
         }) as Promise<{ status: string; owner_id: string }>;
       },
-      async uploadFiles(files: File[]): Promise<UploadResponse> {
+      async uploadFiles(files: File[], agentId: string): Promise<UploadResponse> {
         const token = await getToken();
         if (!token) throw new Error("No authentication token available");
 
@@ -133,7 +134,7 @@ export function useApi(): ApiMethods {
           formData.append("files", file);
         }
 
-        const response = await fetch(`${BACKEND_URL}/container/files`, {
+        const response = await fetch(`${BACKEND_URL}/container/files?agent_id=${encodeURIComponent(agentId)}`, {
           method: "POST",
           headers: { Authorization: `Bearer ${token}` },
           body: formData,
@@ -145,6 +146,17 @@ export function useApi(): ApiMethods {
         }
 
         return response.json();
+      },
+      saveWorkspaceFile(
+        agentId: string,
+        path: string,
+        content: string,
+        tab: "workspace" | "config",
+      ): Promise<{ status: string; path: string }> {
+        return authenticatedFetch(`/container/workspace/${encodeURIComponent(agentId)}/file`, {
+          method: "PUT",
+          body: JSON.stringify({ path, content, tab }),
+        }) as Promise<{ status: string; path: string }>;
       },
     }),
     [authenticatedFetch, getToken]

--- a/docs/superpowers/plans/2026-04-13-file-viewer-v2.md
+++ b/docs/superpowers/plans/2026-04-13-file-viewer-v2.md
@@ -1,0 +1,1178 @@
+# File Viewer V2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the empty file viewer, broken uploads, and cramped layout — replace with a full-width IDE-style split pane with two tabs (Workspace/Config) and inline editing.
+
+**Architecture:** Backend gets 3 new endpoints (config file list, config file read, file write) and an `agent_id` param on the existing upload endpoint. Frontend layout flips to `[Chat 380px] [FileViewer 1fr]` when the viewer opens (sidebar hides). FileViewer gains tab state and FileContentViewer becomes an inline editor with save via direct EFS writes.
+
+**Tech Stack:** Python/FastAPI (backend), React/Next.js 16 + Tailwind CSS v4 + SWR (frontend), pytest (backend tests), vitest (frontend tests)
+
+**Spec:** `docs/superpowers/specs/2026-04-13-file-viewer-v2-design.md`
+
+---
+
+### Task 1: Backend — Config file list and read endpoints
+
+**Files:**
+- Modify: `apps/backend/routers/workspace_files.py`
+- Modify: `apps/backend/tests/test_workspace_files.py`
+
+The workspace_files router currently only has endpoints for `workspaces/{agent_id}/`. We need two new endpoints that serve allowlisted config files from `agents/{agent_id}/`.
+
+- [ ] **Step 1: Write failing tests for config-files endpoint**
+
+Add to `apps/backend/tests/test_workspace_files.py`:
+
+```python
+# At the top, add imports
+from unittest.mock import MagicMock, patch, AsyncMock
+from fastapi.testclient import TestClient
+
+# Add these constants
+AGENT_ID = "agent-abc-123"
+ALLOWLISTED_FILES = [
+    "SOUL.md", "MEMORY.md", "TOOLS.md", "IDENTITY.md",
+    "USER.md", "HEARTBEAT.md", "BOOTSTRAP.md", "AGENTS.md",
+]
+
+
+class TestConfigFilesEndpoint:
+    """Tests for GET /workspace/{agent_id}/config-files."""
+
+    def test_returns_only_allowlisted_files(self, tmp_path):
+        """Only allowlisted files that exist on disk are returned."""
+        ws = _make_workspace(tmp_path)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "SOUL.md").write_text("I am helpful", encoding="utf-8")
+        (agent_dir / "MEMORY.md").write_text("Remember this", encoding="utf-8")
+        (agent_dir / "sessions").mkdir()  # should be excluded
+        (agent_dir / "secret.json").write_text("{}", encoding="utf-8")  # not allowlisted
+
+        from routers.workspace_files import _list_config_files
+        result = _list_config_files(ws, USER_ID, AGENT_ID)
+        names = {f["name"] for f in result}
+        assert names == {"SOUL.md", "MEMORY.md"}
+        assert all(f["type"] == "file" for f in result)
+
+    def test_empty_when_no_agent_dir(self, tmp_path):
+        """Returns empty list when agent dir doesn't exist."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID).mkdir(parents=True)
+        from routers.workspace_files import _list_config_files
+        result = _list_config_files(ws, USER_ID, AGENT_ID)
+        assert result == []
+
+    def test_file_entries_have_required_fields(self, tmp_path):
+        """Each entry has name, path, type, size, modified_at."""
+        ws = _make_workspace(tmp_path)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "BOOTSTRAP.md").write_text("# Bootstrap", encoding="utf-8")
+        from routers.workspace_files import _list_config_files
+        result = _list_config_files(ws, USER_ID, AGENT_ID)
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["name"] == "BOOTSTRAP.md"
+        assert entry["path"] == "BOOTSTRAP.md"
+        assert entry["type"] == "file"
+        assert isinstance(entry["size"], int)
+        assert isinstance(entry["modified_at"], float)
+
+
+class TestConfigFileReadEndpoint:
+    """Tests for GET /workspace/{agent_id}/config-file."""
+
+    def test_reads_allowlisted_file(self, tmp_path):
+        """Can read an allowlisted config file."""
+        ws = _make_workspace(tmp_path)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "SOUL.md").write_text("I am helpful", encoding="utf-8")
+        info = ws.read_file_info(USER_ID, f"agents/{AGENT_ID}/SOUL.md")
+        assert info["content"] == "I am helpful"
+        assert info["binary"] is False
+
+    def test_rejects_non_allowlisted_filename(self, tmp_path):
+        """Non-allowlisted filenames are rejected."""
+        from routers.workspace_files import CONFIG_ALLOWLIST
+        assert "secret.json" not in CONFIG_ALLOWLIST
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/test_workspace_files.py::TestConfigFilesEndpoint tests/test_workspace_files.py::TestConfigFileReadEndpoint -v`
+Expected: FAIL — `_list_config_files` and `CONFIG_ALLOWLIST` don't exist yet.
+
+- [ ] **Step 3: Implement config file list/read endpoints**
+
+In `apps/backend/routers/workspace_files.py`, add the allowlist constant and helper function after the existing `_collect_recursive` function:
+
+```python
+CONFIG_ALLOWLIST: set[str] = {
+    "SOUL.md", "MEMORY.md", "TOOLS.md", "IDENTITY.md",
+    "USER.md", "HEARTBEAT.md", "BOOTSTRAP.md", "AGENTS.md",
+}
+
+
+def _list_config_files(workspace, owner_id: str, agent_id: str) -> list[dict]:
+    """List only allowlisted config files from agents/{agent_id}/."""
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        return []
+    user_root = workspace.user_path(owner_id)
+    agent_dir = user_root / "agents" / agent_id
+    if not agent_dir.exists() or not agent_dir.is_dir():
+        return []
+    results = []
+    for name in sorted(CONFIG_ALLOWLIST):
+        fpath = agent_dir / name
+        if fpath.exists() and fpath.is_file():
+            stat = fpath.stat()
+            results.append({
+                "name": name,
+                "path": name,
+                "type": "file",
+                "size": stat.st_size,
+                "modified_at": stat.st_mtime,
+            })
+    return results
+```
+
+Add two new endpoint functions:
+
+```python
+@router.get("/workspace/{agent_id}/config-files")
+async def list_config_files(
+    agent_id: str,
+    auth: AuthContext = Depends(get_current_user),
+):
+    """List allowlisted agent config files (SOUL.md, MEMORY.md, etc.)."""
+    owner_id = resolve_owner_id(auth)
+    workspace = get_workspace()
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
+    return {"files": _list_config_files(workspace, owner_id, agent_id)}
+
+
+@router.get("/workspace/{agent_id}/config-file")
+async def read_config_file(
+    agent_id: str,
+    path: str = Query(..., description="Config filename (must be allowlisted)"),
+    auth: AuthContext = Depends(get_current_user),
+):
+    """Read a single allowlisted agent config file."""
+    owner_id = resolve_owner_id(auth)
+    if path not in CONFIG_ALLOWLIST:
+        raise HTTPException(status_code=400, detail=f"File not in allowlist: {path}")
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
+    workspace = get_workspace()
+    full_path = f"agents/{agent_id}/{path}"
+    try:
+        info = workspace.read_file_info(owner_id, full_path)
+    except WorkspaceError as exc:
+        if "not found" in str(exc).lower():
+            raise HTTPException(status_code=404, detail=str(exc))
+        raise HTTPException(status_code=500, detail=str(exc))
+    return info
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/backend && uv run pytest tests/test_workspace_files.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/routers/workspace_files.py apps/backend/tests/test_workspace_files.py
+git commit -m "feat(api): add config-files list and read endpoints for agent personality files"
+```
+
+---
+
+### Task 2: Backend — File write endpoint
+
+**Files:**
+- Modify: `apps/backend/routers/workspace_files.py`
+- Modify: `apps/backend/tests/test_workspace_files.py`
+
+New `PUT /workspace/{agent_id}/file` endpoint that writes to either `workspaces/` or `agents/` depending on the `tab` parameter. This powers inline editing in the file viewer.
+
+- [ ] **Step 1: Write failing tests for write endpoint**
+
+Add to `apps/backend/tests/test_workspace_files.py`:
+
+```python
+class TestWriteFileEndpoint:
+    """Tests for the _write_workspace_file helper used by PUT endpoint."""
+
+    def test_write_workspace_file(self, tmp_path):
+        """Writing a workspace file creates it on disk."""
+        ws = _make_workspace(tmp_path)
+        user_root = tmp_path / USER_ID
+        user_root.mkdir(parents=True)
+        ws_dir = user_root / "workspaces" / AGENT_ID
+        ws_dir.mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+        _write_file(ws, USER_ID, AGENT_ID, "plan.md", "# My Plan", "workspace")
+        assert (ws_dir / "plan.md").read_text() == "# My Plan"
+
+    def test_write_config_file_allowlisted(self, tmp_path):
+        """Writing an allowlisted config file succeeds."""
+        ws = _make_workspace(tmp_path)
+        agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
+        agent_dir.mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+        _write_file(ws, USER_ID, AGENT_ID, "SOUL.md", "I am kind", "config")
+        assert (agent_dir / "SOUL.md").read_text() == "I am kind"
+
+    def test_write_config_file_not_allowlisted_raises(self, tmp_path):
+        """Writing a non-allowlisted config file raises ValueError."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+        with pytest.raises(ValueError, match="not in allowlist"):
+            _write_file(ws, USER_ID, AGENT_ID, "secret.json", "{}", "config")
+
+    def test_write_creates_parent_dirs(self, tmp_path):
+        """Writing to a nested path creates intermediate directories."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _write_file
+        _write_file(ws, USER_ID, AGENT_ID, "deep/nested/file.txt", "hello", "workspace")
+        assert (tmp_path / USER_ID / "workspaces" / AGENT_ID / "deep" / "nested" / "file.txt").read_text() == "hello"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/test_workspace_files.py::TestWriteFileEndpoint -v`
+Expected: FAIL — `_write_file` doesn't exist yet.
+
+- [ ] **Step 3: Implement the write helper and endpoint**
+
+Add to `apps/backend/routers/workspace_files.py`:
+
+```python
+from pydantic import BaseModel
+
+
+class WriteFileRequest(BaseModel):
+    path: str
+    content: str
+    tab: str  # "workspace" or "config"
+
+
+def _write_file(
+    workspace, owner_id: str, agent_id: str, path: str, content: str, tab: str
+) -> str:
+    """Write a file to workspace or config directory. Returns the written path."""
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise ValueError(f"Invalid agent_id: {agent_id!r}")
+
+    if tab == "config":
+        if path not in CONFIG_ALLOWLIST:
+            raise ValueError(f"File not in allowlist: {path}")
+        full_path = f"agents/{agent_id}/{path}"
+    elif tab == "workspace":
+        full_path = f"workspaces/{agent_id}/{path}"
+    else:
+        raise ValueError(f"Invalid tab: {tab!r}")
+
+    workspace.write_file(owner_id, full_path, content)
+    return full_path
+
+
+@router.put("/workspace/{agent_id}/file")
+async def write_workspace_file(
+    agent_id: str,
+    body: WriteFileRequest,
+    auth: AuthContext = Depends(get_current_user),
+):
+    """Write a file to the agent's workspace or config directory."""
+    owner_id = resolve_owner_id(auth)
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
+    if body.tab not in ("workspace", "config"):
+        raise HTTPException(status_code=400, detail="tab must be 'workspace' or 'config'")
+
+    workspace = get_workspace()
+    try:
+        written_path = _write_file(workspace, owner_id, agent_id, body.path, body.content, body.tab)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except WorkspaceError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    logger.info("Wrote %s for user %s (tab=%s)", written_path, owner_id, body.tab)
+    return {"status": "ok", "path": written_path}
+```
+
+Add the `BaseModel` import at the top of the file:
+
+```python
+from pydantic import BaseModel
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/backend && uv run pytest tests/test_workspace_files.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/routers/workspace_files.py apps/backend/tests/test_workspace_files.py
+git commit -m "feat(api): add PUT file write endpoint for inline editing"
+```
+
+---
+
+### Task 3: Backend — Fix upload endpoint to write into agent workspace
+
+**Files:**
+- Modify: `apps/backend/routers/container_rpc.py`
+- Modify: `apps/backend/tests/test_workspace_files.py` (add upload path test)
+
+The upload endpoint currently writes to `uploads/{filename}` at the user root. Change it to write to `workspaces/{agent_id}/uploads/{filename}` so uploaded files appear in the Workspace tab.
+
+- [ ] **Step 1: Write failing test for upload path change**
+
+Add to `apps/backend/tests/test_workspace_files.py`:
+
+```python
+class TestUploadPath:
+    """Verify upload destination path construction."""
+
+    def test_upload_writes_to_agent_workspace(self, tmp_path):
+        """Uploads should go to workspaces/{agent_id}/uploads/."""
+        ws = _make_workspace(tmp_path)
+        ws_dir = tmp_path / USER_ID / "workspaces" / AGENT_ID / "uploads"
+        (tmp_path / USER_ID).mkdir(parents=True)
+
+        dest_path = f"workspaces/{AGENT_ID}/uploads/test.pdf"
+        ws.write_bytes(USER_ID, dest_path, b"fake pdf content")
+        assert (ws_dir / "test.pdf").read_bytes() == b"fake pdf content"
+
+    def test_agent_visible_path(self):
+        """Agent-visible path should include workspaces/{agent_id}."""
+        agent_id = "my-agent"
+        filename = "data.csv"
+        dest_path = f"workspaces/{agent_id}/uploads/{filename}"
+        agent_path = f".openclaw/{dest_path}"
+        assert agent_path == f".openclaw/workspaces/{agent_id}/uploads/{filename}"
+```
+
+- [ ] **Step 2: Run tests to verify they pass** (these test path construction, not the endpoint itself)
+
+Run: `cd apps/backend && uv run pytest tests/test_workspace_files.py::TestUploadPath -v`
+Expected: PASS (these validate the path scheme, the write_bytes already works)
+
+- [ ] **Step 3: Modify upload endpoint to accept agent_id**
+
+In `apps/backend/routers/container_rpc.py`, modify the `upload_files` function signature and body. Add `Query` import at the top (it's already imported from fastapi). Change:
+
+```python
+async def upload_files(
+    files: List[UploadFile] = File(..., description="Files to upload"),
+    agent_id: str = Query(..., description="Target agent ID"),
+    auth: AuthContext = Depends(get_current_user),
+):
+```
+
+Add agent_id validation after the file count check:
+
+```python
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
+```
+
+Change the dest_path and agent_path lines (around line 283-287):
+
+```python
+        safe_name = _sanitize_filename(f.filename or "upload")
+        dest_path = f"workspaces/{agent_id}/uploads/{safe_name}"
+        workspace.write_bytes(owner_id, dest_path, data)
+        agent_path = f".openclaw/{dest_path}"
+```
+
+- [ ] **Step 4: Run full backend test suite**
+
+Run: `cd apps/backend && uv run pytest tests/ -v --timeout=30`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/routers/container_rpc.py apps/backend/tests/test_workspace_files.py
+git commit -m "fix(api): upload files to agent workspace directory instead of user root"
+```
+
+---
+
+### Task 4: Frontend — Add config file hooks and update API client
+
+**Files:**
+- Modify: `apps/frontend/src/hooks/useWorkspaceFiles.ts`
+- Modify: `apps/frontend/src/lib/api.ts`
+
+Add SWR hooks for config file endpoints and update the API client with `agentId` on uploads and a new `saveWorkspaceFile` method.
+
+- [ ] **Step 1: Add config file hooks to useWorkspaceFiles.ts**
+
+Add to the bottom of `apps/frontend/src/hooks/useWorkspaceFiles.ts`:
+
+```typescript
+export function useConfigFiles(agentId: string | null) {
+  const api = useApi();
+  const key = agentId ? `/container/workspace/${agentId}/config-files` : null;
+
+  const { data, error, isLoading, mutate } = useSWR<{ files: FileEntry[] }>(
+    key,
+    () => api.get(key!) as Promise<{ files: FileEntry[] }>,
+  );
+
+  return {
+    files: data?.files ?? [],
+    error,
+    isLoading,
+    refresh: mutate,
+  };
+}
+
+export function useConfigFile(agentId: string | null, filePath: string | null) {
+  const api = useApi();
+  const key = agentId && filePath
+    ? `/container/workspace/${agentId}/config-file?path=${encodeURIComponent(filePath)}`
+    : null;
+
+  const { data, error, isLoading } = useSWR<FileInfo>(
+    key,
+    () => api.get(key!) as Promise<FileInfo>,
+  );
+
+  return {
+    file: data ?? null,
+    error,
+    isLoading,
+  };
+}
+```
+
+- [ ] **Step 2: Update api.ts — add agentId to uploadFiles and add saveWorkspaceFile**
+
+In `apps/frontend/src/lib/api.ts`, update the `UploadResponse` interface area and the `ApiMethods` interface:
+
+Add to `ApiMethods`:
+```typescript
+  uploadFiles: (files: File[], agentId: string) => Promise<UploadResponse>;
+  saveWorkspaceFile: (agentId: string, path: string, content: string, tab: "workspace" | "config") => Promise<{ status: string; path: string }>;
+```
+
+Update the `uploadFiles` implementation to include `agentId`:
+
+```typescript
+      async uploadFiles(files: File[], agentId: string): Promise<UploadResponse> {
+        const token = await getToken();
+        if (!token) throw new Error("No authentication token available");
+
+        const formData = new FormData();
+        for (const file of files) {
+          formData.append("files", file);
+        }
+
+        const response = await fetch(`${BACKEND_URL}/container/files?agent_id=${encodeURIComponent(agentId)}`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          body: formData,
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(errorData.detail || "Upload failed");
+        }
+
+        return response.json();
+      },
+```
+
+Add `saveWorkspaceFile` method after `uploadFiles`:
+
+```typescript
+      saveWorkspaceFile(
+        agentId: string,
+        path: string,
+        content: string,
+        tab: "workspace" | "config",
+      ): Promise<{ status: string; path: string }> {
+        return authenticatedFetch(`/container/workspace/${encodeURIComponent(agentId)}/file`, {
+          method: "PUT",
+          body: JSON.stringify({ path, content, tab }),
+        }) as Promise<{ status: string; path: string }>;
+      },
+```
+
+- [ ] **Step 3: Update AgentChatWindow.tsx to pass agentId to uploadFiles**
+
+In `apps/frontend/src/components/chat/AgentChatWindow.tsx`, in the `handleSend` callback (around line 448), change:
+
+```typescript
+            const result = await api.uploadFiles(files);
+```
+
+to:
+
+```typescript
+            const result = await api.uploadFiles(files, agentId!);
+```
+
+- [ ] **Step 4: Run frontend lint and type check**
+
+Run: `cd apps/frontend && pnpm run lint && pnpm tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src/hooks/useWorkspaceFiles.ts apps/frontend/src/lib/api.ts apps/frontend/src/components/chat/AgentChatWindow.tsx
+git commit -m "feat(frontend): add config file hooks, save API, fix upload agentId"
+```
+
+---
+
+### Task 5: Frontend — ChatInput file size validation
+
+**Files:**
+- Modify: `apps/frontend/src/components/chat/ChatInput.tsx`
+
+Add client-side 10MB file size limit with inline error feedback.
+
+- [ ] **Step 1: Add file size validation to ChatInput.tsx**
+
+Add a constant and error state at the top of the `ChatInput` component:
+
+```typescript
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+```
+
+Inside the component, add state for size errors:
+
+```typescript
+  const [sizeError, setSizeError] = React.useState<string | null>(null);
+```
+
+Create a filter function that separates valid and oversized files:
+
+```typescript
+  const filterOversizedFiles = (files: File[]): File[] => {
+    const valid: File[] = [];
+    const rejected: string[] = [];
+    for (const file of files) {
+      if (file.size > MAX_FILE_SIZE) {
+        rejected.push(file.name);
+      } else {
+        valid.push(file);
+      }
+    }
+    if (rejected.length > 0) {
+      setSizeError(`${rejected.join(", ")} exceed${rejected.length === 1 ? "s" : ""} the 10MB limit`);
+      setTimeout(() => setSizeError(null), 5000);
+    }
+    return valid;
+  };
+```
+
+Update `handleFileSelect` to filter:
+
+```typescript
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files;
+    if (!selected) return;
+
+    const valid = filterOversizedFiles(Array.from(selected));
+    const newFiles: PendingFile[] = valid.map((file) => ({
+      file,
+      id: crypto.randomUUID(),
+    }));
+    setPendingFiles((prev) => [...prev, ...newFiles].slice(0, 10));
+
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+```
+
+Update `handleDrop` similarly:
+
+```typescript
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const dropped = e.dataTransfer.files;
+    if (!dropped.length) return;
+
+    const valid = filterOversizedFiles(Array.from(dropped));
+    const newFiles: PendingFile[] = valid.map((file) => ({
+      file,
+      id: crypto.randomUUID(),
+    }));
+    setPendingFiles((prev) => [...prev, ...newFiles].slice(0, 10));
+  };
+```
+
+Add the error message display after the pending files list, before the input row:
+
+```tsx
+        {sizeError && (
+          <div className="flex items-center gap-1.5 mb-2 px-2 py-1.5 bg-red-50 border border-red-200 rounded-lg text-xs text-red-600">
+            <span>{sizeError}</span>
+            <button
+              type="button"
+              onClick={() => setSizeError(null)}
+              className="ml-auto text-red-400 hover:text-red-600"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        )}
+```
+
+- [ ] **Step 2: Run frontend lint**
+
+Run: `cd apps/frontend && pnpm run lint`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/frontend/src/components/chat/ChatInput.tsx
+git commit -m "feat(chat): add client-side 10MB file size validation"
+```
+
+---
+
+### Task 6: Frontend — Layout transition (sidebar hides, chat compresses)
+
+**Files:**
+- Modify: `apps/frontend/src/components/chat/ChatLayout.css`
+- Modify: `apps/frontend/src/components/chat/ChatLayout.tsx`
+
+When the file viewer opens, the sidebar hides and the chat compresses to 380px. The file viewer fills the remaining space. 200ms ease transition.
+
+- [ ] **Step 1: Update ChatLayout.css grid and transition**
+
+Replace the existing `.app-shell` and `.app-shell.with-file-viewer` rules:
+
+```css
+.app-shell {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  grid-template-areas: "sidebar main";
+  height: 100vh;
+  overflow: hidden;
+  transition: grid-template-columns 200ms ease;
+}
+.app-shell.with-file-viewer {
+  grid-template-columns: 0px 380px 1fr;
+  grid-template-areas: "sidebar main viewer";
+}
+```
+
+Add sidebar transition styles:
+
+```css
+.app-shell.with-file-viewer .cream-sidebar {
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  border-right: none;
+  transition: opacity 150ms ease;
+}
+.cream-sidebar {
+  /* existing styles plus: */
+  transition: opacity 150ms ease;
+}
+```
+
+Add the file viewer grid area:
+
+```css
+.file-viewer-panel {
+  grid-area: viewer;
+}
+```
+
+Update the mobile breakpoint to keep the file viewer single-column:
+
+```css
+@media (max-width: 768px) {
+  .app-shell.with-file-viewer {
+    grid-template-columns: 1fr;
+    grid-template-areas: "viewer";
+  }
+  .app-shell.with-file-viewer .main-area {
+    display: none;
+  }
+}
+```
+
+- [ ] **Step 2: Update ChatLayout.tsx grid areas**
+
+Add `grid-area` to the sidebar div (the `cream-sidebar` element already uses the CSS class, so the grid area comes from CSS). Add `style={{ gridArea: "main" }}` to the `.main-area` div and ensure the FileViewer renders with `gridArea: "viewer"`.
+
+In the JSX where the `main-area` div is rendered (around line 339), add:
+
+```tsx
+        <div className="main-area" style={{ gridArea: "main" }}>
+```
+
+The FileViewer component already has the `file-viewer-panel` CSS class which gets `grid-area: viewer`.
+
+- [ ] **Step 3: Test visually**
+
+Run: `cd apps/frontend && pnpm run dev`
+Open http://localhost:3000/chat, click the folder icon. Verify:
+- Sidebar slides away (opacity 0, width 0)
+- Chat compresses to ~380px on the left
+- File viewer fills the right
+- Closing reverses the animation
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/frontend/src/components/chat/ChatLayout.css apps/frontend/src/components/chat/ChatLayout.tsx
+git commit -m "feat(layout): animate sidebar hide + chat compress when file viewer opens"
+```
+
+---
+
+### Task 7: Frontend — FileViewer tabs (Workspace / Config)
+
+**Files:**
+- Modify: `apps/frontend/src/components/chat/FileViewer.tsx`
+- Modify: `apps/frontend/src/components/chat/FileTree.tsx`
+
+Add tab state to FileViewer. The header shows two underline tabs. Switching tabs swaps the data source and resets the selected file. Update FileTree empty states per tab.
+
+- [ ] **Step 1: Add tab state and tab UI to FileViewer.tsx**
+
+Replace the full `FileViewer` component in `apps/frontend/src/components/chat/FileViewer.tsx`:
+
+```typescript
+import { useWorkspaceTree, useWorkspaceFile, useConfigFiles, useConfigFile } from "@/hooks/useWorkspaceFiles";
+
+type ViewerTab = "workspace" | "config";
+
+export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProps) {
+  const [activeTab, setActiveTab] = React.useState<ViewerTab>("workspace");
+  const [selectedPath, setSelectedPath] = React.useState<string | null>(initialFilePath ?? null);
+
+  const relativeFilePath = React.useMemo(() => {
+    if (!selectedPath) return null;
+    const prefix = `agents/${agentId}/`;
+    return selectedPath.startsWith(prefix) ? selectedPath.slice(prefix.length) : selectedPath;
+  }, [selectedPath, agentId]);
+
+  // Workspace tab data
+  const { files: wsFiles, isLoading: wsTreeLoading, refresh: wsRefresh } = useWorkspaceTree(agentId);
+  const { file: wsFile, isLoading: wsFileLoading, error: wsFileError } = useWorkspaceFile(
+    activeTab === "workspace" ? agentId : null,
+    activeTab === "workspace" ? relativeFilePath : null,
+  );
+
+  // Config tab data
+  const { files: cfgFiles, isLoading: cfgTreeLoading, refresh: cfgRefresh } = useConfigFiles(agentId);
+  const { file: cfgFile, isLoading: cfgFileLoading, error: cfgFileError } = useConfigFile(
+    activeTab === "config" ? agentId : null,
+    activeTab === "config" ? relativeFilePath : null,
+  );
+
+  const files = activeTab === "workspace" ? wsFiles : cfgFiles;
+  const treeLoading = activeTab === "workspace" ? wsTreeLoading : cfgTreeLoading;
+  const refresh = activeTab === "workspace" ? wsRefresh : cfgRefresh;
+  const file = activeTab === "workspace" ? wsFile : cfgFile;
+  const fileLoading = activeTab === "workspace" ? wsFileLoading : cfgFileLoading;
+  const fileError = activeTab === "workspace" ? wsFileError : cfgFileError;
+
+  React.useEffect(() => {
+    if (initialFilePath) {
+      setSelectedPath(initialFilePath);
+      setActiveTab("workspace"); // file path clicks are always workspace
+    }
+  }, [initialFilePath]);
+
+  function handleTabChange(tab: ViewerTab) {
+    setActiveTab(tab);
+    setSelectedPath(null); // reset selection on tab switch
+  }
+
+  function handleCopyContent() {
+    if (file?.content) {
+      navigator.clipboard.writeText(file.content).catch(() => {});
+    }
+  }
+
+  return (
+    <div className="file-viewer-panel">
+      {/* ... existing <style> block unchanged ... */}
+
+      <div className="file-viewer-header">
+        {/* Tabs */}
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => handleTabChange("workspace")}
+            className={`px-3 py-1 text-sm rounded-md transition-colors ${
+              activeTab === "workspace"
+                ? "bg-white text-[#1a1a1a] shadow-sm font-medium"
+                : "text-[#8a8578] hover:text-[#1a1a1a]"
+            }`}
+          >
+            Workspace
+          </button>
+          <button
+            onClick={() => handleTabChange("config")}
+            className={`px-3 py-1 text-sm rounded-md transition-colors ${
+              activeTab === "config"
+                ? "bg-white text-[#1a1a1a] shadow-sm font-medium"
+                : "text-[#8a8578] hover:text-[#1a1a1a]"
+            }`}
+          >
+            Config
+          </button>
+        </div>
+
+        <div className="flex-1" />
+
+        {/* File metadata + actions when a file is selected */}
+        {selectedPath && file && (
+          <>
+            <Breadcrumbs path={relativeFilePath ?? selectedPath} onNavigate={() => {}} />
+            <span className="text-xs text-[#8a8578] flex-shrink-0 ml-2">
+              {formatFileSize(file.size)} · {formatDate(file.modified_at)}
+            </span>
+            {file.content && (
+              <button onClick={handleCopyContent} className="text-[#8a8578] hover:text-[#1a1a1a] transition-colors flex-shrink-0 ml-2" title="Copy file content">
+                <Copy className="h-4 w-4" />
+              </button>
+            )}
+          </>
+        )}
+
+        <button onClick={onClose} className="text-[#8a8578] hover:text-[#1a1a1a] transition-colors flex-shrink-0 ml-2" title="Close file viewer">
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="file-viewer-body">
+        <div className="file-viewer-tree">
+          <FileTree
+            files={files}
+            selectedPath={selectedPath}
+            onSelect={setSelectedPath}
+            onRefresh={() => refresh()}
+            isLoading={treeLoading}
+            emptyMessage={
+              activeTab === "workspace"
+                ? "No files yet. Your agent will create files here as it works."
+                : "No config files found."
+            }
+          />
+        </div>
+        <div className="file-viewer-content">
+          <FileContentViewer file={file} isLoading={fileLoading} error={fileError ?? null} />
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update FileTree to accept emptyMessage prop**
+
+In `apps/frontend/src/components/chat/FileTree.tsx`, add `emptyMessage` to the props interface:
+
+```typescript
+interface FileTreeProps {
+  files: FileEntry[];
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onRefresh: () => void;
+  isLoading: boolean;
+  emptyMessage?: string;
+}
+
+export function FileTree({ files, selectedPath, onSelect, onRefresh, isLoading, emptyMessage }: FileTreeProps) {
+```
+
+Update the empty state in the render:
+
+```tsx
+        {files.length === 0 && !isLoading ? (
+          <div className="text-xs text-[#8a8578] text-center py-4 px-3">
+            {emptyMessage ?? "No files in workspace"}
+          </div>
+        ) : (
+```
+
+- [ ] **Step 3: Test visually**
+
+Run: `cd apps/frontend && pnpm run dev`
+Open the file viewer, verify:
+- Two tabs appear in the header
+- Workspace tab shows workspace files (or empty state)
+- Config tab shows SOUL.md, MEMORY.md, etc. (or empty state)
+- Switching tabs resets the file selection
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/frontend/src/components/chat/FileViewer.tsx apps/frontend/src/components/chat/FileTree.tsx
+git commit -m "feat(viewer): add Workspace and Config tabs to file viewer"
+```
+
+---
+
+### Task 8: Frontend — Inline editing in FileContentViewer
+
+**Files:**
+- Modify: `apps/frontend/src/components/chat/FileContentViewer.tsx`
+- Modify: `apps/frontend/src/components/chat/FileViewer.tsx`
+
+Replace the read-only file content viewer with an editable textarea for text files. Add dirty tracking, save button, Cmd+S shortcut, and unsaved confirmation.
+
+- [ ] **Step 1: Rewrite FileContentViewer.tsx for inline editing**
+
+Replace the full content of `apps/frontend/src/components/chat/FileContentViewer.tsx`:
+
+```typescript
+"use client";
+
+import * as React from "react";
+import { Loader2, Save } from "lucide-react";
+import type { FileInfo } from "@/hooks/useWorkspaceFiles";
+
+interface FileContentViewerProps {
+  file: FileInfo | null;
+  isLoading: boolean;
+  error: Error | null;
+  onSave?: (content: string) => Promise<void>;
+}
+
+export function FileContentViewer({ file, isLoading, error, onSave }: FileContentViewerProps) {
+  const [editContent, setEditContent] = React.useState("");
+  const [originalContent, setOriginalContent] = React.useState("");
+  const [saving, setSaving] = React.useState(false);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  const dirty = editContent !== originalContent;
+
+  // Sync editor content when a new file loads
+  React.useEffect(() => {
+    if (file?.content != null && !file.binary) {
+      setEditContent(file.content);
+      setOriginalContent(file.content);
+      setSaveError(null);
+    }
+  }, [file?.path, file?.content, file?.binary]);
+
+  // Cmd/Ctrl+S save shortcut
+  const handleSaveRef = React.useRef(handleSave);
+  handleSaveRef.current = handleSave;
+
+  React.useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault();
+        handleSaveRef.current();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  async function handleSave() {
+    if (!onSave || !dirty) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onSave(editContent);
+      setOriginalContent(editContent);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full text-[#8a8578]">
+        <Loader2 className="h-5 w-5 animate-spin mr-2" />
+        Loading file...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-full text-red-500 text-sm">
+        Could not load file.
+      </div>
+    );
+  }
+
+  if (!file) {
+    return (
+      <div className="flex items-center justify-center h-full text-[#8a8578] text-sm">
+        Select a file to view its contents.
+      </div>
+    );
+  }
+
+  // Image preview (read-only)
+  if (file.binary && file.mime_type.startsWith("image/") && file.content) {
+    return (
+      <div className="p-4 flex items-center justify-center">
+        <img
+          src={`data:${file.mime_type};base64,${file.content}`}
+          alt={file.name}
+          className="max-w-full max-h-[80vh] object-contain rounded border border-[#e0dbd0]"
+        />
+      </div>
+    );
+  }
+
+  // Binary file (read-only)
+  if (file.binary || file.content === null) {
+    return (
+      <div className="flex items-center justify-center h-full text-[#8a8578] text-sm">
+        Binary file — preview not available.
+      </div>
+    );
+  }
+
+  // Editable text file
+  return (
+    <div className="flex flex-col h-full">
+      {/* Editor toolbar */}
+      <div className="flex items-center justify-between px-3 py-1.5 bg-[#f3efe6] border-b border-[#e0dbd0] flex-shrink-0">
+        <span className="text-xs text-[#8a8578]">{file.name}</span>
+        <div className="flex items-center gap-2">
+          {dirty && <span className="text-[10px] text-amber-500 font-medium">unsaved</span>}
+          {saveError && <span className="text-[10px] text-red-500">{saveError}</span>}
+          <button
+            onClick={handleSave}
+            disabled={!dirty || saving}
+            className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-[#06402B] text-white hover:bg-[#0a5c3e] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+            Save
+          </button>
+        </div>
+      </div>
+
+      {/* Editor area */}
+      <textarea
+        ref={textareaRef}
+        value={editContent}
+        onChange={(e) => setEditContent(e.target.value)}
+        className="flex-1 w-full p-4 text-sm font-mono bg-white text-[#1a1a1a] resize-none focus:outline-none"
+        spellCheck={false}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Wire onSave callback from FileViewer.tsx**
+
+In `apps/frontend/src/components/chat/FileViewer.tsx`, import `useApi`:
+
+```typescript
+import { useApi } from "@/lib/api";
+```
+
+Inside the `FileViewer` component, add the API hook and save handler:
+
+```typescript
+  const api = useApi();
+
+  const handleSave = React.useCallback(async (content: string) => {
+    if (!agentId || !relativeFilePath) return;
+    await api.saveWorkspaceFile(agentId, relativeFilePath, content, activeTab);
+    // Refresh the tree to pick up size/date changes
+    refresh();
+  }, [agentId, relativeFilePath, activeTab, api, refresh]);
+```
+
+Pass `onSave` to `FileContentViewer`:
+
+```tsx
+          <FileContentViewer
+            file={file}
+            isLoading={fileLoading}
+            error={fileError ?? null}
+            onSave={selectedPath ? handleSave : undefined}
+          />
+```
+
+- [ ] **Step 3: Test visually**
+
+Run: `cd apps/frontend && pnpm run dev`
+Open the file viewer, select a text file (e.g., SOUL.md in Config tab). Verify:
+- Content appears in an editable textarea
+- Editing shows "unsaved" badge
+- Save button + Cmd+S both work
+- After save, "unsaved" disappears
+- Binary/image files remain read-only
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/frontend/src/components/chat/FileContentViewer.tsx apps/frontend/src/components/chat/FileViewer.tsx
+git commit -m "feat(viewer): inline editing with save for text files"
+```
+
+---
+
+### Task 9: Integration test and final verification
+
+**Files:**
+- No new files — this is a verification task
+
+- [ ] **Step 1: Run full backend test suite**
+
+Run: `cd apps/backend && uv run pytest tests/ -v --timeout=30`
+Expected: ALL PASS
+
+- [ ] **Step 2: Run frontend lint and type check**
+
+Run: `cd apps/frontend && pnpm run lint && pnpm tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Run frontend unit tests**
+
+Run: `cd apps/frontend && pnpm test`
+Expected: ALL PASS
+
+- [ ] **Step 4: Manual E2E verification**
+
+Run: `cd apps/frontend && pnpm run dev`
+
+Test the following scenarios:
+1. **Config tab**: Open file viewer → Config tab shows SOUL.md, BOOTSTRAP.md, etc. → Click SOUL.md → Content is editable → Edit and save → Refresh shows saved content
+2. **Workspace tab**: Workspace tab shows agent working files (or empty state if no files yet)
+3. **Upload**: Attach a file (< 10MB) to chat → Send → File appears in Workspace tab under `uploads/`
+4. **File size rejection**: Try to attach a file > 10MB → See error message → File is not added to pending list
+5. **Layout animation**: Open file viewer → Sidebar slides away, chat compresses left → Close → Sidebar returns, chat expands
+6. **Cmd+S**: Edit a file → Press Cmd+S → File saves without clicking button
+
+- [ ] **Step 5: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address integration test feedback"
+```

--- a/docs/superpowers/specs/2026-04-13-file-viewer-v2-design.md
+++ b/docs/superpowers/specs/2026-04-13-file-viewer-v2-design.md
@@ -63,7 +63,7 @@ The file viewer header contains two tabs that switch the entire tree + content c
   - `AGENTS.md` — sub-agent configuration
   - `HEARTBEAT.md` — heartbeat configuration
 - **Excluded:** `sessions/` directory, dotfiles, any other internal OpenClaw state
-- Read-only in V2 (editing via the existing AgentFilesTab in the control panel)
+- Editable inline (see Inline Editing below)
 - Empty state: "No config files found. Agent config files will appear here once the agent is initialized."
 
 **Tab behavior:**
@@ -93,6 +93,34 @@ Changes required:
 - Rejected files show a toast/inline error: `"{filename}" exceeds the 10MB file size limit`
 - Valid files in the same batch still proceed
 - The pending file chip already shows file size — files over 10MB get a red highlight
+
+### Inline Editing
+
+Both tabs support inline editing. The file content viewer doubles as an editor.
+
+**UX:**
+- When a file is selected, its content renders in a `textarea` (monospace, full height) instead of the read-only rendered view
+- For text files (markdown, code, config): the textarea is immediately editable — no "edit mode" toggle needed
+- An "unsaved" indicator appears in the header when content has been modified
+- **Save:** Cmd/Ctrl+S saves, or a Save button in the file header. Save writes directly to EFS via a new backend endpoint.
+- **Discard:** Clicking a different file or switching tabs discards unsaved changes (with a confirmation if dirty)
+- Binary files and images remain read-only (no textarea)
+
+**Write mechanism — direct EFS, no gateway RPC:**
+- All saves go through the backend's new `PUT /container/workspace/{agent_id}/file` endpoint
+- Backend writes to the correct EFS path (`workspaces/{agent_id}/` for Workspace tab, `agents/{agent_id}/` for Config tab)
+- Backend `chown`s to 1000:1000 after write
+- OpenClaw's Chokidar file watcher (`CHOKIDAR_USEPOLLING=true`) detects the change and reloads
+- This replaces the `agents.files.set` gateway RPC for config file editing — direct EFS writes are more reliable (work when container is stopped, no gateway dependency)
+
+**Config tab writes:**
+- Only the 8 allowlisted files can be written (400 for anything else)
+- The endpoint validates the filename against the allowlist before writing
+
+**Deprecation of AgentFilesTab:**
+- The existing `AgentFilesTab` in the control panel (`panels/AgentFilesTab.tsx`) uses `agents.files.set` RPC
+- Once the file viewer editing is live, `AgentFilesTab` becomes redundant
+- Remove it in a follow-up (not in this PR) to avoid scope creep
 
 ### File Path Detection Update
 
@@ -142,6 +170,25 @@ Returns content for a single allowlisted config file from `agents/{agent_id}/`.
 - Uses the same `read_file_info()` method as the workspace file endpoint
 - Same response format as `GET .../file`
 
+### New: `PUT /api/v1/container/workspace/{agent_id}/file`
+
+Writes a file to the agent's workspace or config directory.
+
+**Request body:**
+```json
+{
+  "path": "plan.md",
+  "content": "# My Plan\n...",
+  "tab": "workspace"
+}
+```
+
+- `tab` is `"workspace"` or `"config"`
+- When `tab=workspace`: writes to `workspaces/{agent_id}/{path}`. Path validated against traversal. Directories created as needed.
+- When `tab=config`: writes to `agents/{agent_id}/{path}`. `path` must be one of the 8 allowlisted filenames (400 otherwise).
+- File is `chown`ed to 1000:1000 after write (Chokidar picks up the change)
+- Returns `{ "status": "ok", "path": "<written_path>" }`
+
 ## Frontend Changes
 
 ### ChatLayout.tsx
@@ -160,6 +207,16 @@ Returns content for a single allowlisted config file from `agents/{agent_id}/`.
   - Workspace: existing `useWorkspaceTree(agentId)` + `useWorkspaceFile(agentId, path)`
   - Config: new `useConfigFiles(agentId)` + `useConfigFile(agentId, path)`
 - Selected file resets on tab switch
+
+### FileContentViewer.tsx
+
+- Text files render in an editable `textarea` (monospace) instead of read-only rendered view
+- Track dirty state (content !== original)
+- Header shows "unsaved" badge when dirty
+- Save button + Cmd/Ctrl+S keyboard shortcut
+- Save calls new `api.saveWorkspaceFile(agentId, path, content, tab)` method
+- Confirmation dialog on navigate-away when dirty
+- Binary/image files remain read-only
 
 ### useWorkspaceFiles.ts
 
@@ -182,6 +239,7 @@ export function useConfigFile(agentId: string | null, filePath: string | null)
 ### api.ts
 
 - `uploadFiles(files, agentId)` — add `agentId` param, append as query string
+- `saveWorkspaceFile(agentId, path, content, tab)` — new method, `PUT /container/workspace/{agentId}/file`
 
 ### AgentChatWindow.tsx
 
@@ -192,9 +250,10 @@ export function useConfigFile(agentId: string | null, filePath: string | null)
 | File | Change |
 |------|--------|
 | `apps/backend/routers/container_rpc.py` | Add `agent_id` param to upload endpoint, change dest path |
-| `apps/backend/routers/workspace_files.py` | Add config-files and config-file endpoints |
+| `apps/backend/routers/workspace_files.py` | Add config-files, config-file, and file write endpoints |
 | `apps/frontend/src/components/chat/ChatLayout.tsx` | Animated grid transition, hide sidebar |
 | `apps/frontend/src/components/chat/FileViewer.tsx` | Two tabs (Workspace/Config), tab state |
+| `apps/frontend/src/components/chat/FileContentViewer.tsx` | Inline editing with save, dirty state, Cmd+S |
 | `apps/frontend/src/components/chat/ChatInput.tsx` | Client-side 10MB validation |
 | `apps/frontend/src/hooks/useWorkspaceFiles.ts` | Add useConfigFiles, useConfigFile hooks |
 | `apps/frontend/src/lib/api.ts` | Add agentId to uploadFiles |
@@ -202,8 +261,8 @@ export function useConfigFile(agentId: string | null, filePath: string | null)
 
 ## Not in This Version
 
-- File editing in the viewer (use AgentFilesTab in control panel)
 - Real-time file change push (manual refresh button)
 - File download
 - Search within files
 - Drag-to-resize the chat/viewer split
+- Removing AgentFilesTab from control panel (follow-up after this ships)

--- a/docs/superpowers/specs/2026-04-13-file-viewer-v2-design.md
+++ b/docs/superpowers/specs/2026-04-13-file-viewer-v2-design.md
@@ -1,0 +1,209 @@
+# File Viewer V2 — Design Spec
+
+**Date:** 2026-04-13
+**Status:** Approved
+**Supersedes:** 2026-04-03-workspace-file-viewer-design.md (V1)
+
+## Problem
+
+The V1 file viewer has three bugs:
+
+1. **Empty workspace** — The viewer browses `workspaces/{agent_id}/` but agent personality files (SOUL.md, BOOTSTRAP.md, etc.) live in `agents/{agent_id}/`. For agents that haven't created working files yet, the viewer shows "No files in workspace" despite the agent having files.
+2. **Uploads invisible** — File uploads write to `{user_root}/uploads/` which is outside the viewed directory tree. Uploaded files never appear in the viewer.
+3. **No client-side file size validation** — The 10MB backend limit exists but the frontend doesn't warn users before uploading.
+
+Additionally, the V1 layout splits chat and file viewer 50/50, which wastes horizontal space — chat is naturally narrow, files need width.
+
+## Design
+
+### Layout Change
+
+When the file viewer opens, the layout transforms from the normal chat view into a split-pane IDE-style layout with a 200ms ease CSS transition.
+
+**Normal (file viewer closed):**
+```
+[Sidebar 260px] [Chat 1fr                                      ]
+```
+
+**File viewer open (sidebar hidden):**
+```
+[Chat ~380px               ] [File Viewer 1fr                              ]
+ | Connection bar           |  | Header: [Workspace] [Config] tabs         |
+ | Messages (scrollable)    |  | File tree   |  File content               |
+ | ...                      |  | (220px)     |  (rest)                     |
+ | Chat input (bottom)      |  |             |                             |
+```
+
+Key behaviors:
+- **Sidebar hides** when file viewer opens, reappears on close
+- **Chat compresses** to ~380px fixed width — still fully functional (messages scroll, input works, streaming continues)
+- **File viewer** gets the remaining space (majority of screen)
+- **200ms ease transition** on open/close for the grid change
+- **Close button** (X) in file viewer header restores normal layout
+
+### Two Tabs: Workspace and Config
+
+The file viewer header contains two tabs that switch the entire tree + content context.
+
+**Workspace tab (default):**
+- Browses `workspaces/{agent_id}/` on EFS — files the agent creates during conversations (plans, code, outputs, uploads)
+- This is the agent's working directory
+- Uploads now write here (see Upload Fix below)
+- Empty state: "No files yet. Your agent will create files here as it works."
+
+**Config tab:**
+- Browses `agents/{agent_id}/` on EFS — agent personality and configuration files
+- **Allowlisted files only** (not a raw directory listing):
+  - `SOUL.md` — agent personality
+  - `BOOTSTRAP.md` — first-run instructions
+  - `MEMORY.md` — agent memory
+  - `TOOLS.md` — tool configuration
+  - `IDENTITY.md` — identity
+  - `USER.md` — user context
+  - `AGENTS.md` — sub-agent configuration
+  - `HEARTBEAT.md` — heartbeat configuration
+- **Excluded:** `sessions/` directory, dotfiles, any other internal OpenClaw state
+- Read-only in V2 (editing via the existing AgentFilesTab in the control panel)
+- Empty state: "No config files found. Agent config files will appear here once the agent is initialized."
+
+**Tab behavior:**
+- Clicking a file path in chat opens the Workspace tab (since agent-referenced paths are workspace paths)
+- Manual open via folder icon defaults to Workspace tab
+- Tab selection persists while the viewer is open but resets on close
+- Switching tabs clears the selected file
+
+### Upload Path Fix
+
+**Current (broken):** Files upload to `{user_root}/uploads/{filename}` — invisible to file viewer.
+
+**Fixed:** Files upload to `{user_root}/workspaces/{agent_id}/uploads/{filename}` — visible in the Workspace tab.
+
+Changes required:
+
+1. **Backend `POST /container/files`** — add required `agent_id` query parameter. Validate agent_id (no `/`, `\`, `..`). Write to `workspaces/{agent_id}/uploads/{safe_name}` instead of `uploads/{safe_name}`.
+2. **Agent-visible path** — changes from `.openclaw/uploads/{filename}` to `.openclaw/workspaces/{agent_id}/uploads/{filename}`.
+3. **Frontend `api.uploadFiles()`** — accept `agentId` parameter, pass as query param.
+4. **Frontend `AgentChatWindow.handleSend()`** — pass current `agentId` to upload call.
+5. **Chat file notice** — update the prepended message to reference the new path.
+
+### Client-Side File Size Validation
+
+- **10MB per-file limit** enforced in the frontend before upload
+- Files exceeding 10MB are rejected at selection time (both file picker and drag-drop)
+- Rejected files show a toast/inline error: `"{filename}" exceeds the 10MB file size limit`
+- Valid files in the same batch still proceed
+- The pending file chip already shows file size — files over 10MB get a red highlight
+
+### File Path Detection Update
+
+The existing `filePathDetection.ts` regex detects agent file paths in chat messages and wraps them in `isol8-file://` links. These paths are relative to the agent's workspace (e.g., `plan.md`, `uploads/data.csv`). No change needed — clicking detected paths opens the Workspace tab with the correct relative path.
+
+## Backend API Changes
+
+### Modified: `POST /api/v1/container/files`
+
+Add `agent_id` query parameter:
+
+```
+POST /api/v1/container/files?agent_id={agent_id}
+```
+
+- `agent_id` is required (400 if missing)
+- Validated: no `/`, `\`, `..` characters
+- Files written to `workspaces/{agent_id}/uploads/{safe_name}`
+- Agent-visible path: `.openclaw/workspaces/{agent_id}/uploads/{filename}`
+- Existing 10MB/10-file limits unchanged
+
+### Modified: `GET /api/v1/container/workspace/{agent_id}/tree`
+
+No API change. The endpoint already browses `workspaces/{agent_id}/`. The Workspace tab uses it as-is.
+
+### New: `GET /api/v1/container/workspace/{agent_id}/config-files`
+
+Returns only the allowlisted config files from `agents/{agent_id}/`.
+
+**Response:**
+```json
+{
+  "files": [
+    { "name": "SOUL.md", "path": "SOUL.md", "type": "file", "size": 1234, "modified_at": 1712000000.0 },
+    { "name": "BOOTSTRAP.md", "path": "BOOTSTRAP.md", "type": "file", "size": 567, "modified_at": 1712000000.0 }
+  ]
+}
+```
+
+Only files that exist on disk AND are in the allowlist are returned. No directory traversal, no recursive listing.
+
+### New: `GET /api/v1/container/workspace/{agent_id}/config-file?path=...`
+
+Returns content for a single allowlisted config file from `agents/{agent_id}/`.
+
+- `path` must be one of the 8 allowlisted filenames (400 otherwise)
+- Uses the same `read_file_info()` method as the workspace file endpoint
+- Same response format as `GET .../file`
+
+## Frontend Changes
+
+### ChatLayout.tsx
+
+- New CSS grid states with transition:
+  - Closed: `grid-template-columns: 260px 1fr` (current)
+  - Open: `grid-template-columns: 0px 380px 1fr` (sidebar width → 0, overflow hidden)
+- `transition: grid-template-columns 200ms ease` on the grid container
+- Sidebar gets `overflow: hidden` and `opacity: 0` during transition to prevent flash
+
+### FileViewer.tsx
+
+- Add tab state: `activeTab: "workspace" | "config"`
+- Header renders two tab buttons styled as underline tabs
+- Tab switch swaps the data source:
+  - Workspace: existing `useWorkspaceTree(agentId)` + `useWorkspaceFile(agentId, path)`
+  - Config: new `useConfigFiles(agentId)` + `useConfigFile(agentId, path)`
+- Selected file resets on tab switch
+
+### useWorkspaceFiles.ts
+
+Add two new hooks:
+
+```typescript
+export function useConfigFiles(agentId: string | null)
+// GET /container/workspace/{agentId}/config-files
+
+export function useConfigFile(agentId: string | null, filePath: string | null)
+// GET /container/workspace/{agentId}/config-file?path={filePath}
+```
+
+### ChatInput.tsx
+
+- On file selection (picker + drag-drop), filter out files > 10MB
+- Show inline error for rejected files: `"{name}" exceeds the 10MB limit`
+- Error auto-dismisses after 5 seconds or on next file selection
+
+### api.ts
+
+- `uploadFiles(files, agentId)` — add `agentId` param, append as query string
+
+### AgentChatWindow.tsx
+
+- Pass `agentId` to `api.uploadFiles(files, agentId)` in `handleSend`
+
+## File Changes Summary
+
+| File | Change |
+|------|--------|
+| `apps/backend/routers/container_rpc.py` | Add `agent_id` param to upload endpoint, change dest path |
+| `apps/backend/routers/workspace_files.py` | Add config-files and config-file endpoints |
+| `apps/frontend/src/components/chat/ChatLayout.tsx` | Animated grid transition, hide sidebar |
+| `apps/frontend/src/components/chat/FileViewer.tsx` | Two tabs (Workspace/Config), tab state |
+| `apps/frontend/src/components/chat/ChatInput.tsx` | Client-side 10MB validation |
+| `apps/frontend/src/hooks/useWorkspaceFiles.ts` | Add useConfigFiles, useConfigFile hooks |
+| `apps/frontend/src/lib/api.ts` | Add agentId to uploadFiles |
+| `apps/frontend/src/components/chat/AgentChatWindow.tsx` | Pass agentId to uploadFiles |
+
+## Not in This Version
+
+- File editing in the viewer (use AgentFilesTab in control panel)
+- Real-time file change push (manual refresh button)
+- File download
+- Search within files
+- Drag-to-resize the chat/viewer split


### PR DESCRIPTION
## Summary

Fixes three bugs in the file viewer and redesigns the layout as an IDE-style split pane.

- **Empty Workspace viewer fixed:** adds a Config tab that exposes allowlisted agent personality files (SOUL.md, BOOTSTRAP.md, MEMORY.md, TOOLS.md, IDENTITY.md, USER.md, HEARTBEAT.md, AGENTS.md) from `agents/{agent_id}/`.
- **Upload fix:** `POST /container/files` now requires an `agent_id` and writes to `workspaces/{agent_id}/uploads/` so uploaded files appear in the Workspace tab and the agent can see them at `.openclaw/workspaces/{agent_id}/uploads/`.
- **Client-side 10MB file size validation** with inline dismissible error; matches the existing server-side cap.
- **Inline editing** for text files in both tabs with dirty tracking, Save button, Cmd/Ctrl+S shortcut, and unsaved-change prompt before switching files. Saves go through a new `PUT /container/workspace/{agent_id}/file` endpoint that writes direct to EFS (Chokidar picks up the change) — replaces the container-gateway `agents.files.set` RPC for config edits (AgentFilesTab removal is a follow-up).
- **Layout transformation when viewer opens:** sidebar hides, chat compresses to 380px, viewer gets the rest. 3-track grid so `grid-template-columns` actually animates (track-count change would have silently skipped the transition). Hidden sidebar gets `visibility: hidden` after the fade so it's out of the tab order / AT tree.
- **Tab semantics:** `role="tablist"` + `role="tab"` + `aria-selected` + `role="tabpanel"` on the Workspace/Config selector.

Spec: `docs/superpowers/specs/2026-04-13-file-viewer-v2-design.md`
Plan: `docs/superpowers/plans/2026-04-13-file-viewer-v2.md`

## Backend API changes

- `POST /container/files?agent_id=...` — new required query param; writes to `workspaces/{agent_id}/uploads/{filename}`.
- `GET /container/workspace/{agent_id}/config-files` — new; returns allowlisted config files present on disk.
- `GET /container/workspace/{agent_id}/config-file?path=...` — new; reads one allowlisted config file.
- `PUT /container/workspace/{agent_id}/file` — new; body `{path, content, tab}`; writes to `workspaces/{agent_id}/` or `agents/{agent_id}/` based on `tab`. Rejects traversal, path containing `..` segments, non-allowlisted config filenames, content >10MB.
- `GET /container/workspace/{agent_id}/tree` — now returns agent-relative paths (previously returned user-root-relative paths, which caused a double-prefix 404 when the frontend tried to read them back).

## Security

- Allowlist enforced server-side on both list and read endpoints.
- `_validate_relative_path` rejects `..` segments, absolute paths, and empty paths on writes. This prevents a `tab="workspace"` write with `path="../../agents/{id}/SOUL.md"` bypassing the config allowlist.
- `agent_id` traversal guards on all new endpoints (400 on `../`, `/`, `\`).
- 10MB content cap enforced both client-side (before upload/save) and server-side.

## Test plan

- [x] Backend unit + handler tests: `cd apps/backend && CLERK_ISSUER=https://up-moth-55.clerk.accounts.dev uv run pytest tests/` — 650 passed
- [x] Frontend lint: `cd apps/frontend && pnpm run lint` — clean
- [x] Frontend typecheck: `cd apps/frontend && pnpm tsc --noEmit` — clean
- [x] Cross-task integration review caught and fixed a double-prefix 404 on workspace-tree file clicks
- [ ] Manual E2E in dev — open viewer, verify Config tab shows SOUL.md etc., edit and save a config file, upload a file and verify it appears in Workspace tab, try to upload >10MB and verify rejection, verify sidebar hides with animation

## Deferred to follow-ups

- Remove `AgentFilesTab` from the control panel (now redundant with Config tab)
- `aria-label` on the textarea editor
- `FolderOpen` header button passing `""` vs `null` (works by accident)
- Agent-switch-during-save race hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)