### PR TITLE
feat(landing): lead hero with one-click-agent value prop

### DIFF
--- a/apps/frontend/src/components/landing/Hero.tsx
+++ b/apps/frontend/src/components/landing/Hero.tsx
@@ -151,16 +151,16 @@ export function Hero() {
   return (
     <section className="landing-hero">
       <div className="hero-left">
-        <p className="eyebrow">isol8 — private AI pods</p>
+        <p className="eyebrow">isol8 — automated workflows</p>
         <h1 className="hero-h1">
-          An agent for <em>every part</em>
+          Deploy an agent
           <br />
-          of your business.
+          <em>in one click.</em>
         </h1>
         <p className="hero-sub">
-          Your isol8 pod is a dedicated AI environment — isolated, persistent,
-          and personal. It knows your history, matches your voice, connects to
-          your tools, and works autonomously so you don&apos;t have to.
+          Pre-built agents for every branch of your business. Pick one, click
+          deploy — it connects to the tools you already use and runs the
+          workflow autonomously.
         </p>
         <div className="hero-ctas">
           <Link href="/chat" className="btn-large">


### PR DESCRIPTION
Updates the hero eyebrow, headline, and subhead on the landing page to lead with the real value prop -- one-click deployable agents that automate business workflows -- instead of the abstract "private AI pods" framing.

Also fixes a visual bug where "every" in the previous headline ("An agent for every part of your business") cropped on narrower viewports because the italicized "every part" overflowed the hero column at the clamped font size.

Before:
  eyebrow:  "isol8 -- private AI pods"
  h1:       "An agent for every part of your business."
  sub:      "Your isol8 pod is a dedicated AI environment -- isolated,
             persistent, and personal. It knows your history, matches
             your voice..."

After:
  eyebrow:  "isol8 -- automated workflows"
  h1:       "Deploy an agent in one click."  (emphasis on "in one click")
  sub:      "Pre-built agents for every branch of your business. Pick one,
             click deploy -- it connects to the tools you already use and
             runs the workflow autonomously."

CTAs unchanged: "Start your pod" / "Learn more". The workflow animation on the right half of the hero is untouched.