### PR TITLE
fix: resolve agent workspace paths correctly for main vs custom agents

### DIFF
--- a/apps/backend/routers/container_rpc.py
+++ b/apps/backend/routers/container_rpc.py
@@ -24,6 +24,7 @@ from websockets import connect as ws_connect
 from core.auth import AuthContext, get_current_user, resolve_owner_id
 from core.containers import get_ecs_manager, get_workspace
 from core.containers.ecs_manager import GATEWAY_PORT
+from routers.workspace_files import _agent_workspace_dir
 
 logger = logging.getLogger(__name__)
 
@@ -240,8 +241,8 @@ def _sanitize_filename(name: str) -> str:
     summary="Upload files to the user's agent workspace",
     description=(
         "Uploads one or more files to the user's workspace on EFS. "
-        "Files are placed in the agent's `workspaces/{agent_id}/uploads/` directory "
-        "and are accessible to the user's OpenClaw agent. "
+        "Files are placed in the agent's `uploads/` directory (inside the "
+        "agent's workspace dir) and are accessible to the user's OpenClaw agent. "
         "Max 10MB per file, 10 files per request."
     ),
     operation_id="upload_files",
@@ -285,7 +286,7 @@ async def upload_files(
             )
 
         safe_name = _sanitize_filename(f.filename or "upload")
-        dest_path = f"workspaces/{agent_id}/uploads/{safe_name}"
+        dest_path = f"{_agent_workspace_dir(agent_id)}/uploads/{safe_name}"
         workspace.write_bytes(owner_id, dest_path, data)
         # The agent's working dir is $HOME (/home/node) but EFS is mounted
         # at $HOME/.openclaw, so the agent sees uploads relative to that mount.

--- a/apps/backend/routers/workspace_files.py
+++ b/apps/backend/routers/workspace_files.py
@@ -58,11 +58,23 @@ def _ensure_within_subtree(workspace, owner_id: str, full_path: str, subtree: st
         raise ValueError(f"path escapes agent subtree: {full_path!r}")
 
 
-def _agent_workspace_path(owner_id: str, agent_id: str) -> str:
-    """Build the relative path to an agent's workspace within the user dir."""
-    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
-        raise HTTPException(status_code=400, detail="Invalid agent_id")
-    return f"workspaces/{agent_id}"
+MAIN_AGENT_ID = "main"
+
+
+def _agent_workspace_dir(agent_id: str) -> str:
+    """Return the user-root-relative directory holding an agent's files.
+
+    Layout convention (see file-viewer v2 follow-up):
+    - main agent stores everything at workspaces/ (user-root, inherits OpenClaw's default)
+    - Custom agents store everything at agents/{agent_id}/ (explicit override from frontend)
+
+    This wrapper lets callers say "give me agent X's dir" without branching at
+    every call site. A future PR will normalize to workspaces/{id}/ for all
+    agents; this keeps the mapping in one place so that PR is a one-line change.
+    """
+    if agent_id == MAIN_AGENT_ID:
+        return "workspaces"
+    return f"agents/{agent_id}"
 
 
 def _collect_recursive(workspace, owner_id: str, path: str, entries: list, max_depth: int = 10):
@@ -82,15 +94,16 @@ def _collect_recursive(workspace, owner_id: str, path: str, entries: list, max_d
 def _strip_agent_prefix(entries: list[dict], agent_id: str) -> list[dict]:
     """Rewrite entry paths from user-root-relative to agent-workspace-relative.
 
-    Input paths look like `workspaces/{agent_id}/foo/bar.md`. Output paths
-    strip the `workspaces/{agent_id}/` prefix so they match the contract
-    expected by the read/write endpoints.
+    Input paths look like `{_agent_workspace_dir(agent_id)}/foo/bar.md`. Output
+    paths strip the prefix so they match the contract expected by the
+    read/write endpoints.
     """
-    prefix = f"workspaces/{agent_id}/"
+    bare = _agent_workspace_dir(agent_id)
+    prefix = f"{bare}/"
     out = []
     for entry in entries:
         p = entry["path"]
-        if p == f"workspaces/{agent_id}":
+        if p == bare:
             # The agent root itself — present when the workspace dir is listed at depth 0.
             new_path = ""
         elif p.startswith(prefix):
@@ -118,16 +131,16 @@ MAX_WRITE_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 def _list_config_files(workspace, owner_id: str, agent_id: str) -> list[dict]:
-    """List only allowlisted config files from agents/{agent_id}/."""
+    """List only allowlisted config files from the agent's workspace."""
     if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
         return []
     user_root = workspace.user_path(owner_id)
-    agent_dir = user_root / "agents" / agent_id
-    if not agent_dir.exists() or not agent_dir.is_dir():
+    ws_dir = user_root / _agent_workspace_dir(agent_id)
+    if not ws_dir.exists() or not ws_dir.is_dir():
         return []
     results = []
     for name in sorted(CONFIG_ALLOWLIST):
-        fpath = agent_dir / name
+        fpath = ws_dir / name
         if fpath.exists() and fpath.is_file():
             stat = fpath.stat()
             results.append(
@@ -153,7 +166,10 @@ async def list_workspace_tree(
     owner_id = resolve_owner_id(auth)
     workspace = get_workspace()
 
-    agent_base = _agent_workspace_path(owner_id, agent_id)
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
+
+    agent_base = _agent_workspace_dir(agent_id)
     full_path = f"{agent_base}/{path}" if path else agent_base
 
     if recursive:
@@ -183,7 +199,10 @@ async def read_workspace_file(
     owner_id = resolve_owner_id(auth)
     workspace = get_workspace()
 
-    agent_base = _agent_workspace_path(owner_id, agent_id)
+    if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
+        raise HTTPException(status_code=400, detail="Invalid agent_id")
+
+    agent_base = _agent_workspace_dir(agent_id)
     full_path = f"{agent_base}/{path}"
 
     try:
@@ -224,7 +243,7 @@ async def read_config_file(
     if "/" in agent_id or "\\" in agent_id or ".." in agent_id:
         raise HTTPException(status_code=400, detail="Invalid agent_id")
     workspace = get_workspace()
-    full_path = f"agents/{agent_id}/{path}"
+    full_path = f"{_agent_workspace_dir(agent_id)}/{path}"
     try:
         info = workspace.read_file_info(owner_id, full_path)
     except WorkspaceError as exc:
@@ -241,7 +260,13 @@ class WriteFileRequest(BaseModel):
 
 
 def _write_file(workspace, owner_id: str, agent_id: str, path: str, content: str, tab: str) -> str:
-    """Write a file to workspace or config directory. Returns the written path."""
+    """Write a file to the agent's workspace. Returns the written path.
+
+    With the file-viewer v2 follow-up, config and workspace tabs point at the
+    same directory on disk (see ``_agent_workspace_dir``). The ``tab`` argument
+    is cosmetic on the backend — its only role is to gate config writes through
+    the allowlist.
+    """
     encoded = content.encode("utf-8")
     if len(encoded) > MAX_WRITE_SIZE:
         raise ValueError(f"content exceeds {MAX_WRITE_SIZE // (1024 * 1024)}MB limit")
@@ -251,15 +276,12 @@ def _write_file(workspace, owner_id: str, agent_id: str, path: str, content: str
 
     _validate_relative_path(path)
 
-    if tab == "config":
-        if path not in CONFIG_ALLOWLIST:
-            raise ValueError(f"File not in allowlist: {path}")
-        subtree = f"agents/{agent_id}"
-    elif tab == "workspace":
-        subtree = f"workspaces/{agent_id}"
-    else:
+    if tab not in ("workspace", "config"):
         raise ValueError(f"Invalid tab: {tab!r}")
+    if tab == "config" and path not in CONFIG_ALLOWLIST:
+        raise ValueError(f"File not in allowlist: {path}")
 
+    subtree = _agent_workspace_dir(agent_id)
     full_path = f"{subtree}/{path}"
     _ensure_within_subtree(workspace, owner_id, full_path, subtree)
 

--- a/apps/backend/tests/test_workspace_files.py
+++ b/apps/backend/tests/test_workspace_files.py
@@ -442,11 +442,11 @@ class TestWriteFileEndpoint:
     """Tests for the _write_file helper used by the PUT endpoint."""
 
     def test_write_workspace_file(self, tmp_path):
-        """Writing a workspace file creates it on disk."""
+        """Writing a workspace file for a custom agent creates it under agents/{id}/."""
         ws = _make_workspace(tmp_path)
         user_root = tmp_path / USER_ID
         user_root.mkdir(parents=True)
-        ws_dir = user_root / "workspaces" / AGENT_ID
+        ws_dir = user_root / "agents" / AGENT_ID
         ws_dir.mkdir(parents=True)
 
         from routers.workspace_files import _write_file
@@ -478,12 +478,12 @@ class TestWriteFileEndpoint:
     def test_write_creates_parent_dirs(self, tmp_path):
         """Writing to a nested path creates intermediate directories."""
         ws = _make_workspace(tmp_path)
-        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+        (tmp_path / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
 
         from routers.workspace_files import _write_file
 
         _write_file(ws, USER_ID, AGENT_ID, "deep/nested/file.txt", "hello", "workspace")
-        assert (tmp_path / USER_ID / "workspaces" / AGENT_ID / "deep" / "nested" / "file.txt").read_text() == "hello"
+        assert (tmp_path / USER_ID / "agents" / AGENT_ID / "deep" / "nested" / "file.txt").read_text() == "hello"
 
     @pytest.mark.asyncio
     async def test_endpoint_rejects_traversal_in_agent_id(self, workspace, monkeypatch):
@@ -527,7 +527,7 @@ class TestWriteFileEndpoint:
     def test_write_rejects_traversal_in_path(self, tmp_path):
         """`..` in path raises ValueError (regression for allowlist bypass)."""
         ws = _make_workspace(tmp_path)
-        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+        (tmp_path / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
 
         from routers.workspace_files import _write_file
 
@@ -544,7 +544,7 @@ class TestWriteFileEndpoint:
     def test_write_rejects_absolute_path(self, tmp_path):
         """Absolute paths are rejected."""
         ws = _make_workspace(tmp_path)
-        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+        (tmp_path / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
 
         from routers.workspace_files import _write_file
 
@@ -554,7 +554,7 @@ class TestWriteFileEndpoint:
     def test_write_rejects_empty_path(self, tmp_path):
         """Empty path is rejected."""
         ws = _make_workspace(tmp_path)
-        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+        (tmp_path / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
 
         from routers.workspace_files import _write_file
 
@@ -564,7 +564,7 @@ class TestWriteFileEndpoint:
     def test_write_rejects_dot_only_path(self, tmp_path):
         """Dot-only paths (., ./, .) are rejected with ValueError."""
         ws = _make_workspace(tmp_path)
-        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+        (tmp_path / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
 
         from routers.workspace_files import _write_file
 
@@ -575,7 +575,7 @@ class TestWriteFileEndpoint:
     def test_write_rejects_oversized_content(self, tmp_path):
         """Content over 10MB is rejected."""
         ws = _make_workspace(tmp_path)
-        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+        (tmp_path / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
 
         from routers.workspace_files import _write_file
 
@@ -601,29 +601,25 @@ class TestWriteFileEndpoint:
         assert exc.value.status_code == 400
 
     def test_write_rejects_symlink_escape_workspace(self, tmp_path):
-        """Symlink in workspaces/{id}/ pointing outside must be rejected."""
+        """Symlink in the custom agent's workspace dir pointing outside must be rejected."""
         import os
 
         ws = _make_workspace(tmp_path)
-        ws_dir = tmp_path / USER_ID / "workspaces" / AGENT_ID
-        ws_dir.mkdir(parents=True)
         agent_dir = tmp_path / USER_ID / "agents" / AGENT_ID
         agent_dir.mkdir(parents=True)
-        (agent_dir / "SOUL.md").write_text("original", encoding="utf-8")
+        target = tmp_path / USER_ID / "elsewhere.txt"
+        target.write_text("original", encoding="utf-8")
 
-        # Symlink workspaces/{id}/evil -> ../../agents/{id}/SOUL.md
-        os.symlink(
-            "../../agents/" + AGENT_ID + "/SOUL.md",
-            ws_dir / "evil",
-        )
+        # Symlink agents/{id}/evil -> ../../elsewhere.txt
+        os.symlink("../../elsewhere.txt", agent_dir / "evil")
 
         from routers.workspace_files import _write_file
 
         with pytest.raises(ValueError, match="escapes"):
             _write_file(ws, USER_ID, AGENT_ID, "evil", "hacked", "workspace")
 
-        # SOUL.md must be untouched
-        assert (agent_dir / "SOUL.md").read_text() == "original"
+        # target must be untouched
+        assert target.read_text() == "original"
 
     def test_write_rejects_symlink_escape_config(self, tmp_path):
         """Symlink in agents/{id}/ pointing outside must be rejected."""
@@ -648,13 +644,13 @@ class TestWriteFileEndpoint:
     def test_write_allows_nested_dirs_within_workspace(self, tmp_path):
         """Subtree check allows legitimate nested paths inside the workspace."""
         ws = _make_workspace(tmp_path)
-        (tmp_path / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+        (tmp_path / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
 
         from routers.workspace_files import _write_file
 
         written = _write_file(ws, USER_ID, AGENT_ID, "deep/nested/notes.md", "ok", "workspace")
-        assert written == f"workspaces/{AGENT_ID}/deep/nested/notes.md"
-        assert (tmp_path / USER_ID / "workspaces" / AGENT_ID / "deep" / "nested" / "notes.md").read_text() == "ok"
+        assert written == f"agents/{AGENT_ID}/deep/nested/notes.md"
+        assert (tmp_path / USER_ID / "agents" / AGENT_ID / "deep" / "nested" / "notes.md").read_text() == "ok"
 
 
 # ===========================================================================
@@ -665,23 +661,48 @@ class TestWriteFileEndpoint:
 class TestUploadPath:
     """Verify upload destination path construction."""
 
-    def test_upload_writes_to_agent_workspace(self, tmp_path):
-        """Uploads should go to workspaces/{agent_id}/uploads/."""
+    def test_upload_writes_to_custom_agent_workspace(self, tmp_path):
+        """Uploads for a custom agent should go to agents/{agent_id}/uploads/."""
+        from routers.workspace_files import _agent_workspace_dir
+
         ws = _make_workspace(tmp_path)
-        ws_dir = tmp_path / USER_ID / "workspaces" / AGENT_ID / "uploads"
+        ws_dir = tmp_path / USER_ID / "agents" / AGENT_ID / "uploads"
         (tmp_path / USER_ID).mkdir(parents=True)
 
-        dest_path = f"workspaces/{AGENT_ID}/uploads/test.pdf"
+        dest_path = f"{_agent_workspace_dir(AGENT_ID)}/uploads/test.pdf"
         ws.write_bytes(USER_ID, dest_path, b"fake pdf content")
         assert (ws_dir / "test.pdf").read_bytes() == b"fake pdf content"
 
-    def test_agent_visible_path(self):
-        """Agent-visible path should include workspaces/{agent_id}."""
+    def test_upload_writes_to_main_agent_workspace(self, tmp_path):
+        """Uploads for the main agent should go to workspaces/uploads/ (user root)."""
+        from routers.workspace_files import _agent_workspace_dir
+
+        ws = _make_workspace(tmp_path)
+        ws_dir = tmp_path / USER_ID / "workspaces" / "uploads"
+        (tmp_path / USER_ID).mkdir(parents=True)
+
+        dest_path = f"{_agent_workspace_dir('main')}/uploads/test.pdf"
+        ws.write_bytes(USER_ID, dest_path, b"fake pdf content")
+        assert (ws_dir / "test.pdf").read_bytes() == b"fake pdf content"
+
+    def test_agent_visible_path_custom(self):
+        """Agent-visible path for a custom agent should include agents/{agent_id}."""
+        from routers.workspace_files import _agent_workspace_dir
+
         agent_id = "my-agent"
         filename = "data.csv"
-        dest_path = f"workspaces/{agent_id}/uploads/{filename}"
+        dest_path = f"{_agent_workspace_dir(agent_id)}/uploads/{filename}"
         agent_path = f".openclaw/{dest_path}"
-        assert agent_path == f".openclaw/workspaces/{agent_id}/uploads/{filename}"
+        assert agent_path == f".openclaw/agents/{agent_id}/uploads/{filename}"
+
+    def test_agent_visible_path_main(self):
+        """Agent-visible path for the main agent should use workspaces/ at user root."""
+        from routers.workspace_files import _agent_workspace_dir
+
+        filename = "data.csv"
+        dest_path = f"{_agent_workspace_dir('main')}/uploads/{filename}"
+        agent_path = f".openclaw/{dest_path}"
+        assert agent_path == f".openclaw/workspaces/uploads/{filename}"
 
 
 # ===========================================================================
@@ -696,7 +717,7 @@ class TestWorkspaceTreeRoundTrip:
     async def test_tree_path_feeds_back_to_read(self, workspace, monkeypatch):
         """A path returned by the tree endpoint reads successfully via the file endpoint."""
         monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
-        ws_dir = workspace._mount / USER_ID / "workspaces" / AGENT_ID
+        ws_dir = workspace._mount / USER_ID / "agents" / AGENT_ID
         ws_dir.mkdir(parents=True)
         (ws_dir / "plan.md").write_text("# Plan\nstep 1", encoding="utf-8")
         (ws_dir / "uploads").mkdir()
@@ -711,10 +732,11 @@ class TestWorkspaceTreeRoundTrip:
             auth=_auth(),
         )
         paths = {f["path"] for f in tree["files"]}
-        # Paths must be agent-relative (no `workspaces/{agent_id}/` prefix)
+        # Paths must be agent-relative (no `agents/{agent_id}/` prefix)
         assert "plan.md" in paths
         assert "uploads" in paths
         assert "uploads/data.csv" in paths
+        assert not any(p.startswith("agents/") for p in paths if p)
         assert not any(p.startswith("workspaces/") for p in paths if p)
 
         # Every file path should read successfully via the file endpoint
@@ -732,7 +754,7 @@ class TestWorkspaceTreeRoundTrip:
     async def test_write_then_tree_then_read(self, workspace, monkeypatch):
         """After saveWorkspaceFile writes a workspace file, tree lists it and read returns content."""
         monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
-        (workspace._mount / USER_ID / "workspaces" / AGENT_ID).mkdir(parents=True)
+        (workspace._mount / USER_ID / "agents" / AGENT_ID).mkdir(parents=True)
 
         from routers.workspace_files import (
             WriteFileRequest,
@@ -745,7 +767,7 @@ class TestWorkspaceTreeRoundTrip:
         result = await write_workspace_file(agent_id=AGENT_ID, body=body, auth=_auth())
         assert result["status"] == "ok"
         # Backend returned path is user-root-relative; tree will show agent-relative
-        assert result["path"] == f"workspaces/{AGENT_ID}/notes.txt"
+        assert result["path"] == f"agents/{AGENT_ID}/notes.txt"
 
         tree = await list_workspace_tree(
             agent_id=AGENT_ID,
@@ -757,3 +779,177 @@ class TestWorkspaceTreeRoundTrip:
 
         info = await read_workspace_file(agent_id=AGENT_ID, path="notes.txt", auth=_auth())
         assert info["content"] == "hello world"
+
+
+# ===========================================================================
+# TestMainAgentLayout
+#
+# The `main` agent inherits OpenClaw's default workspace setting, which points
+# at the user-root `workspaces/` directory — NOT a per-agent subdir. Custom
+# agents, by contrast, override workspace to `agents/{id}/`. This class covers
+# the main-agent branch of `_agent_workspace_dir`.
+# ===========================================================================
+
+
+class TestMainAgentLayout:
+    """Tests verifying main agent's workspace resolves to user-root workspaces/."""
+
+    def test_agent_workspace_dir_main(self):
+        """Main agent maps to the user-root workspaces/ directory."""
+        from routers.workspace_files import _agent_workspace_dir
+
+        assert _agent_workspace_dir("main") == "workspaces"
+
+    def test_agent_workspace_dir_custom(self):
+        """Custom agent maps to agents/{id}/."""
+        from routers.workspace_files import _agent_workspace_dir
+
+        assert _agent_workspace_dir("ember") == "agents/ember"
+        assert _agent_workspace_dir(AGENT_ID) == f"agents/{AGENT_ID}"
+
+    def test_list_config_files_main(self, tmp_path):
+        """Config files for main agent are read from workspaces/ at user root."""
+        ws = _make_workspace(tmp_path)
+        ws_dir = tmp_path / USER_ID / "workspaces"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "SOUL.md").write_text("I am main", encoding="utf-8")
+        (ws_dir / "MEMORY.md").write_text("Remember", encoding="utf-8")
+        (ws_dir / "IDENTITY.md").write_text("Me", encoding="utf-8")
+        (ws_dir / "TOOLS.md").write_text("Tools", encoding="utf-8")
+        (ws_dir / "USER.md").write_text("User", encoding="utf-8")
+        (ws_dir / "HEARTBEAT.md").write_text("Heartbeat", encoding="utf-8")
+        # Non-allowlisted file should not appear
+        (ws_dir / "random.json").write_text("{}", encoding="utf-8")
+
+        from routers.workspace_files import _list_config_files
+
+        result = _list_config_files(ws, USER_ID, "main")
+        names = {f["name"] for f in result}
+        assert names == {"SOUL.md", "MEMORY.md", "IDENTITY.md", "TOOLS.md", "USER.md", "HEARTBEAT.md"}
+        assert all(f["type"] == "file" for f in result)
+
+    def test_list_config_files_main_empty_when_no_workspaces_dir(self, tmp_path):
+        """No workspaces/ dir yet -> empty config list for main (not an error)."""
+        ws = _make_workspace(tmp_path)
+        (tmp_path / USER_ID).mkdir(parents=True)
+
+        from routers.workspace_files import _list_config_files
+
+        assert _list_config_files(ws, USER_ID, "main") == []
+
+    @pytest.mark.asyncio
+    async def test_read_workspace_file_main(self, workspace, monkeypatch):
+        """Reading a workspace file for main reads from workspaces/ at user root."""
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        ws_dir = workspace._mount / USER_ID / "workspaces"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "SOUL.md").write_text("main soul", encoding="utf-8")
+
+        from routers.workspace_files import read_workspace_file
+
+        info = await read_workspace_file(agent_id="main", path="SOUL.md", auth=_auth())
+        assert info["name"] == "SOUL.md"
+        assert info["content"] == "main soul"
+
+    @pytest.mark.asyncio
+    async def test_write_workspace_file_main_config_tab(self, workspace, monkeypatch):
+        """Writing SOUL.md for main via tab=config lands in workspaces/SOUL.md."""
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        (workspace._mount / USER_ID / "workspaces").mkdir(parents=True)
+
+        from routers.workspace_files import WriteFileRequest, write_workspace_file
+
+        body = WriteFileRequest(path="SOUL.md", content="I am main", tab="config")
+        result = await write_workspace_file(agent_id="main", body=body, auth=_auth())
+        assert result["status"] == "ok"
+        assert result["path"] == "workspaces/SOUL.md"
+
+        on_disk = workspace._mount / USER_ID / "workspaces" / "SOUL.md"
+        assert on_disk.read_text() == "I am main"
+
+    @pytest.mark.asyncio
+    async def test_write_workspace_file_main_workspace_tab(self, workspace, monkeypatch):
+        """Writing an arbitrary workspace file for main lands under workspaces/."""
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        (workspace._mount / USER_ID / "workspaces").mkdir(parents=True)
+
+        from routers.workspace_files import WriteFileRequest, write_workspace_file
+
+        body = WriteFileRequest(path="plan.md", content="plan text", tab="workspace")
+        result = await write_workspace_file(agent_id="main", body=body, auth=_auth())
+        assert result["status"] == "ok"
+        assert result["path"] == "workspaces/plan.md"
+
+        assert (workspace._mount / USER_ID / "workspaces" / "plan.md").read_text() == "plan text"
+
+    @pytest.mark.asyncio
+    async def test_list_workspace_tree_main(self, workspace, monkeypatch):
+        """list_workspace_tree for main returns entries from workspaces/ at user root."""
+        monkeypatch.setattr("routers.workspace_files.get_workspace", lambda: workspace)
+        ws_dir = workspace._mount / USER_ID / "workspaces"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "SOUL.md").write_text("soul", encoding="utf-8")
+        (ws_dir / "notes").mkdir()
+        (ws_dir / "notes" / "plan.md").write_text("plan", encoding="utf-8")
+
+        from routers.workspace_files import list_workspace_tree
+
+        tree = await list_workspace_tree(
+            agent_id="main",
+            path="",
+            recursive=True,
+            auth=_auth(),
+        )
+        paths = {f["path"] for f in tree["files"]}
+        # Paths returned must be relative to workspaces/, not including workspaces/ prefix
+        assert "SOUL.md" in paths
+        assert "notes" in paths
+        assert "notes/plan.md" in paths
+        assert not any(p.startswith("workspaces/") for p in paths if p)
+
+    def test_strip_agent_prefix_main(self):
+        """_strip_agent_prefix strips workspaces/ prefix when agent_id=main."""
+        from routers.workspace_files import _strip_agent_prefix
+
+        entries = [
+            {"name": "workspaces", "type": "dir", "path": "workspaces"},
+            {"name": "SOUL.md", "type": "file", "path": "workspaces/SOUL.md"},
+            {"name": "plan.md", "type": "file", "path": "workspaces/notes/plan.md"},
+        ]
+        out = _strip_agent_prefix(entries, "main")
+        out_paths = [e["path"] for e in out]
+        assert "" in out_paths  # the root itself
+        assert "SOUL.md" in out_paths
+        assert "notes/plan.md" in out_paths
+
+    def test_strip_agent_prefix_custom(self):
+        """_strip_agent_prefix strips agents/{id}/ prefix for custom agents."""
+        from routers.workspace_files import _strip_agent_prefix
+
+        entries = [
+            {"name": AGENT_ID, "type": "dir", "path": f"agents/{AGENT_ID}"},
+            {"name": "SOUL.md", "type": "file", "path": f"agents/{AGENT_ID}/SOUL.md"},
+        ]
+        out = _strip_agent_prefix(entries, AGENT_ID)
+        out_paths = [e["path"] for e in out]
+        assert "" in out_paths
+        assert "SOUL.md" in out_paths
+
+    def test_write_main_with_symlink_escape_rejected(self, tmp_path):
+        """Symlink in workspaces/ pointing outside must be rejected for main agent."""
+        import os
+
+        ws = _make_workspace(tmp_path)
+        ws_dir = tmp_path / USER_ID / "workspaces"
+        ws_dir.mkdir(parents=True)
+        target = tmp_path / USER_ID / "elsewhere.txt"
+        target.write_text("original", encoding="utf-8")
+
+        os.symlink("../elsewhere.txt", ws_dir / "evil")
+
+        from routers.workspace_files import _write_file
+
+        with pytest.raises(ValueError, match="escapes"):
+            _write_file(ws, USER_ID, "main", "evil", "hacked", "workspace")
+
+        assert target.read_text() == "original"

--- a/apps/backend/tests/unit/routers/test_file_upload.py
+++ b/apps/backend/tests/unit/routers/test_file_upload.py
@@ -58,11 +58,42 @@ async def test_upload_single_file(app, auth_override, mock_container, mock_works
             body = resp.json()
             assert len(body["uploaded"]) == 1
             assert body["uploaded"][0]["filename"] == "test.txt"
-            assert body["uploaded"][0]["path"] == f".openclaw/workspaces/{AGENT_ID}/uploads/test.txt"
+            # Custom agent uploads resolve under agents/{id}/uploads/
+            assert body["uploaded"][0]["path"] == f".openclaw/agents/{AGENT_ID}/uploads/test.txt"
             assert body["uploaded"][0]["size"] == 11
 
             mock_workspace.write_bytes.assert_called_once_with(
-                "user_123", f"workspaces/{AGENT_ID}/uploads/test.txt", b"hello world"
+                "user_123", f"agents/{AGENT_ID}/uploads/test.txt", b"hello world"
+            )
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.mark.asyncio
+async def test_upload_main_agent_writes_to_user_root_workspaces(app, auth_override, mock_container, mock_workspace):
+    """Upload for agent_id=main writes to workspaces/uploads/ at the user root."""
+    app.dependency_overrides[get_current_user] = auth_override
+    try:
+        with (
+            patch("routers.container_rpc.get_ecs_manager") as mock_ecs,
+            patch("routers.container_rpc.get_workspace", return_value=mock_workspace),
+        ):
+            mock_ecs.return_value.get_service_status = AsyncMock(return_value=mock_container)
+
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/v1/container/files?agent_id=main",
+                    files=[("files", ("test.txt", b"hello world", "text/plain"))],
+                )
+
+            assert resp.status_code == 200
+            body = resp.json()
+            assert len(body["uploaded"]) == 1
+            # Main agent uploads resolve under workspaces/uploads/ (user root)
+            assert body["uploaded"][0]["path"] == ".openclaw/workspaces/uploads/test.txt"
+
+            mock_workspace.write_bytes.assert_called_once_with(
+                "user_123", "workspaces/uploads/test.txt", b"hello world"
             )
     finally:
         app.dependency_overrides.pop(get_current_user, None)


### PR DESCRIPTION
## Summary

Follow-up to #260. Fixes a production bug where the file viewer shows "No config files found" for the `main` agent, and the Workspace tab shows empty trees for all agents.

## Root cause

PR #260 assumed this EFS layout:
- Agent config files (SOUL.md etc.) at `agents/{agent_id}/`
- Agent working files at `workspaces/{agent_id}/`

The actual production layout (verified via `aws ecs execute-command` into the backend):

- **`main` agent**: workspace = `{user_root}/workspaces/` (no per-agent subdir — it inherits OpenClaw's default). Config files + working files live together here.
- **Custom agents** (e.g., `ember`): workspace = `{user_root}/agents/{agent_id}/`. Config + working files together.
- `agents/{id}/` does NOT separately hold config files — just `agent/models.json` and `sessions/` metadata.

So the viewer was reading the wrong directory and coming up empty.

## The fix

Centralize path resolution in one helper in `apps/backend/routers/workspace_files.py`:

```python
MAIN_AGENT_ID = "main"

def _agent_workspace_dir(agent_id: str) -> str:
    if agent_id == MAIN_AGENT_ID:
        return "workspaces"
    return f"agents/{agent_id}"
```

Use it everywhere paths are constructed:
- `list_workspace_tree`, `read_workspace_file`, `_list_config_files`, `read_config_file`, `_write_file`, `_strip_agent_prefix`
- Upload endpoint in `routers/container_rpc.py`

The `tab="workspace"` vs `"config"` distinction becomes cosmetic on the backend — both point at the same agent directory; only the allowlist gate differs.

## Deferred: path normalization

A future PR should normalize all agents to `workspaces/{id}/` (main → `workspaces/main/`, ember → `workspaces/ember/`). That requires:
- Migrating existing users' EFS files
- Rewriting `openclaw.json` per user to set main's workspace to `workspaces/main`
- A maintenance window

The helper keeps the mapping in one place so that PR becomes a one-line change once the migration runs.

## Test plan

- [x] Existing custom-agent tests updated to expect `agents/{id}/` paths (64 existing)
- [x] New `TestMainAgentLayout` covers `_agent_workspace_dir("main")`, config listing, read/write/tree, symlink escape, prefix stripping (~8 tests)
- [x] Upload tests cover both `agents/{id}/uploads/` (custom) and `workspaces/uploads/` (main)
- [x] All 72 tests pass: \`cd apps/backend && uv run pytest tests/test_workspace_files.py tests/unit/routers/test_file_upload.py\`
- [ ] Manual: browse file viewer on prod preview for \`main\` — Config tab shows SOUL.md, MEMORY.md, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)