### PR TITLE
feat(chat): tool input/output + real-time thinking

### DIFF
--- a/apps/backend/core/containers/config.py
+++ b/apps/backend/core/containers/config.py
@@ -339,7 +339,25 @@ def write_openclaw_config(
                 "llm": {
                     "idleTimeoutSeconds": 300,
                 },
+                # verboseDefault="full" keeps tool result/partialResult in
+                # agent events so the frontend can show tool input + output.
+                # OpenClaw defaults to "off" which strips those fields before
+                # they reach our WebSocket subscriber.
+                "verboseDefault": "full",
             },
+            # Per-agent settings. reasoningDefault is not allowed in
+            # agents.defaults (see openclaw zod-schema.agent-defaults.ts), so
+            # we declare the implicit "main" agent explicitly here to opt it
+            # into real-time thinking streams. User-created agents inherit it
+            # via AgentCreateForm passing reasoningDefault: "stream" on
+            # agents.create.
+            "list": [
+                {
+                    "id": "main",
+                    "default": True,
+                    "reasoningDefault": "stream",
+                },
+            ],
         },
         "memory": {
             "backend": "qmd",

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -311,17 +311,27 @@ class GatewayConnection:
                 return None
             tool_call_id = data.get("toolCallId", "")
             if phase == "start":
+                # OpenClaw never strips `args` — it's safe to forward at any
+                # verboseLevel. Shows the user what the tool was called with.
                 msg: dict = {"type": "tool_start", "tool": name}
                 if tool_call_id:
                     msg["toolCallId"] = tool_call_id
+                if "args" in data:
+                    msg["args"] = data["args"]
                 return msg
             if phase == "result":
                 # OpenClaw signals tool errors via isError flag on the result
-                # phase, not a separate "error" phase.
+                # phase, not a separate "error" phase. `result` and `meta`
+                # are only populated when verboseLevel is "full" (set in
+                # agents.defaults.verboseDefault).
                 is_error = bool(data.get("isError"))
                 msg = {"type": "tool_error" if is_error else "tool_end", "tool": name}
                 if tool_call_id:
                     msg["toolCallId"] = tool_call_id
+                if "result" in data:
+                    msg["result"] = data["result"]
+                if data.get("meta"):
+                    msg["meta"] = data["meta"]
                 return msg
             return None
 

--- a/apps/backend/routers/debug.py
+++ b/apps/backend/routers/debug.py
@@ -143,9 +143,12 @@ async def redeploy_container(
                     "models": tier_cfg.get("model_aliases", {}),
                     "verboseDefault": "full",
                 },
-                "list": [
-                    {"id": "main", "default": True, "reasoningDefault": "stream"},
-                ],
+                # Don't patch `agents.list` here — `_deep_merge` replaces
+                # arrays wholesale, which would clobber user-created agents
+                # persisted via OpenClaw's `agents.create` RPC. The initial
+                # write in `write_openclaw_config` sets up `main` on first
+                # provision; existing containers keep whatever list is
+                # already on EFS.
             },
         }
 

--- a/apps/backend/routers/debug.py
+++ b/apps/backend/routers/debug.py
@@ -141,7 +141,11 @@ async def redeploy_container(
                 "defaults": {
                     "model": {"primary": tier_cfg["primary_model"]},
                     "models": tier_cfg.get("model_aliases", {}),
+                    "verboseDefault": "full",
                 },
+                "list": [
+                    {"id": "main", "default": True, "reasoningDefault": "stream"},
+                ],
             },
         }
 

--- a/apps/backend/tests/unit/core/test_chat_event_transform.py
+++ b/apps/backend/tests/unit/core/test_chat_event_transform.py
@@ -85,25 +85,71 @@ class TestTransformAgentEvent:
 
     def test_tool_stream_start_phase(self):
         result = GatewayConnection._transform_agent_event(
+            {
+                "stream": "tool",
+                "data": {
+                    "name": "web_search",
+                    "phase": "start",
+                    "toolCallId": "abc-123",
+                    "args": {"query": "weather in Berwyn"},
+                },
+            }
+        )
+        assert result == {
+            "type": "tool_start",
+            "tool": "web_search",
+            "toolCallId": "abc-123",
+            "args": {"query": "weather in Berwyn"},
+        }
+
+    def test_tool_stream_start_without_args(self):
+        """args key missing — output omits it rather than sending null."""
+        result = GatewayConnection._transform_agent_event(
             {"stream": "tool", "data": {"name": "web_search", "phase": "start", "toolCallId": "abc-123"}}
         )
         assert result == {"type": "tool_start", "tool": "web_search", "toolCallId": "abc-123"}
 
     def test_tool_stream_result_phase(self):
         result = GatewayConnection._transform_agent_event(
-            {"stream": "tool", "data": {"name": "web_search", "phase": "result", "toolCallId": "abc-123"}}
+            {
+                "stream": "tool",
+                "data": {
+                    "name": "web_search",
+                    "phase": "result",
+                    "toolCallId": "abc-123",
+                    "result": [{"type": "text", "text": "72°F"}],
+                    "meta": "Berwyn, PA",
+                },
+            }
         )
-        assert result == {"type": "tool_end", "tool": "web_search", "toolCallId": "abc-123"}
+        assert result == {
+            "type": "tool_end",
+            "tool": "web_search",
+            "toolCallId": "abc-123",
+            "result": [{"type": "text", "text": "72°F"}],
+            "meta": "Berwyn, PA",
+        }
 
     def test_tool_stream_result_with_is_error(self):
         """OpenClaw signals tool errors via isError on the result phase."""
         result = GatewayConnection._transform_agent_event(
             {
                 "stream": "tool",
-                "data": {"name": "web_search", "phase": "result", "toolCallId": "abc-123", "isError": True},
+                "data": {
+                    "name": "web_search",
+                    "phase": "result",
+                    "toolCallId": "abc-123",
+                    "isError": True,
+                    "result": [{"type": "text", "text": "Perplexity API 404"}],
+                },
             }
         )
-        assert result == {"type": "tool_error", "tool": "web_search", "toolCallId": "abc-123"}
+        assert result == {
+            "type": "tool_error",
+            "tool": "web_search",
+            "toolCallId": "abc-123",
+            "result": [{"type": "text", "text": "Perplexity API 404"}],
+        }
 
     def test_tool_stream_update_phase_ignored(self):
         """Intermediate tool updates are not forwarded."""

--- a/apps/frontend/src/components/chat/MessageList.tsx
+++ b/apps/frontend/src/components/chat/MessageList.tsx
@@ -9,10 +9,20 @@ import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 
+interface ToolResultBlock {
+  type: string;
+  text?: string;
+  bytes?: number;
+  omitted?: boolean;
+}
+
 interface ToolUse {
   tool: string;
   toolCallId?: string;
   status: "running" | "done" | "error";
+  args?: Record<string, unknown>;
+  result?: ToolResultBlock[];
+  meta?: string;
 }
 
 interface Message {
@@ -171,26 +181,82 @@ const TOOL_STYLES = {
   },
 } as const;
 
+function renderToolResult(blocks: ToolResultBlock[] | undefined): string | null {
+  if (!blocks?.length) return null;
+  const parts: string[] = [];
+  for (const b of blocks) {
+    if (b.type === "text" && b.text) parts.push(b.text);
+    else if (b.omitted) parts.push(`[${b.type} — ${b.bytes ?? "?"} bytes, omitted]`);
+  }
+  return parts.join("\n\n") || null;
+}
+
+function ToolPill({ t }: { t: ToolUse }) {
+  const [open, setOpen] = React.useState(false);
+  const s = TOOL_STYLES[t.status];
+  const hasDetails = !!(t.args || t.result || t.meta);
+
+  return (
+    <div className="inline-block">
+      <button
+        type="button"
+        onClick={() => hasDetails && setOpen((v) => !v)}
+        disabled={!hasDetails}
+        className={cn(
+          "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border transition-colors",
+          s.pill,
+          hasDetails ? "cursor-pointer hover:brightness-95" : "cursor-default",
+        )}
+        aria-expanded={open}
+      >
+        <span className={cn("w-1.5 h-1.5 rounded-full", s.dot)} />
+        <span>{t.tool}</span>
+        {t.status === "error" && <span>failed</span>}
+        {hasDetails &&
+          (open ? (
+            <ChevronDown className="h-3 w-3 opacity-70" />
+          ) : (
+            <ChevronRight className="h-3 w-3 opacity-70" />
+          ))}
+      </button>
+      {open && hasDetails && (
+        <div className="mt-1.5 max-w-xl rounded-md border border-[#e0dbd0] bg-[#faf7f2] p-2 text-xs space-y-2">
+          {t.meta && (
+            <div className="text-[#8a8578]">
+              <span className="font-medium text-[#302d28]">target:</span> {t.meta}
+            </div>
+          )}
+          {t.args && Object.keys(t.args).length > 0 && (
+            <div>
+              <div className="font-medium text-[#302d28] mb-0.5">input</div>
+              <pre className="whitespace-pre-wrap break-words text-[#302d28] bg-[#f3efe6] rounded px-2 py-1 max-h-48 overflow-auto">
+                {JSON.stringify(t.args, null, 2)}
+              </pre>
+            </div>
+          )}
+          {renderToolResult(t.result) && (
+            <div>
+              <div className="font-medium text-[#302d28] mb-0.5">
+                {t.status === "error" ? "error" : "output"}
+              </div>
+              <pre className="whitespace-pre-wrap break-words text-[#302d28] bg-[#f3efe6] rounded px-2 py-1 max-h-48 overflow-auto">
+                {renderToolResult(t.result)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ToolUseIndicator({ toolUses }: { toolUses: ToolUse[] }) {
   if (toolUses.length === 0) return null;
   return (
-    <div className="mb-3 flex flex-wrap gap-2">
-      {toolUses.map((t, i) => {
-        const s = TOOL_STYLES[t.status];
-        return (
-          <span
-            key={t.toolCallId ?? `${t.tool}-${i}`}
-            className={cn(
-              "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border",
-              s.pill,
-            )}
-          >
-            <span className={cn("w-1.5 h-1.5 rounded-full", s.dot)} />
-            {t.tool}
-            {t.status === "error" && " failed"}
-          </span>
-        );
-      })}
+    <div className="mb-3 flex flex-wrap gap-2 items-start">
+      {toolUses.map((t, i) => (
+        <ToolPill key={t.toolCallId ?? `${t.tool}-${i}`} t={t} />
+      ))}
     </div>
   );
 }

--- a/apps/frontend/src/components/control/panels/AgentCreateForm.tsx
+++ b/apps/frontend/src/components/control/panels/AgentCreateForm.tsx
@@ -38,7 +38,13 @@ export function AgentCreateForm({ existingIds, onCreated, onCancel }: AgentCreat
     setError(null);
 
     try {
-      await callRpc("agents.create", { name: name.trim(), workspace: "agents/" + normalizedId });
+      await callRpc("agents.create", {
+        name: name.trim(),
+        workspace: "agents/" + normalizedId,
+        // Match the main agent's default so new agents stream thinking
+        // events in real time instead of batching at chat.final.
+        reasoningDefault: "stream",
+      });
       onCreated();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -13,7 +13,12 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
-import { useGateway, type ChatIncomingMessage, type BudgetExceededPayload } from "@/hooks/useGateway";
+import {
+  useGateway,
+  type ChatIncomingMessage,
+  type BudgetExceededPayload,
+  type ToolResultBlock,
+} from "@/hooks/useGateway";
 
 // =============================================================================
 // Friendly error messages
@@ -73,6 +78,9 @@ export interface ToolUse {
   tool: string;
   toolCallId?: string;
   status: "running" | "done" | "error";
+  args?: Record<string, unknown>;
+  result?: ToolResultBlock[];
+  meta?: string;
 }
 
 export interface AgentMessage {
@@ -328,6 +336,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
                         tool: msg.tool,
                         toolCallId: msg.toolCallId,
                         status: "running" as const,
+                        ...(msg.args ? { args: msg.args } : {}),
                       },
                     ],
                   }
@@ -351,9 +360,15 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
                 const matchesName =
                   msg.toolCallId === undefined && t.tool === msg.tool;
                 const isRunning = t.status === "running";
-                return isRunning && (matchesCallId || matchesName)
-                  ? { ...t, status: nextStatus as "done" | "error" }
-                  : t;
+                if (isRunning && (matchesCallId || matchesName)) {
+                  return {
+                    ...t,
+                    status: nextStatus as "done" | "error",
+                    ...(msg.result ? { result: msg.result } : {}),
+                    ...(msg.meta ? { meta: msg.meta } : {}),
+                  };
+                }
+                return t;
               });
               return { ...m, toolUses };
             }),

--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -40,15 +40,41 @@ export interface BudgetExceededPayload {
   tier: string;
 }
 
+/**
+ * OpenClaw tool result content blocks — text blocks or image refs. Image
+ * data is replaced with `{ bytes, omitted: true }` by OpenClaw's sanitizer.
+ */
+export type ToolResultBlock = { type: string; text?: string; bytes?: number; omitted?: boolean };
+
 export type ChatIncomingMessage =
   | { type: "chunk"; content: string; agent_id?: string }
   | { type: "thinking"; content: string; agent_id?: string }
   | { type: "done"; agent_id?: string }
   | { type: "error"; message: string; code?: string; agent_id?: string } & Partial<BudgetExceededPayload>
   | { type: "heartbeat" }
-  | { type: "tool_start"; tool: string; toolCallId?: string; agent_id?: string }
-  | { type: "tool_end"; tool: string; toolCallId?: string; agent_id?: string }
-  | { type: "tool_error"; tool: string; toolCallId?: string; agent_id?: string }
+  | {
+      type: "tool_start";
+      tool: string;
+      toolCallId?: string;
+      args?: Record<string, unknown>;
+      agent_id?: string;
+    }
+  | {
+      type: "tool_end";
+      tool: string;
+      toolCallId?: string;
+      result?: ToolResultBlock[];
+      meta?: string;
+      agent_id?: string;
+    }
+  | {
+      type: "tool_error";
+      tool: string;
+      toolCallId?: string;
+      result?: ToolResultBlock[];
+      meta?: string;
+      agent_id?: string;
+    }
   | { type: "update_available" };
 
 /** Gateway event forwarded from OpenClaw */


### PR DESCRIPTION
## Summary
- Adds `agents.list: [{id: "main", default: true, reasoningDefault: "stream"}]` to the container config so OpenClaw emits real-time `stream: "thinking"` agent events during generation (instead of batching reasoning at `chat.final`)
- Passes `reasoningDefault: "stream"` on `agents.create` so user-created agents match
- Sets `agents.defaults.verboseDefault: "full"` so OpenClaw stops stripping `result`/`partialResult` from tool events
- Backend transformer now forwards `args` on `tool_start` and `result`/`meta` on `tool_end`/`tool_error`
- Frontend tool pills are click-to-expand — reveal input (JSON) and output (text, up to OpenClaw's 8KB sanitizer cap)

## Why
Follow-up to #258. After that PR shipped we could see tool pills, but:
- Pills were just names — no input or output visible
- Thinking still only appeared batch-at-end, not during generation

Research traced this to two config knobs (`verboseDefault`, `reasoningDefault`) that OpenClaw gates these features behind. Setting them at provision time closes the loop.

## Test plan
- [x] `pytest tests/unit` — 558 passing
- [x] `ruff check` / `tsc --noEmit` / `eslint` — clean
- [ ] Dev deploy + reprovision container (`PATCH /debug/provision`) to pick up the new openclaw.json
- [ ] Ask agent to read a file → tool pill expands to show `{"path": "..."}` and the file contents
- [ ] Ask agent to do something reasoning-heavy → thinking text streams token-by-token in the ThinkingBlock

## Migration
Existing containers need `PATCH /container/config/{owner_id}` (Track 1) or full reprovision to get the new `verboseDefault`/`agents.list`. New containers get them on first boot. User-created agents from before this PR won't have `reasoningDefault: "stream"` — they'd need an `agents.update` call or deletion + recreation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)