### PR TITLE
feat: add PostHog analytics integration

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -33,6 +33,7 @@
     "lucide-react": "^0.562.0",
     "nanoid": "^5.1.6",
     "next": "16.1.1",
+    "posthog-js": "^1.368.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono, Host_Grotesk, DM_Sans, Lora, Press_Start_2P, Epilogu
 import { ClerkProvider } from "@clerk/nextjs";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { DesktopAuthListener } from "@/components/DesktopAuthListener";
+import { PostHogProvider } from "@/components/PostHogProvider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -63,8 +64,10 @@ export default function RootLayout({
           className={`${geistSans.variable} ${geistMono.variable} ${hostGrotesk.variable} ${dmSans.variable} ${lora.variable} ${pressStart2P.variable} ${epilogue.variable} antialiased`}
         >
           <ErrorBoundary>
-            <DesktopAuthListener />
-            {children}
+            <PostHogProvider>
+              <DesktopAuthListener />
+              {children}
+            </PostHogProvider>
           </ErrorBoundary>
         </body>
       </html>

--- a/apps/frontend/src/app/onboarding/page.tsx
+++ b/apps/frontend/src/app/onboarding/page.tsx
@@ -10,6 +10,7 @@ import {
   useUser,
 } from "@clerk/nextjs";
 import { useApi } from "@/lib/api";
+import { usePostHog } from "posthog-js/react";
 import { Button } from "@/components/ui/button";
 import { User, Users, Mail } from "lucide-react";
 
@@ -23,6 +24,7 @@ export default function OnboardingPage() {
     userInvitations: true,
   });
   const api = useApi();
+  const posthog = usePostHog();
   const [loading, setLoading] = useState(false);
   const [acceptingId, setAcceptingId] = useState<string | null>(null);
 
@@ -97,6 +99,7 @@ export default function OnboardingPage() {
   async function handleAcceptInvitation(invitationId: string) {
     setAcceptingId(invitationId);
     try {
+      posthog?.capture("org_invitation_accepted", { org_id: invitationId });
       const inv = pendingInvitations.find((i) => i.id === invitationId);
       if (inv && typeof (inv as unknown as { accept?: () => Promise<void> }).accept === "function") {
         await (inv as unknown as { accept: () => Promise<void> }).accept();
@@ -115,6 +118,7 @@ export default function OnboardingPage() {
 
   async function handlePersonal() {
     setLoading(true);
+    posthog?.capture("workspace_type_selected", { type: "personal" });
     try {
       // Mark onboarding complete and sync user
       await user?.update({ unsafeMetadata: { onboarded: true } });
@@ -223,7 +227,7 @@ export default function OnboardingPage() {
         </button>
 
         <button
-          onClick={() => setMode("org")}
+          onClick={() => { posthog?.capture("workspace_type_selected", { type: "org" }); setMode("org"); }}
           disabled={loading}
           className="flex flex-col items-center gap-3 p-6 rounded-lg border border-border hover:border-primary/50 hover:bg-accent transition-colors w-56"
         >

--- a/apps/frontend/src/app/settings/page.tsx
+++ b/apps/frontend/src/app/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import "./settings.css";
 import React, { useState, useEffect, useCallback } from "react";
+import { usePostHog } from "posthog-js/react";
 import Link from "next/link";
 import { useUser, UserButton, useOrganization } from "@clerk/nextjs";
 import { useBilling } from "@/hooks/useBilling";
@@ -177,6 +178,7 @@ function ProfilePanel() {
 // =============================================================================
 
 function BillingPanel() {
+  const posthog = usePostHog();
   const {
     account,
     isLoading,
@@ -216,13 +218,14 @@ function BillingPanel() {
   }, [createCheckout]);
 
   const handlePortal = useCallback(async () => {
+    posthog?.capture("billing_portal_opened");
     setPortalLoading(true);
     try {
       await openPortal();
     } catch {
       setPortalLoading(false);
     }
-  }, [openPortal]);
+  }, [openPortal, posthog]);
 
   const handleOverageToggle = useCallback(async () => {
     const newEnabled = !overageEnabled;
@@ -233,6 +236,7 @@ function BillingPanel() {
       const limit = overageLimit ? parseFloat(overageLimit) : null;
       await toggleOverage(newEnabled, limit);
       setOverageEnabled(newEnabled);
+      posthog?.capture("overage_enabled", { enabled: newEnabled });
       setOverageSuccess(true);
       setTimeout(() => setOverageSuccess(false), 2000);
     } catch (err) {
@@ -240,7 +244,7 @@ function BillingPanel() {
     } finally {
       setOverageSaving(false);
     }
-  }, [overageEnabled, overageLimit, toggleOverage]);
+  }, [overageEnabled, overageLimit, toggleOverage, posthog]);
 
   const handleOverageLimitSave = useCallback(async () => {
     setOverageSaving(true);
@@ -249,6 +253,7 @@ function BillingPanel() {
     try {
       const limit = overageLimit ? parseFloat(overageLimit) : null;
       await toggleOverage(overageEnabled, limit);
+      posthog?.capture("overage_limit_set", { limit });
       setOverageSuccess(true);
       setTimeout(() => setOverageSuccess(false), 2000);
     } catch (err) {
@@ -256,7 +261,7 @@ function BillingPanel() {
     } finally {
       setOverageSaving(false);
     }
-  }, [overageEnabled, overageLimit, toggleOverage]);
+  }, [overageEnabled, overageLimit, toggleOverage, posthog]);
 
   // Loading
   if (isLoading) {

--- a/apps/frontend/src/components/PostHogProvider.tsx
+++ b/apps/frontend/src/components/PostHogProvider.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useAuth, useUser } from "@clerk/nextjs";
+import posthog from "posthog-js";
+import { PostHogProvider as PHProvider } from "posthog-js/react";
+
+const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+
+if (typeof window !== "undefined" && POSTHOG_KEY) {
+  posthog.init(POSTHOG_KEY, {
+    api_host: POSTHOG_HOST,
+    person_profiles: "identified_only",
+    capture_pageview: false,
+    capture_pageleave: true,
+  });
+}
+
+function PostHogPageview() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!POSTHOG_KEY) return;
+    const url = pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : "");
+    posthog.capture("$pageview", { $current_url: url });
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+function PostHogIdentify() {
+  const { isSignedIn, userId } = useAuth();
+  const { user } = useUser();
+  const identifiedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!POSTHOG_KEY) return;
+
+    if (isSignedIn && userId && identifiedRef.current !== userId) {
+      posthog.identify(userId, {
+        email: user?.primaryEmailAddress?.emailAddress,
+        firstName: user?.firstName,
+        lastName: user?.lastName,
+      });
+      identifiedRef.current = userId;
+    } else if (!isSignedIn && identifiedRef.current) {
+      posthog.reset();
+      identifiedRef.current = null;
+    }
+  }, [isSignedIn, userId, user]);
+
+  return null;
+}
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  if (!POSTHOG_KEY) {
+    return <>{children}</>;
+  }
+
+  return (
+    <PHProvider client={posthog}>
+      <PostHogPageview />
+      <PostHogIdentify />
+      {children}
+    </PHProvider>
+  );
+}

--- a/apps/frontend/src/components/__tests__/PostHogProvider.test.tsx
+++ b/apps/frontend/src/components/__tests__/PostHogProvider.test.tsx
@@ -94,8 +94,8 @@ describe("PostHogProvider", () => {
       </mod.PostHogProvider>
     );
 
-    expect(screen.getByTestId("child")).toBeInTheDocument();
-    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByTestId("child")).toBeTruthy();
+    expect(screen.getByText("Hello")).toBeTruthy();
   });
 
   it("renders children when NEXT_PUBLIC_POSTHOG_KEY is set", async () => {
@@ -108,7 +108,7 @@ describe("PostHogProvider", () => {
       </mod.PostHogProvider>
     );
 
-    expect(screen.getByTestId("child")).toBeInTheDocument();
-    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByTestId("child")).toBeTruthy();
+    expect(screen.getByText("Hello")).toBeTruthy();
   });
 });

--- a/apps/frontend/src/components/__tests__/PostHogProvider.test.tsx
+++ b/apps/frontend/src/components/__tests__/PostHogProvider.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Mock posthog-js before any imports that use it
+const mockInit = vi.fn();
+const mockCapture = vi.fn();
+const mockIdentify = vi.fn();
+const mockReset = vi.fn();
+
+vi.mock("posthog-js", () => {
+  const posthog = {
+    init: mockInit,
+    capture: mockCapture,
+    identify: mockIdentify,
+    reset: mockReset,
+  };
+  return { default: posthog };
+});
+
+vi.mock("posthog-js/react", () => ({
+  PostHogProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="ph-provider">{children}</div>
+  ),
+}));
+
+describe("PostHogProvider", () => {
+  const originalKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const originalHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+
+  afterEach(() => {
+    // Restore original env
+    if (originalKey === undefined) {
+      delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    } else {
+      process.env.NEXT_PUBLIC_POSTHOG_KEY = originalKey;
+    }
+    if (originalHost === undefined) {
+      delete process.env.NEXT_PUBLIC_POSTHOG_HOST;
+    } else {
+      process.env.NEXT_PUBLIC_POSTHOG_HOST = originalHost;
+    }
+  });
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockInit.mockClear();
+    mockCapture.mockClear();
+    mockIdentify.mockClear();
+    mockReset.mockClear();
+    delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    delete process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  });
+
+  it("does NOT initialize PostHog when NEXT_PUBLIC_POSTHOG_KEY is not set", async () => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+    const mod = await import("../PostHogProvider");
+    render(
+      <mod.PostHogProvider>
+        <div>child content</div>
+      </mod.PostHogProvider>
+    );
+
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  it("initializes PostHog when NEXT_PUBLIC_POSTHOG_KEY is set", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_123";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://ph.example.com";
+
+    const mod = await import("../PostHogProvider");
+    render(
+      <mod.PostHogProvider>
+        <div>child content</div>
+      </mod.PostHogProvider>
+    );
+
+    expect(mockInit).toHaveBeenCalledWith("phc_test_key_123", {
+      api_host: "https://ph.example.com",
+      person_profiles: "identified_only",
+      capture_pageview: false,
+      capture_pageleave: true,
+    });
+  });
+
+  it("renders children when NEXT_PUBLIC_POSTHOG_KEY is not set", async () => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+    const mod = await import("../PostHogProvider");
+    render(
+      <mod.PostHogProvider>
+        <div data-testid="child">Hello</div>
+      </mod.PostHogProvider>
+    );
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("renders children when NEXT_PUBLIC_POSTHOG_KEY is set", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_123";
+
+    const mod = await import("../PostHogProvider");
+    render(
+      <mod.PostHogProvider>
+        <div data-testid="child">Hello</div>
+      </mod.PostHogProvider>
+    );
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/channels/BotSetupWizard.tsx
+++ b/apps/frontend/src/components/channels/BotSetupWizard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { usePostHog } from "posthog-js/react";
 import {
   AlertCircle,
   ArrowLeft,
@@ -221,6 +222,7 @@ export function BotSetupWizard({
   onComplete,
   onCancel,
 }: BotSetupWizardProps) {
+  const posthog = usePostHog();
   const api = useApi();
   const callRpc = useGatewayRpcMutation();
 
@@ -445,6 +447,7 @@ export function BotSetupWizard({
         agent_id: agentId,
         code: trimmed,
       })) as { status: string; peer_id: string };
+      posthog?.capture("channel_connected", { provider });
       setStepIndex(steps.indexOf("done"));
       onComplete({ peer_id: result.peer_id });
     } catch (e) {

--- a/apps/frontend/src/components/chat/AgentChatWindow.tsx
+++ b/apps/frontend/src/components/chat/AgentChatWindow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePostHog } from "posthog-js/react";
 
 import { ChatInput } from "./ChatInput";
 import { MessageList, MessageListHandle } from "./MessageList";
@@ -35,6 +36,7 @@ function BudgetExceededBanner({
 }: {
   budgetError: BudgetExceededPayload;
 }) {
+  const posthog = usePostHog();
   const { account, createCheckout, toggleOverage } = useBilling();
   const { organization, membership } = useOrganization();
   const [loading, setLoading] = useState(false);
@@ -46,8 +48,10 @@ function BudgetExceededBanner({
     setLoading(true);
     try {
       if (!budgetError.is_subscribed) {
+        posthog?.capture("overage_enabled_from_banner", { action: "subscribe" });
         await createCheckout("starter");
       } else if (budgetError.overage_available && !budgetError.overage_enabled) {
+        posthog?.capture("overage_enabled_from_banner", { action: "enable_paygo" });
         await toggleOverage(true);
       }
     } catch (err) {
@@ -55,7 +59,7 @@ function BudgetExceededBanner({
     } finally {
       setLoading(false);
     }
-  }, [budgetError, createCheckout, toggleOverage]);
+  }, [budgetError, createCheckout, toggleOverage, posthog]);
 
   let message: string;
   let subtext: string | null = null;
@@ -202,6 +206,7 @@ interface PendingUpdate {
 
 
 function UpdateBanner() {
+  const posthog = usePostHog();
   const api = useApi();
   const { organization, membership } = useOrganization();
   const { onChatMessage } = useGateway();
@@ -246,6 +251,7 @@ function UpdateBanner() {
       setApplying(true);
       try {
         await api.post(`/container/updates/${updateId}/apply`, { schedule: "now" });
+        posthog?.capture("update_applied");
         setUpdates((prev) => prev.filter((u) => u.update_id !== updateId));
       } catch (err) {
         console.error("Failed to apply update:", err);
@@ -253,19 +259,20 @@ function UpdateBanner() {
         setApplying(false);
       }
     },
-    [api],
+    [api, posthog],
   );
 
   const handleScheduleTonight = useCallback(
     async (updateId: string) => {
       try {
         await api.post(`/container/updates/${updateId}/apply`, { schedule: "tonight" });
+        posthog?.capture("update_scheduled");
         setUpdates((prev) => prev.filter((u) => u.update_id !== updateId));
       } catch (err) {
         console.error("Failed to schedule update:", err);
       }
     },
-    [api],
+    [api, posthog],
   );
 
   const handleRemindLater = useCallback(

--- a/apps/frontend/src/components/chat/AgentDialogs.tsx
+++ b/apps/frontend/src/components/chat/AgentDialogs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { usePostHog } from "posthog-js/react";
 import { Loader2 } from "lucide-react";
 import {
   AlertDialog,
@@ -145,6 +146,7 @@ interface RenameProps {
 }
 
 export function AgentRenameDialog({ agent, onCancel, onRename }: RenameProps) {
+  const posthog = usePostHog();
   const [name, setName] = useState(agent?.identity?.name || agent?.name || agent?.id || "");
   const [submitting, setSubmitting] = useState(false);
   const submittingRef = useRef(false);
@@ -159,6 +161,7 @@ export function AgentRenameDialog({ agent, onCancel, onRename }: RenameProps) {
     setError(null);
     try {
       await onRename(name.trim());
+      posthog?.capture("agent_renamed", { agent_id: agent?.id });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       submittingRef.current = false;
@@ -213,6 +216,7 @@ interface DeleteProps {
 }
 
 export function AgentDeleteDialog({ agent, onCancel, onDelete }: DeleteProps) {
+  const posthog = usePostHog();
   const [submitting, setSubmitting] = useState(false);
   const submittingRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
@@ -223,6 +227,7 @@ export function AgentDeleteDialog({ agent, onCancel, onDelete }: DeleteProps) {
     setError(null);
     try {
       await onDelete();
+      posthog?.capture("agent_deleted", { agent_id: agent?.id });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       submittingRef.current = false;

--- a/apps/frontend/src/components/chat/ChatInput.tsx
+++ b/apps/frontend/src/components/chat/ChatInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { usePostHog } from "posthog-js/react";
 import { Button } from "@/components/ui/button";
 import { SendHorizontal, Paperclip, X, FileIcon, Loader2, Square } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -30,6 +31,7 @@ function formatFileSize(bytes: number): string {
 }
 
 export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isStreaming, suggestedMessage, budgetExceeded }: ChatInputProps) {
+  const posthog = usePostHog();
   const [input, setInput] = React.useState("");
   const [pendingFiles, setPendingFiles] = React.useState<PendingFile[]>([]);
   const [sizeError, setSizeError] = React.useState<{ id: number; message: string } | null>(null);
@@ -88,6 +90,7 @@ export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isS
   const handleSend = () => {
     if (input.trim() || pendingFiles.length > 0) {
       const files = pendingFiles.map((pf) => pf.file);
+      posthog?.capture("chat_message_sent", { has_files: files.length > 0 });
       onSend(input, files.length > 0 ? files : undefined);
       setInput("");
       setPendingFiles([]);
@@ -116,6 +119,7 @@ export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isS
       id: crypto.randomUUID(),
     }));
     setPendingFiles((prev) => [...prev, ...newFiles].slice(0, 10));
+    posthog?.capture("chat_file_uploaded", { file_count: selected.length });
 
     // Reset input so the same file can be selected again
     if (fileInputRef.current) fileInputRef.current.value = "";
@@ -232,7 +236,7 @@ export function ChatInput({ onSend, onStop, disabled, centered, isUploading, isS
               size="icon"
               variant="destructive"
               className="shrink-0 h-8 w-8 rounded-full"
-              onClick={onStop}
+              onClick={() => { posthog?.capture("chat_stopped"); onStop?.(); }}
               data-testid="stop-button"
               aria-label="Stop agent"
             >

--- a/apps/frontend/src/components/chat/ChatLayout.tsx
+++ b/apps/frontend/src/components/chat/ChatLayout.tsx
@@ -2,6 +2,7 @@
 
 import "./ChatLayout.css";
 import { useEffect, useRef, useState } from "react";
+import { usePostHog } from "posthog-js/react";
 import { useAuth, useOrganization, useOrganizationList, useUser, UserButton } from "@clerk/nextjs";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Settings, Plus, Bot, CheckCircle, CreditCard, Menu, X, FolderOpen, Pencil, Trash2 } from "lucide-react";
@@ -50,6 +51,7 @@ export function ChatLayout({
   onOpenFile,
   onCloseFileViewer,
 }: ChatLayoutProps): React.ReactElement {
+  const posthog = usePostHog();
   const { isSignedIn } = useAuth();
   const { user, isLoaded: userLoaded } = useUser();
   const { organization, isLoaded: orgLoaded } = useOrganization();
@@ -172,6 +174,7 @@ export function ChatLayout({
   }, [showSubscriptionSuccess, refreshBilling, router]);
 
   function handleSelectAgent(agentId: string): void {
+    posthog?.capture("agent_selected", { agent_id: agentId });
     setUserSelectedId(agentId);
     dispatchSelectAgentEvent(agentId);
     setSidebarOpen(false);
@@ -251,7 +254,7 @@ export function ChatLayout({
             </button>
             <button
               className={`tab-btn${activeView === "control" ? " active" : ""}`}
-              onClick={() => { onViewChange("control"); setSidebarOpen(false); }}
+              onClick={() => { posthog?.capture("control_panel_opened"); onViewChange("control"); setSidebarOpen(false); }}
             >
               Control
             </button>
@@ -343,7 +346,7 @@ export function ChatLayout({
             </button>
             {onOpenFile && (
               <button
-                onClick={() => onOpenFile?.("")}
+                onClick={() => { posthog?.capture("file_browser_opened"); onOpenFile?.(""); }}
                 className="flex items-center justify-center text-[#8a8578] hover:text-[#1a1a1a] transition-colors p-1"
                 title="Browse workspace files"
               >

--- a/apps/frontend/src/components/chat/ProvisioningStepper.tsx
+++ b/apps/frontend/src/components/chat/ProvisioningStepper.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { usePostHog } from "posthog-js/react";
 import useSWR from "swr";
 import {
   Loader2,
@@ -137,6 +138,7 @@ export function ProvisioningStepper({
    *  "recovery" = skip billing, start from container provisioning. */
   trigger?: "onboarding" | "recovery";
 }) {
+  const posthog = usePostHog();
   const { organization, membership, isLoaded: orgLoaded } = useOrganization();
   const isOrg = !!organization;
   // Personal accounts (no org) and explicit org admins manage channels.
@@ -284,7 +286,7 @@ export function ProvisioningStepper({
             provider={wizardProvider}
             agentId="main"
             botUsername={wizardBotUsername}
-            onComplete={() => setOnboardingComplete(true)}
+            onComplete={() => { posthog?.capture("onboarding_completed"); setOnboardingComplete(true); }}
             onCancel={() => setOnboardingComplete(true)}
           />
         </div>
@@ -304,6 +306,7 @@ export function ProvisioningStepper({
   // Not subscribed and not free — show pricing
   if (!isSubscribed && !isFree) {
     return <PricingCards checkoutLoading={checkoutLoading} isOrg={isOrg} orgName={organization?.name} onCheckout={async (tier) => {
+      posthog?.capture("checkout_started", { tier });
       setCheckoutLoading(tier);
       try {
         await createCheckout(tier);

--- a/apps/frontend/src/components/control/panels/AgentCreateForm.tsx
+++ b/apps/frontend/src/components/control/panels/AgentCreateForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { usePostHog } from "posthog-js/react";
 import { Loader2, Plus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useGatewayRpcMutation } from "@/hooks/useGatewayRpc";
@@ -21,6 +22,7 @@ function normalizeToId(name: string): string {
 }
 
 export function AgentCreateForm({ existingIds, onCreated, onCancel }: AgentCreateFormProps) {
+  const posthog = usePostHog();
   const [name, setName] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -45,13 +47,14 @@ export function AgentCreateForm({ existingIds, onCreated, onCancel }: AgentCreat
         // events in real time instead of batching at chat.final.
         reasoningDefault: "stream",
       });
+      posthog?.capture("agent_created", { agent_name: name.trim() });
       onCreated();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setCreating(false);
     }
-  }, [canCreate, callRpc, name, onCreated]);
+  }, [canCreate, callRpc, name, onCreated, posthog]);
 
   const clientError = isDuplicate
     ? "An agent with this name already exists"

--- a/apps/frontend/src/components/control/panels/CronPanel.tsx
+++ b/apps/frontend/src/components/control/panels/CronPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
+import { usePostHog } from "posthog-js/react";
 import cronstrue from "cronstrue";
 import {
   Loader2,
@@ -415,6 +416,7 @@ function RunHistory({ jobId }: { jobId: string }) {
 // --- Main panel ---
 
 export function CronPanel() {
+  const posthog = usePostHog();
   const { data, error, isLoading, mutate } = useGatewayRpc<CronListResponse>("cron.list", {
     includeDisabled: true,
   });
@@ -443,6 +445,7 @@ export function CronPanel() {
         sessionTarget: "isolated",
         wakeMode: "now",
       });
+      posthog?.capture("cron_job_created", { schedule: buildSchedule(form) });
       setMode("list");
       mutate();
       showFeedback("success", `Created "${form.name.trim()}"`);
@@ -480,6 +483,7 @@ export function CronPanel() {
   const handleDelete = async (id: string) => {
     try {
       await callRpc("cron.remove", { id });
+      posthog?.capture("cron_job_deleted");
       setDeletingJob(null);
       mutate();
       showFeedback("success", "Job deleted");
@@ -491,6 +495,7 @@ export function CronPanel() {
   const handleToggle = async (id: string, currentlyEnabled: boolean) => {
     try {
       await callRpc("cron.update", { id, patch: { enabled: !currentlyEnabled } });
+      posthog?.capture("cron_job_toggled", { enabled: !currentlyEnabled });
       mutate();
     } catch (err) {
       showFeedback("error", `Failed to toggle: ${err instanceof Error ? err.message : String(err)}`);
@@ -500,6 +505,7 @@ export function CronPanel() {
   const handleRun = async (id: string) => {
     try {
       await callRpc("cron.run", { id, mode: "force" });
+      posthog?.capture("cron_job_triggered");
       showFeedback("success", "Job triggered");
       mutate();
     } catch (err) {

--- a/apps/frontend/src/components/control/panels/McpServersTab.tsx
+++ b/apps/frontend/src/components/control/panels/McpServersTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { usePostHog } from "posthog-js/react";
 import {
   Loader2,
   RefreshCw,
@@ -37,6 +38,7 @@ const PLACEHOLDER_CONFIG = `{
 
 export function McpServersTab(props: { agentId?: string }) {
   void props;
+  const posthog = usePostHog();
   const api = useApi();
   const [servers, setServers] = useState<Record<string, McpServer>>({});
   const [loading, setLoading] = useState(true);
@@ -92,6 +94,7 @@ export function McpServersTab(props: { agentId?: string }) {
       const resp = (await api.put("/integrations/mcp/servers", { servers: merged })) as ServersResponse;
       setServers(resp.servers ?? {});
       setConfigInput("");
+      posthog?.capture("mcp_server_added", { server_name: Object.keys(parsed).join(", ") });
       setStatus({ type: "success", message: "Server(s) added successfully." });
       setTimeout(() => setStatus(null), 3000);
     } catch (err) {
@@ -107,6 +110,7 @@ export function McpServersTab(props: { agentId?: string }) {
     try {
       const resp = (await api.del(`/integrations/mcp/servers/${encodeURIComponent(name)}`)) as ServersResponse;
       setServers(resp.servers ?? {});
+      posthog?.capture("mcp_server_removed", { server_name: name });
     } catch (err) {
       console.error("Failed to remove MCP server:", err);
     } finally {

--- a/apps/frontend/src/components/control/panels/SkillsPanel.tsx
+++ b/apps/frontend/src/components/control/panels/SkillsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { usePostHog } from "posthog-js/react";
 import {
   Loader2,
   RefreshCw,
@@ -484,6 +485,7 @@ function SkillCard({
   onRefresh: () => void;
   variant: "installed" | "available";
 }) {
+  const posthog = usePostHog();
   const [toggleLoading, setToggleLoading] = useState(false);
   const [apiKey, setApiKey] = useState("");
   const [apiKeyVisible, setApiKeyVisible] = useState(false);
@@ -504,6 +506,7 @@ function SkillCard({
         skillKey: skill.skillKey || skill.name,
         enabled: skill.disabled,
       });
+      posthog?.capture("skill_toggled", { skill: skill.name, enabled: skill.disabled });
       onRefresh();
     } catch (err) {
       console.error("Failed to toggle skill:", err);
@@ -532,6 +535,7 @@ function SkillCard({
         }
       }
 
+      posthog?.capture("skill_api_key_saved", { skill: skill.name });
       setSaveStatus("success");
       setApiKey("");
       onRefresh();
@@ -553,6 +557,7 @@ function SkillCard({
         installId: spec.id,
         timeoutMs: 120000,
       });
+      posthog?.capture("skill_installed", { skill: skill.name });
       onRefresh();
     } catch (err) {
       console.error("Failed to install:", err);

--- a/apps/frontend/src/components/landing/Hero.tsx
+++ b/apps/frontend/src/components/landing/Hero.tsx
@@ -2,8 +2,10 @@
 
 import Link from "next/link";
 import { useEffect } from "react";
+import { usePostHog } from "posthog-js/react";
 
 export function Hero() {
+  const posthog = usePostHog();
   useEffect(() => {
     const seq = document.getElementById("wfSeq");
     if (!seq || window.matchMedia("(prefers-reduced-motion: reduce)").matches)
@@ -163,7 +165,7 @@ export function Hero() {
           workflow autonomously.
         </p>
         <div className="hero-ctas">
-          <Link href="/chat" className="btn-large">
+          <Link href="/chat" className="btn-large" onClick={() => posthog?.capture("landing_cta_clicked")}>
             Start your pod
           </Link>
           <Link href="#features" className="btn-secondary">

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -135,7 +135,6 @@ const _needsBootstrap = new Set<string>();
 // =============================================================================
 
 export function useAgentChat(agentId: string | null, sessionName: string): UseAgentChatReturn {
-
   const { isConnected, sendChat, onChatMessage, sendReq } = useGateway();
 
   // Cache key includes session name so org members don't share history cache

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -135,6 +135,7 @@ const _needsBootstrap = new Set<string>();
 // =============================================================================
 
 export function useAgentChat(agentId: string | null, sessionName: string): UseAgentChatReturn {
+
   const { isConnected, sendChat, onChatMessage, sendReq } = useGateway();
 
   // Cache key includes session name so org members don't share history cache

--- a/apps/frontend/src/hooks/useAgents.ts
+++ b/apps/frontend/src/hooks/useAgents.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback } from "react";
+import { usePostHog } from "posthog-js/react";
 import { useGatewayRpc, useGatewayRpcMutation } from "@/hooks/useGatewayRpc";
 
 /**
@@ -38,6 +39,7 @@ interface AgentsListResponse {
 }
 
 export function useAgents() {
+  const posthog = usePostHog();
   const { data, error, isLoading, mutate } =
     useGatewayRpc<AgentsListResponse>("agents.list");
   const callRpc = useGatewayRpcMutation();
@@ -64,9 +66,12 @@ export function useAgents() {
   const updateAgent = useCallback(
     async (agentId: string, updates: { model?: string; name?: string }) => {
       await callRpc("agents.update", { agentId, ...updates });
+      if (updates.model) {
+        posthog?.capture("agent_model_changed", { agent_id: agentId, model: updates.model });
+      }
       mutate();
     },
-    [callRpc, mutate],
+    [callRpc, mutate, posthog],
   );
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^6.36.5
-        version: 6.39.0(next@16.1.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 6.39.0(next@16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@noble/curves':
         specifier: ^1.8.1
         version: 1.9.7
@@ -69,7 +69,10 @@ importers:
         version: 5.1.7
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      posthog-js:
+        specifier: ^1.368.0
+        version: 1.368.0
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1094,6 +1097,78 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.2.0':
+    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.6.1':
+    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0':
+    resolution: {integrity: sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.208.0':
+    resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.208.0':
+    resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.2.0':
+    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.6.1':
+    resolution: {integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.208.0':
+    resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.2.0':
+    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.2.0':
+    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1105,6 +1180,42 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@posthog/core@1.25.2':
+    resolution: {integrity: sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==}
+
+  '@posthog/types@1.368.0':
+    resolution: {integrity: sha512-ORuGmgEmEkwaf/bEI4mOlrzIdOSJJ44vuz+XHPFycmt5Y6swjTXH/1NmIKas5KdKi/SOaKGvSkHGqUv7hHcNaw==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1866,6 +1977,9 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2456,6 +2570,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2593,6 +2710,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   dotenv@17.2.2:
     resolution: {integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==}
@@ -2872,6 +2992,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -3655,6 +3778,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -4127,6 +4253,12 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.368.0:
+    resolution: {integrity: sha512-Smh2Q49oIOzGph73A3dLXCjepze8Nk0ApPtbJvbARFXI8XQp0mD+ia0RFcYQ25m2+PA1ViE8pR+Ga8yG7awzsw==}
+
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4153,6 +4285,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4163,6 +4299,9 @@ packages:
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4966,6 +5105,9 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -5338,13 +5480,13 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       tslib: 2.8.1
 
-  '@clerk/nextjs@6.39.0(next@16.1.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@clerk/nextjs@6.39.0(next@16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@clerk/backend': 2.33.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@clerk/clerk-react': 5.61.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@clerk/shared': 3.47.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@clerk/types': 4.101.20(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      next: 16.1.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       server-only: 0.0.1
@@ -5978,6 +6120,82 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -5986,6 +6204,33 @@ snapshots:
       playwright: 1.58.2
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@posthog/core@1.25.2': {}
+
+  '@posthog/types@1.368.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6677,6 +6922,9 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -7308,6 +7556,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-js@3.49.0: {}
+
   create-jest@29.7.0(@types/node@22.7.9)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -7428,6 +7678,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@17.2.2: {}
 
@@ -7871,6 +8125,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.4.8: {}
 
   fflate@0.8.2: {}
 
@@ -8872,6 +9128,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -9347,7 +9605,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.1.1(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -9366,6 +9624,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.1
       '@next/swc-win32-arm64-msvc': 16.1.1
       '@next/swc-win32-x64-msvc': 16.1.1
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.58.2
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
@@ -9557,6 +9816,24 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.368.0:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@posthog/core': 1.25.2
+      '@posthog/types': 1.368.0
+      core-js: 3.49.0
+      dompurify: 3.3.3
+      fflate: 0.4.8
+      preact: 10.29.1
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.2.0
+
+  preact@10.29.1: {}
+
   prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
@@ -9586,6 +9863,21 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.2.5
+      long: 5.3.2
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
@@ -9593,6 +9885,8 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -10545,6 +10839,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  web-vitals@5.2.0: {}
 
   webidl-conversions@7.0.0: {}
 


### PR DESCRIPTION
## Summary

- Adds PostHog product analytics, session replay, and web analytics to the frontend
- Gated to production via `NEXT_PUBLIC_POSTHOG_KEY` env var (no-op in dev/local/CI)
- Identifies users via Clerk auth state (identify on sign-in, reset on sign-out)
- Tracks pageviews via Next.js App Router `usePathname()` + `useSearchParams()`
- Adds 33 custom events across all key user flows:
  - Onboarding & auth (4): workspace type, org invitation, onboarding complete, checkout
  - Agent management (5): create, delete, rename, select, model change
  - Chat (3): message sent, file upload, stop
  - Billing (5): portal, overage toggle, overage limit, banner CTA, checkout
  - Skills & tools (3): toggle, install, API key save
  - MCP servers (2): add, remove
  - Cron jobs (4): create, delete, toggle, trigger
  - Channels (1): connected
  - Container updates (2): apply now, schedule tonight
  - Navigation (3): control panel, file browser, landing CTA

## Setup Required

After merge, set these in Vercel **production** environment variables:
- `NEXT_PUBLIC_POSTHOG_KEY` = `phc_nzqnGGPwHfrKycptH3TViSAo3uaxT8CHAXovvHnBGEma`
- `NEXT_PUBLIC_POSTHOG_HOST` = `https://us.i.posthog.com`

## Test plan

- [ ] PostHogProvider unit tests pass (4/4)
- [ ] All existing tests unaffected (PostHog is inert without env var)
- [ ] Lint passes with 0 errors
- [ ] After deploy: verify events appear in PostHog dashboard > Activity > Live Events
- [ ] After deploy: verify session replay is recording
- [ ] Verify PostHog does NOT initialize in dev (no network requests to posthog.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)