### PR TITLE
fix(gateway): free-tier scale-to-zero actually works

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -29,6 +29,11 @@ _RPC_TIMEOUT = 30  # seconds
 _GRACE_PERIOD = 30  # seconds before closing idle connection
 _IDLE_CHECK_INTERVAL = 60  # seconds between idle checks
 _IDLE_TIMEOUT = 300  # 5 minutes of inactivity before scale-to-zero
+_DDB_WRITE_COOLDOWN = 30.0  # seconds between per-owner last_active_at writes
+
+# Per-owner cooldown map. Module-level so it survives pool reconstruction in tests
+# and across pool singletons. Values are the last epoch-seconds we wrote to DDB.
+_LAST_DDB_WRITE: Dict[str, float] = {}
 
 
 class GatewayConnection:
@@ -795,6 +800,28 @@ class GatewayConnectionPool:
     def touch_activity(self, user_id: str) -> None:
         """Update last activity timestamp for a user. Called on agent_chat."""
         self._last_activity[user_id] = time.time()
+
+    async def record_activity(self, owner_id: str) -> None:
+        """Record a user-interaction event.
+
+        Throttles DDB writes to at most one per owner per _DDB_WRITE_COOLDOWN
+        seconds. Callers are not expected to throttle; fire for every event.
+        """
+        now = time.time()
+        last = _LAST_DDB_WRITE.get(owner_id, 0.0)
+        if now - last < _DDB_WRITE_COOLDOWN:
+            return
+        _LAST_DDB_WRITE[owner_id] = now
+
+        from core.dynamodb import utc_now_iso
+        from core.repositories import container_repo
+
+        try:
+            await container_repo.update_last_active(owner_id, utc_now_iso())
+        except Exception:
+            # Don't let DDB flakiness break the hot path; let the next ping retry.
+            logger.warning("record_activity: DDB write failed for %s", owner_id, exc_info=True)
+            _LAST_DDB_WRITE.pop(owner_id, None)
 
     async def _create_connection(self, user_id: str, ip: str, token: str) -> GatewayConnection:
         """Create and connect a new GatewayConnection."""

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -965,6 +965,10 @@ class GatewayConnectionPool:
 
         try:
             gauge("gateway.running.count", len(rows))
+            # Preserve the legacy metric so the W5 alarm on gateway.connection.open
+            # keeps getting datapoints. Measures active backend↔container gateway
+            # WS connections (distinct from running.count, which is DDB-backed).
+            gauge("gateway.connection.open", len(self._connections))
         except Exception:
             pass
 

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -803,6 +803,13 @@ class GatewayConnectionPool:
 
         Throttles DDB writes to at most one per owner per _DDB_WRITE_COOLDOWN
         seconds. Callers are not expected to throttle; fire for every event.
+
+        Cooldown is claimed *before* the await to deflect a thundering herd of
+        concurrent pings, but is released if the write turns out to be a no-op
+        (row missing or still `status=stopped`) or if the await raises. Both
+        cases need the next ping to retry immediately — most importantly on
+        cold start, where the first ping can land while the row is still
+        flipping from `stopped` to `running`.
         """
         now = time.time()
         last = _LAST_DDB_WRITE.get(owner_id, 0.0)
@@ -814,10 +821,13 @@ class GatewayConnectionPool:
         from core.repositories import container_repo
 
         try:
-            await container_repo.update_last_active(owner_id, utc_now_iso())
+            wrote = await container_repo.update_last_active(owner_id, utc_now_iso())
         except Exception:
-            # Don't let DDB flakiness break the hot path; let the next ping retry.
             logger.warning("record_activity: DDB write failed for %s", owner_id, exc_info=True)
+            _LAST_DDB_WRITE.pop(owner_id, None)
+            return
+
+        if not wrote:
             _LAST_DDB_WRITE.pop(owner_id, None)
 
     async def _create_connection(self, user_id: str, ip: str, token: str) -> GatewayConnection:

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -966,7 +966,9 @@ class GatewayConnectionPool:
             last_active_str = row.get("last_active_at")
             if last_active_str:
                 try:
-                    last_active_epoch = datetime.fromisoformat(last_active_str).timestamp()
+                    # Our writer emits `+00:00`, but replace a trailing `Z` so
+                    # any external writer (or pre-3.11 Python) parses cleanly.
+                    last_active_epoch = datetime.fromisoformat(last_active_str.replace("Z", "+00:00")).timestamp()
                 except Exception:
                     last_active_epoch = 0.0
             else:

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -13,10 +13,12 @@ import json
 import logging
 import time
 import uuid
+from datetime import datetime
 from typing import Any, Dict, Optional, Set
 
 from websockets import connect as ws_connect
 
+from core.config import TIER_CONFIG
 from core.observability.metrics import put_metric, gauge
 from core.repositories import channel_link_repo
 
@@ -795,11 +797,6 @@ class GatewayConnectionPool:
         self._conn_member_map: Dict[str, str] = {}  # connection_id -> member_user_id
         self._lock = asyncio.Lock()
         self._grace_tasks: Dict[str, asyncio.Task] = {}
-        self._last_activity: Dict[str, float] = {}  # user_id -> last activity timestamp
-
-    def touch_activity(self, user_id: str) -> None:
-        """Update last activity timestamp for a user. Called on agent_chat."""
-        self._last_activity[user_id] = time.time()
 
     async def record_activity(self, owner_id: str) -> None:
         """Record a user-interaction event.
@@ -921,7 +918,6 @@ class GatewayConnectionPool:
             await conn.close()
         self._frontend_connections.pop(user_id, None)
         self._grace_tasks.pop(user_id, None)
-        self._last_activity.pop(user_id, None)
 
     async def broadcast_to_user(self, user_id: str, message: dict) -> None:
         """Send a message to all frontend connections for a user."""
@@ -934,61 +930,89 @@ class GatewayConnectionPool:
         for user_id in list(self._connections.keys()):
             await self.close_user(user_id)
 
-    async def run_idle_checker(self) -> None:
-        """Background task: stop free-tier containers after 5 minutes of no chat activity.
+    async def _reap_once(self) -> list[str]:
+        """One pass of the reaper. Returns the list of owner_ids that were stopped.
 
-        Runs every 60 seconds. For each user in the pool, checks:
-        1. No chat activity for 5 minutes (only agent_chat updates the timer)
-        2. User is on free tier (billing_repo.get_by_owner_id)
+        Extracted so the loop body is trivially testable — the test calls
+        `_reap_once` directly without running the outer `asyncio.sleep` loop.
 
-        If all conditions are met, stops the container via ECS and closes
-        the gateway connection. The browser may still be open — that's fine,
-        the stepper will restart the container when the user sends a message.
+        Walks DDB (container_repo.get_by_status("running")) rather than the
+        in-memory connection pool, so disconnected users whose browsers have
+        closed remain candidates for reaping. That was the root bug: the old
+        loop walked `self._connections`, and a user who closed their tab was
+        evicted from the dict before the 5-minute timer fired — so their
+        container ran forever.
         """
+        from core.containers import get_ecs_manager
         from core.containers.ecs_manager import EcsManagerError
+        from core.repositories import billing_repo, container_repo
 
-        logger.info("Idle checker started (interval=%ds, timeout=%ds)", _IDLE_CHECK_INTERVAL, _IDLE_TIMEOUT)
+        try:
+            rows = await container_repo.get_by_status("running")
+        except Exception:
+            logger.exception("idle_checker: get_by_status failed")
+            return []
+
+        try:
+            gauge("gateway.running.count", len(rows))
+        except Exception:
+            pass
+
+        now_ts = time.time()
+        stopped: list[str] = []
+
+        for row in rows:
+            owner_id = row["owner_id"]
+            last_active_str = row.get("last_active_at")
+            if last_active_str:
+                try:
+                    last_active_epoch = datetime.fromisoformat(last_active_str).timestamp()
+                except Exception:
+                    last_active_epoch = 0.0
+            else:
+                # Deploy-day path: pre-change rows have no last_active_at.
+                # Treat as epoch 0 so they're reaped on the first cycle.
+                last_active_epoch = 0.0
+
+            if now_ts - last_active_epoch < _IDLE_TIMEOUT:
+                continue
+
+            # Resolve tier; missing billing row is treated as free (orphan policy).
+            try:
+                account = await billing_repo.get_by_owner_id(owner_id)
+            except Exception:
+                logger.warning("idle_checker: billing lookup failed for %s, skipping", owner_id)
+                continue
+            plan_tier = (account or {}).get("plan_tier", "free")
+
+            if not TIER_CONFIG.get(plan_tier, {}).get("scale_to_zero", False):
+                continue
+
+            try:
+                await get_ecs_manager().stop_user_service(owner_id)
+                await container_repo.mark_stopped_if_running(owner_id)
+                put_metric("gateway.idle.scale_to_zero", dimensions={"tier": plan_tier})
+                logger.info("scale-to-zero: stopped %s (tier=%s)", owner_id, plan_tier)
+                stopped.append(owner_id)
+            except EcsManagerError as e:
+                logger.error("scale-to-zero: ECS stop failed for %s: %s", owner_id, e)
+            except Exception:
+                logger.exception("scale-to-zero: unexpected error for %s", owner_id)
+
+        return stopped
+
+    async def run_idle_checker(self) -> None:
+        """Background task: every _IDLE_CHECK_INTERVAL seconds, reap idle
+        free-tier (or orphan) containers using DDB as source of truth."""
+        logger.info(
+            "Idle checker started (interval=%ds, timeout=%ds)",
+            _IDLE_CHECK_INTERVAL,
+            _IDLE_TIMEOUT,
+        )
         try:
             while True:
                 await asyncio.sleep(_IDLE_CHECK_INTERVAL)
-                # Emit open-connection gauge every cycle
-                try:
-                    gauge("gateway.connection.open", len(self._connections))
-                except Exception:
-                    pass
-                now = time.time()
-
-                # Snapshot user_ids with active connections
-                user_ids = list(self._connections.keys())
-                for user_id in user_ids:
-                    # Skip if recent chat activity
-                    last = self._last_activity.get(user_id, now)
-                    if now - last < _IDLE_TIMEOUT:
-                        continue
-
-                    # Check if user is on the free tier
-                    try:
-                        from core.repositories import billing_repo
-
-                        account = await billing_repo.get_by_owner_id(user_id)
-                        if not account or account.get("plan_tier") != "free":
-                            continue
-                    except Exception:
-                        logger.warning("Idle checker: failed to look up billing for user %s, skipping", user_id)
-                        continue
-
-                    # Scale to zero
-                    try:
-                        from core.containers import get_ecs_manager
-
-                        put_metric("gateway.idle.scale_to_zero")
-                        await get_ecs_manager().stop_user_service(user_id)
-                        await self.close_user(user_id)
-                        logger.info("Scale-to-zero: stopped container for idle free user %s", user_id)
-                    except EcsManagerError as e:
-                        logger.error("Scale-to-zero: failed to stop container for user %s: %s", user_id, e)
-                    except Exception:
-                        logger.exception("Scale-to-zero: unexpected error for user %s", user_id)
+                await self._reap_once()
         except asyncio.CancelledError:
             logger.info("Idle checker stopped")
             return

--- a/apps/backend/core/repositories/container_repo.py
+++ b/apps/backend/core/repositories/container_repo.py
@@ -87,6 +87,65 @@ async def update_error(owner_id: str, error: str) -> dict | None:
     )
 
 
+async def update_last_active(owner_id: str, iso_ts: str) -> None:
+    """Record the last user-activity timestamp on a running container.
+
+    Conditional update: only writes if the row exists AND status != "stopped".
+    A ConditionalCheckFailedException is swallowed -- late pings for a stopped
+    or deleted row are a no-op, never an error.
+    """
+    from botocore.exceptions import ClientError
+
+    table = _get_table()
+    try:
+        await run_in_thread(
+            table.update_item,
+            Key={"owner_id": owner_id},
+            UpdateExpression="SET last_active_at = :t, updated_at = :u",
+            ConditionExpression="attribute_exists(owner_id) AND #s <> :stopped",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":t": iso_ts,
+                ":u": utc_now_iso(),
+                ":stopped": "stopped",
+            },
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            return
+        raise
+
+
+async def mark_stopped_if_running(owner_id: str) -> bool:
+    """Flip status from "running" to "stopped" atomically.
+
+    Returns True if this call performed the transition, False if the row
+    was already stopped, missing, or in some other state. Safe for multiple
+    concurrent reapers.
+    """
+    from botocore.exceptions import ClientError
+
+    table = _get_table()
+    try:
+        await run_in_thread(
+            table.update_item,
+            Key={"owner_id": owner_id},
+            UpdateExpression="SET #s = :stopped, updated_at = :u",
+            ConditionExpression="attribute_exists(owner_id) AND #s = :running",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":stopped": "stopped",
+                ":running": "running",
+                ":u": utc_now_iso(),
+            },
+        )
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
 async def delete(owner_id: str) -> None:
     table = _get_table()
     await run_in_thread(table.delete_item, Key={"owner_id": owner_id})

--- a/apps/backend/core/repositories/container_repo.py
+++ b/apps/backend/core/repositories/container_repo.py
@@ -102,12 +102,14 @@ async def update_error(owner_id: str, error: str) -> dict | None:
     )
 
 
-async def update_last_active(owner_id: str, iso_ts: str) -> None:
+async def update_last_active(owner_id: str, iso_ts: str) -> bool:
     """Record the last user-activity timestamp on a running container.
 
     Conditional update: only writes if the row exists AND status != "stopped".
-    A ConditionalCheckFailedException is swallowed -- late pings for a stopped
-    or deleted row are a no-op, never an error.
+    Returns True if the row was mutated, False if the condition failed (row
+    missing or status=stopped). Callers need to know whether the write
+    actually landed so they don't lock out the next retry during cold-start
+    transitions where the row is still flipping from "stopped" to "running".
     """
     from botocore.exceptions import ClientError
 
@@ -125,9 +127,10 @@ async def update_last_active(owner_id: str, iso_ts: str) -> None:
                 ":stopped": "stopped",
             },
         )
+        return True
     except ClientError as e:
         if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
-            return
+            return False
         raise
 
 

--- a/apps/backend/core/repositories/container_repo.py
+++ b/apps/backend/core/repositories/container_repo.py
@@ -29,13 +29,28 @@ async def get_by_gateway_token(token: str) -> dict | None:
 
 
 async def get_by_status(status: str) -> list[dict]:
+    """Return every container row with the given status.
+
+    Follows DynamoDB's LastEvaluatedKey. Query responses are capped at 1 MB,
+    so a single call only returns the first page — the reaper (and any other
+    caller that iterates the full set for correctness) needs every row.
+    """
     table = _get_table()
-    response = await run_in_thread(
-        table.query,
-        IndexName="status-index",
-        KeyConditionExpression=Key("status").eq(status),
-    )
-    return response.get("Items", [])
+    items: list[dict] = []
+    last_evaluated_key: dict | None = None
+    while True:
+        kwargs = {
+            "IndexName": "status-index",
+            "KeyConditionExpression": Key("status").eq(status),
+        }
+        if last_evaluated_key is not None:
+            kwargs["ExclusiveStartKey"] = last_evaluated_key
+        response = await run_in_thread(table.query, **kwargs)
+        items.extend(response.get("Items", []))
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+    return items
 
 
 async def upsert(owner_id: str, fields: dict) -> dict:

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 
@@ -18,7 +19,9 @@ from fastapi.responses import JSONResponse
 
 from core.auth import get_current_user
 from core.config import settings
-from core.containers import startup_containers, shutdown_containers
+from core.containers import get_gateway_pool, startup_containers, shutdown_containers
+from core.observability.metrics import put_metric
+from core.services.update_service import run_scheduled_worker
 from routers import (
     billing,
     channels,
@@ -42,25 +45,33 @@ from routers import (
 logger = logging.getLogger(__name__)
 
 
+async def _safe_idle_checker():
+    """Run the gateway idle checker with a metric emitted on crash.
+
+    The in-process reaper used to die silently inside this broad except, which
+    meant free-tier containers never scaled to zero. Emitting
+    ``gateway.idle_checker.crash`` lets a CloudWatch alarm page when the reaper
+    dies. The metric emit is itself wrapped in try/except so a metric failure
+    can't mask the original reaper crash.
+    """
+    try:
+        pool = get_gateway_pool()
+        await pool.run_idle_checker()
+    except Exception:
+        try:
+            put_metric("gateway.idle_checker.crash")
+        except Exception:
+            pass
+        logger.warning("idle checker exited with exception", exc_info=True)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan handler."""
-    import asyncio
-
-    from core.containers import get_gateway_pool
-    from core.services.update_service import run_scheduled_worker
-
     # Startup
     logger.info("Starting application...")
     await startup_containers()
     worker_task = asyncio.create_task(run_scheduled_worker())
-
-    async def _safe_idle_checker():
-        try:
-            pool = get_gateway_pool()
-            await pool.run_idle_checker()
-        except Exception:
-            logger.warning("Idle checker not available (gateway pool init failed)")
 
     idle_checker_task = asyncio.create_task(_safe_idle_checker())
 

--- a/apps/backend/routers/websocket_chat.py
+++ b/apps/backend/routers/websocket_chat.py
@@ -330,6 +330,13 @@ async def ws_message(
         )
         return Response(status_code=200)
 
+    if msg_type == "user_active":
+        try:
+            await get_gateway_pool().record_activity(owner_id)
+        except Exception:
+            pass  # Pool may not be initialized in tests
+        return Response(status_code=200)
+
     if msg_type == "agent_chat":
         agent_id = body.get("agent_id")
         message = body.get("message")
@@ -344,7 +351,7 @@ async def ws_message(
 
         # Track chat activity for idle detection (scale-to-zero)
         try:
-            get_gateway_pool().touch_activity(owner_id)
+            await get_gateway_pool().record_activity(owner_id)
         except Exception:
             pass  # Pool may not be initialized in tests
 

--- a/apps/backend/routers/websocket_chat.py
+++ b/apps/backend/routers/websocket_chat.py
@@ -331,8 +331,10 @@ async def ws_message(
         return Response(status_code=200)
 
     if msg_type == "user_active":
+        # Fire-and-forget: the ping is best-effort activity tracking. Awaiting
+        # would let DDB slowness stall /ws/message and risk API Gateway timeouts.
         try:
-            await get_gateway_pool().record_activity(owner_id)
+            asyncio.create_task(get_gateway_pool().record_activity(owner_id))
         except Exception:
             pass  # Pool may not be initialized in tests
         return Response(status_code=200)
@@ -349,9 +351,11 @@ async def ws_message(
             )
             return Response(status_code=200)
 
-        # Track chat activity for idle detection (scale-to-zero)
+        # Track chat activity for idle detection (scale-to-zero). Fire-and-forget
+        # so DDB latency can't stall the chat request and trigger an API Gateway
+        # timeout.
         try:
-            await get_gateway_pool().record_activity(owner_id)
+            asyncio.create_task(get_gateway_pool().record_activity(owner_id))
         except Exception:
             pass  # Pool may not be initialized in tests
 

--- a/apps/backend/tests/unit/gateway/test_connection_pool.py
+++ b/apps/backend/tests/unit/gateway/test_connection_pool.py
@@ -80,3 +80,15 @@ async def test_record_activity_different_users_not_coalesced():
         await pool.record_activity("user_2")
 
     assert mock_update.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_close_user_no_longer_references_last_activity():
+    """Regression for Task 4: close_user used to pop _last_activity, now that
+    dict is gone. This test ensures close_user runs cleanly for a user it's
+    never seen — no AttributeError / KeyError from the removed code path."""
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    pool = GatewayConnectionPool(management_api=None)
+    # Should not raise
+    await pool.close_user("user_never_connected")

--- a/apps/backend/tests/unit/gateway/test_connection_pool.py
+++ b/apps/backend/tests/unit/gateway/test_connection_pool.py
@@ -19,6 +19,7 @@ async def test_record_activity_writes_ddb_on_first_call():
     with patch(
         "core.repositories.container_repo.update_last_active",
         new_callable=AsyncMock,
+        return_value=True,
     ) as mock_update:
         await pool.record_activity("user_1")
 
@@ -38,6 +39,7 @@ async def test_record_activity_coalesces_within_cooldown():
     with patch(
         "core.repositories.container_repo.update_last_active",
         new_callable=AsyncMock,
+        return_value=True,
     ) as mock_update:
         await pool.record_activity("user_1")
         await pool.record_activity("user_1")
@@ -56,6 +58,7 @@ async def test_record_activity_writes_again_after_cooldown():
     with patch(
         "core.repositories.container_repo.update_last_active",
         new_callable=AsyncMock,
+        return_value=True,
     ) as mock_update:
         await pool.record_activity("user_1")
         # Simulate 31s elapsed by directly adjusting the coalesce map
@@ -75,9 +78,58 @@ async def test_record_activity_different_users_not_coalesced():
     with patch(
         "core.repositories.container_repo.update_last_active",
         new_callable=AsyncMock,
+        return_value=True,
     ) as mock_update:
         await pool.record_activity("user_1")
         await pool.record_activity("user_2")
+
+    assert mock_update.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_record_activity_releases_cooldown_on_noop_write():
+    """Cold-start regression: when update_last_active returns False (row still
+    status=stopped before start_user_service has flipped it), the cooldown
+    must be released so the next ping retries immediately. Otherwise the
+    reaper could see a null last_active_at on the next cycle and stop an
+    actively-used container.
+    """
+    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with patch(
+        "core.repositories.container_repo.update_last_active",
+        new_callable=AsyncMock,
+        return_value=False,
+    ) as mock_update:
+        await pool.record_activity("user_1")
+
+    mock_update.assert_awaited_once()
+    # Cooldown must NOT be set; next ping should go through.
+    assert "user_1" not in _LAST_DDB_WRITE
+
+
+@pytest.mark.asyncio
+async def test_record_activity_retries_immediately_after_noop_write():
+    """Companion to the above: after a no-op write, a second ping in the
+    same instant should fire another write — cooldown was released, so no
+    30s lockout."""
+    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    # First call: row is stopped, returns False. Second call: row is now
+    # running, returns True. Both should reach update_last_active.
+    with patch(
+        "core.repositories.container_repo.update_last_active",
+        new_callable=AsyncMock,
+        side_effect=[False, True],
+    ) as mock_update:
+        await pool.record_activity("user_1")
+        await pool.record_activity("user_1")
 
     assert mock_update.await_count == 2
 

--- a/apps/backend/tests/unit/gateway/test_connection_pool.py
+++ b/apps/backend/tests/unit/gateway/test_connection_pool.py
@@ -1,0 +1,82 @@
+"""Tests for GatewayConnectionPool public methods."""
+
+import os
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+@pytest.mark.asyncio
+async def test_record_activity_writes_ddb_on_first_call():
+    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with patch(
+        "core.repositories.container_repo.update_last_active",
+        new_callable=AsyncMock,
+    ) as mock_update:
+        await pool.record_activity("user_1")
+
+    mock_update.assert_awaited_once()
+    assert mock_update.await_args.args[0] == "user_1"
+    # Second arg is an ISO-8601 UTC string
+    assert "T" in mock_update.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_record_activity_coalesces_within_cooldown():
+    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with patch(
+        "core.repositories.container_repo.update_last_active",
+        new_callable=AsyncMock,
+    ) as mock_update:
+        await pool.record_activity("user_1")
+        await pool.record_activity("user_1")
+        await pool.record_activity("user_1")
+
+    assert mock_update.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_record_activity_writes_again_after_cooldown():
+    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with patch(
+        "core.repositories.container_repo.update_last_active",
+        new_callable=AsyncMock,
+    ) as mock_update:
+        await pool.record_activity("user_1")
+        # Simulate 31s elapsed by directly adjusting the coalesce map
+        _LAST_DDB_WRITE["user_1"] = time.time() - 31.0
+        await pool.record_activity("user_1")
+
+    assert mock_update.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_record_activity_different_users_not_coalesced():
+    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with patch(
+        "core.repositories.container_repo.update_last_active",
+        new_callable=AsyncMock,
+    ) as mock_update:
+        await pool.record_activity("user_1")
+        await pool.record_activity("user_2")
+
+    assert mock_update.await_count == 2

--- a/apps/backend/tests/unit/gateway/test_idle_checker.py
+++ b/apps/backend/tests/unit/gateway/test_idle_checker.py
@@ -1,0 +1,251 @@
+"""Tests for the free-tier scale-to-zero reaper."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_reaps_disconnected_idle_free_user():
+    """Regression for the core bug: a free user with no open WS gets reaped
+    anyway because the reaper walks DDB, not self._connections."""
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    old_ts = _iso(datetime.now(timezone.utc) - timedelta(minutes=6))
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[{"owner_id": "user_free", "status": "running", "last_active_at": old_ts}],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"owner_id": "user_free", "plan_tier": "free"},
+        ),
+        patch("core.containers.get_ecs_manager") as mock_get_ecs,
+        patch(
+            "core.repositories.container_repo.mark_stopped_if_running",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_mark_stopped,
+    ):
+        ecs = mock_get_ecs.return_value
+        ecs.stop_user_service = AsyncMock()
+
+        stopped = await pool._reap_once()
+
+        ecs.stop_user_service.assert_awaited_once_with("user_free")
+        mock_mark_stopped.assert_awaited_once_with("user_free")
+        assert stopped == ["user_free"]
+
+
+@pytest.mark.asyncio
+async def test_treats_orphan_as_free():
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    old_ts = _iso(datetime.now(timezone.utc) - timedelta(minutes=10))
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[{"owner_id": "user_orphan", "status": "running", "last_active_at": old_ts}],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("core.containers.get_ecs_manager") as mock_get_ecs,
+        patch(
+            "core.repositories.container_repo.mark_stopped_if_running",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        ecs = mock_get_ecs.return_value
+        ecs.stop_user_service = AsyncMock()
+
+        stopped = await pool._reap_once()
+
+        ecs.stop_user_service.assert_awaited_once_with("user_orphan")
+        assert stopped == ["user_orphan"]
+
+
+@pytest.mark.asyncio
+async def test_skips_paid_tier():
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    old_ts = _iso(datetime.now(timezone.utc) - timedelta(minutes=60))
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[{"owner_id": "user_paid", "status": "running", "last_active_at": old_ts}],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"owner_id": "user_paid", "plan_tier": "starter"},
+        ),
+        patch("core.containers.get_ecs_manager") as mock_get_ecs,
+    ):
+        ecs = mock_get_ecs.return_value
+        ecs.stop_user_service = AsyncMock()
+
+        stopped = await pool._reap_once()
+
+        ecs.stop_user_service.assert_not_awaited()
+        assert stopped == []
+
+
+@pytest.mark.asyncio
+async def test_skips_not_yet_idle():
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    recent_ts = _iso(datetime.now(timezone.utc) - timedelta(seconds=120))
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[{"owner_id": "user_free", "status": "running", "last_active_at": recent_ts}],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"owner_id": "user_free", "plan_tier": "free"},
+        ),
+        patch("core.containers.get_ecs_manager") as mock_get_ecs,
+    ):
+        ecs = mock_get_ecs.return_value
+        ecs.stop_user_service = AsyncMock()
+
+        stopped = await pool._reap_once()
+
+        ecs.stop_user_service.assert_not_awaited()
+        assert stopped == []
+
+
+@pytest.mark.asyncio
+async def test_reaps_row_with_null_last_active_at():
+    """Deploy-day path: rows from before this change have no last_active_at.
+    They must be treated as very old and reaped on first cycle."""
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[{"owner_id": "user_stale", "status": "running"}],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"owner_id": "user_stale", "plan_tier": "free"},
+        ),
+        patch("core.containers.get_ecs_manager") as mock_get_ecs,
+        patch(
+            "core.repositories.container_repo.mark_stopped_if_running",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        ecs = mock_get_ecs.return_value
+        ecs.stop_user_service = AsyncMock()
+
+        stopped = await pool._reap_once()
+
+        ecs.stop_user_service.assert_awaited_once_with("user_stale")
+        assert stopped == ["user_stale"]
+
+
+@pytest.mark.asyncio
+async def test_honors_scale_to_zero_flag_not_string_literal():
+    """The reaper reads TIER_CONFIG['<tier>']['scale_to_zero'], not a hard 'free' string.
+    Mutating the flag changes behavior."""
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    old_ts = _iso(datetime.now(timezone.utc) - timedelta(minutes=30))
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.gateway.connection_pool.TIER_CONFIG",
+            {"trial": {"scale_to_zero": True}, "starter": {"scale_to_zero": False}},
+        ),
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[{"owner_id": "user_trial", "status": "running", "last_active_at": old_ts}],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"owner_id": "user_trial", "plan_tier": "trial"},
+        ),
+        patch("core.containers.get_ecs_manager") as mock_get_ecs,
+        patch(
+            "core.repositories.container_repo.mark_stopped_if_running",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        ecs = mock_get_ecs.return_value
+        ecs.stop_user_service = AsyncMock()
+
+        stopped = await pool._reap_once()
+
+        ecs.stop_user_service.assert_awaited_once_with("user_trial")
+        assert stopped == ["user_trial"]
+
+
+@pytest.mark.asyncio
+async def test_reaper_survives_billing_lookup_failure():
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    old_ts = _iso(datetime.now(timezone.utc) - timedelta(minutes=30))
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[
+                {"owner_id": "user_a", "status": "running", "last_active_at": old_ts},
+                {"owner_id": "user_b", "status": "running", "last_active_at": old_ts},
+            ],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            side_effect=[RuntimeError("ddb blip"), {"owner_id": "user_b", "plan_tier": "free"}],
+        ),
+        patch("core.containers.get_ecs_manager") as mock_get_ecs,
+        patch(
+            "core.repositories.container_repo.mark_stopped_if_running",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        ecs = mock_get_ecs.return_value
+        ecs.stop_user_service = AsyncMock()
+
+        stopped = await pool._reap_once()
+
+        # user_a was skipped due to billing failure; user_b still reaped
+        assert stopped == ["user_b"]

--- a/apps/backend/tests/unit/gateway/test_idle_checker.py
+++ b/apps/backend/tests/unit/gateway/test_idle_checker.py
@@ -249,3 +249,40 @@ async def test_reaper_survives_billing_lookup_failure():
 
         # user_a was skipped due to billing failure; user_b still reaped
         assert stopped == ["user_b"]
+
+
+@pytest.mark.asyncio
+async def test_reap_once_emits_both_gauges():
+    """Every reaper cycle must emit both gateway.running.count (new, feeds P12
+    heartbeat alarm) AND gateway.connection.open (legacy, feeds the W5 alarm
+    which has treatMissingData=BREACHING). Dropping the legacy emission would
+    leave W5 permanently in ALARM from absent datapoints."""
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    pool = GatewayConnectionPool(management_api=None)
+    # Simulate two "open" backend↔gateway connections so the legacy gauge has
+    # a non-zero sample to assert on.
+    pool._connections = {"user_a": object(), "user_b": object()}  # type: ignore[assignment]
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[{"owner_id": "user_a", "status": "running"}],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"owner_id": "user_a", "plan_tier": "starter"},
+        ),
+        patch("core.gateway.connection_pool.gauge") as mock_gauge,
+    ):
+        await pool._reap_once()
+
+    metric_names = [call.args[0] for call in mock_gauge.call_args_list]
+    assert "gateway.running.count" in metric_names
+    assert "gateway.connection.open" in metric_names
+    running_call = next(c for c in mock_gauge.call_args_list if c.args[0] == "gateway.running.count")
+    open_call = next(c for c in mock_gauge.call_args_list if c.args[0] == "gateway.connection.open")
+    assert running_call.args[1] == 1  # one row from get_by_status
+    assert open_call.args[1] == 2  # two entries in pool._connections

--- a/apps/backend/tests/unit/repositories/test_container_repo.py
+++ b/apps/backend/tests/unit/repositories/test_container_repo.py
@@ -266,8 +266,9 @@ async def test_update_last_active_sets_timestamp_on_running_container(dynamodb_t
 
     await container_repo.upsert("user_1", {"status": "running", "gateway_token": "t1"})
 
-    await container_repo.update_last_active("user_1", "2026-04-13T20:30:00+00:00")
+    wrote = await container_repo.update_last_active("user_1", "2026-04-13T20:30:00+00:00")
 
+    assert wrote is True
     row = await container_repo.get_by_owner_id("user_1")
     assert row["last_active_at"] == "2026-04-13T20:30:00+00:00"
 
@@ -278,9 +279,11 @@ async def test_update_last_active_noop_when_stopped(dynamodb_table):
 
     await container_repo.upsert("user_1", {"status": "stopped", "gateway_token": "t1"})
 
-    # Must not raise, must not revive a stopped container
-    await container_repo.update_last_active("user_1", "2026-04-13T20:30:00+00:00")
+    # Must not raise; must return False so callers (record_activity) can
+    # release their cooldown and retry on the next ping.
+    wrote = await container_repo.update_last_active("user_1", "2026-04-13T20:30:00+00:00")
 
+    assert wrote is False
     row = await container_repo.get_by_owner_id("user_1")
     assert "last_active_at" not in row
     assert row["status"] == "stopped"
@@ -290,9 +293,10 @@ async def test_update_last_active_noop_when_stopped(dynamodb_table):
 async def test_update_last_active_noop_when_row_missing(dynamodb_table):
     from core.repositories import container_repo
 
-    # Must not raise on missing row (late ping for a user who was fully deleted)
-    await container_repo.update_last_active("user_never_existed", "2026-04-13T20:30:00+00:00")
+    # Must not raise on missing row (late ping for a user who was fully deleted).
+    wrote = await container_repo.update_last_active("user_never_existed", "2026-04-13T20:30:00+00:00")
 
+    assert wrote is False
     row = await container_repo.get_by_owner_id("user_never_existed")
     assert row is None
 

--- a/apps/backend/tests/unit/repositories/test_container_repo.py
+++ b/apps/backend/tests/unit/repositories/test_container_repo.py
@@ -151,6 +151,44 @@ async def test_get_by_status(dynamodb_table):
 
 
 @pytest.mark.asyncio
+async def test_get_by_status_paginates_through_last_evaluated_key():
+    """Regression: DDB Query caps at 1MB per page. get_by_status must follow
+    LastEvaluatedKey so the reaper doesn't silently miss users past the first
+    page once the fleet grows."""
+    from unittest.mock import MagicMock, patch
+
+    from core.repositories import container_repo
+
+    page1 = {
+        "Items": [{"owner_id": "user_page1_a"}, {"owner_id": "user_page1_b"}],
+        "LastEvaluatedKey": {"owner_id": "user_page1_b"},
+    }
+    page2 = {
+        "Items": [{"owner_id": "user_page2_a"}],
+        # no LastEvaluatedKey → loop terminates
+    }
+
+    fake_table = MagicMock()
+    fake_table.query = MagicMock(side_effect=[page1, page2])
+
+    with patch("core.repositories.container_repo._get_table", return_value=fake_table):
+        results = await container_repo.get_by_status("running")
+
+    assert [r["owner_id"] for r in results] == [
+        "user_page1_a",
+        "user_page1_b",
+        "user_page2_a",
+    ]
+    assert fake_table.query.call_count == 2
+    # First call must NOT include ExclusiveStartKey; second call MUST include
+    # the key returned by the first page.
+    first_kwargs = fake_table.query.call_args_list[0].kwargs
+    second_kwargs = fake_table.query.call_args_list[1].kwargs
+    assert "ExclusiveStartKey" not in first_kwargs
+    assert second_kwargs["ExclusiveStartKey"] == {"owner_id": "user_page1_b"}
+
+
+@pytest.mark.asyncio
 async def test_update_status(dynamodb_table):
     from core.repositories import container_repo
 

--- a/apps/backend/tests/unit/repositories/test_container_repo.py
+++ b/apps/backend/tests/unit/repositories/test_container_repo.py
@@ -220,3 +220,75 @@ async def test_get_by_owner_id_alias(dynamodb_table):
     item = await container_repo.get_by_owner_id("org_456")
     assert item is not None
     assert item["owner_type"] == "org"
+
+
+@pytest.mark.asyncio
+async def test_update_last_active_sets_timestamp_on_running_container(dynamodb_table):
+    from core.repositories import container_repo
+
+    await container_repo.upsert("user_1", {"status": "running", "gateway_token": "t1"})
+
+    await container_repo.update_last_active("user_1", "2026-04-13T20:30:00+00:00")
+
+    row = await container_repo.get_by_owner_id("user_1")
+    assert row["last_active_at"] == "2026-04-13T20:30:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_update_last_active_noop_when_stopped(dynamodb_table):
+    from core.repositories import container_repo
+
+    await container_repo.upsert("user_1", {"status": "stopped", "gateway_token": "t1"})
+
+    # Must not raise, must not revive a stopped container
+    await container_repo.update_last_active("user_1", "2026-04-13T20:30:00+00:00")
+
+    row = await container_repo.get_by_owner_id("user_1")
+    assert "last_active_at" not in row
+    assert row["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_update_last_active_noop_when_row_missing(dynamodb_table):
+    from core.repositories import container_repo
+
+    # Must not raise on missing row (late ping for a user who was fully deleted)
+    await container_repo.update_last_active("user_never_existed", "2026-04-13T20:30:00+00:00")
+
+    row = await container_repo.get_by_owner_id("user_never_existed")
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_mark_stopped_if_running_flips_running_to_stopped(dynamodb_table):
+    from core.repositories import container_repo
+
+    await container_repo.upsert("user_1", {"status": "running", "gateway_token": "t1"})
+
+    flipped = await container_repo.mark_stopped_if_running("user_1")
+
+    assert flipped is True
+    row = await container_repo.get_by_owner_id("user_1")
+    assert row["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_mark_stopped_if_running_noop_when_already_stopped(dynamodb_table):
+    from core.repositories import container_repo
+
+    await container_repo.upsert("user_1", {"status": "stopped", "gateway_token": "t1"})
+
+    flipped = await container_repo.mark_stopped_if_running("user_1")
+
+    assert flipped is False
+    row = await container_repo.get_by_owner_id("user_1")
+    assert row["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_mark_stopped_if_running_noop_when_row_missing(dynamodb_table):
+    from core.repositories import container_repo
+
+    flipped = await container_repo.mark_stopped_if_running("user_never_existed")
+
+    assert flipped is False

--- a/apps/backend/tests/unit/routers/test_websocket_chat.py
+++ b/apps/backend/tests/unit/routers/test_websocket_chat.py
@@ -10,6 +10,8 @@ These tests use httpx AsyncClient with ASGITransport for testing HTTP endpoints.
 Services are mocked to isolate route logic.
 """
 
+import asyncio
+
 import pytest
 from unittest.mock import MagicMock, patch
 from fastapi import FastAPI
@@ -426,6 +428,9 @@ class TestActivityTracking:
             )
 
         assert response.status_code == 200
+        # record_activity is scheduled fire-and-forget via asyncio.create_task
+        # so the handler can return before DDB latency. Drain pending tasks.
+        await asyncio.sleep(0)
         mock_gateway_pool.record_activity.assert_awaited_once_with("test-user")
         mock_management_api.send_message.assert_not_called()
 
@@ -450,6 +455,7 @@ class TestActivityTracking:
             )
 
         assert response.status_code == 200
+        await asyncio.sleep(0)  # drain the fire-and-forget task
         mock_gateway_pool.record_activity.assert_awaited_once_with("test-org-789")
 
     @pytest.mark.asyncio
@@ -483,4 +489,5 @@ class TestActivityTracking:
                 )
 
         assert response.status_code == 200
+        await asyncio.sleep(0)  # drain the fire-and-forget task
         mock_gateway_pool.record_activity.assert_awaited_once_with("test-user")

--- a/apps/backend/tests/unit/routers/test_websocket_chat.py
+++ b/apps/backend/tests/unit/routers/test_websocket_chat.py
@@ -400,3 +400,87 @@ class TestReqMessageRouting:
         assert sent_msg["type"] == "res"
         assert sent_msg["id"] == "req-uuid-2"
         assert sent_msg["ok"] is False
+
+
+class TestActivityTracking:
+    """Tests for activity tracking dispatch (scale-to-zero idle detection)."""
+
+    @pytest.mark.asyncio
+    async def test_user_active_dispatch_calls_record_activity(
+        self, test_app, mock_connection_service, mock_management_api, mock_gateway_pool
+    ):
+        """user_active message should call pool.record_activity(owner_id) exactly once and return 200."""
+        from unittest.mock import AsyncMock
+
+        mock_connection_service.get_connection.return_value = {
+            "user_id": "test-user",
+            "org_id": None,
+        }
+        mock_gateway_pool.record_activity = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+            response = await client.post(
+                "/ws/message",
+                headers={"x-connection-id": "conn-abc"},
+                json={"type": "user_active"},
+            )
+
+        assert response.status_code == 200
+        mock_gateway_pool.record_activity.assert_awaited_once_with("test-user")
+        mock_management_api.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_user_active_dispatch_uses_org_owner_id(
+        self, test_app, mock_connection_service, mock_management_api, mock_gateway_pool
+    ):
+        """user_active should record activity under org_id when connection has one."""
+        from unittest.mock import AsyncMock
+
+        mock_connection_service.get_connection.return_value = {
+            "user_id": "test-user",
+            "org_id": "test-org-789",
+        }
+        mock_gateway_pool.record_activity = AsyncMock()
+
+        async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+            response = await client.post(
+                "/ws/message",
+                headers={"x-connection-id": "conn-abc"},
+                json={"type": "user_active"},
+            )
+
+        assert response.status_code == 200
+        mock_gateway_pool.record_activity.assert_awaited_once_with("test-org-789")
+
+    @pytest.mark.asyncio
+    async def test_agent_chat_dispatch_calls_record_activity(
+        self, test_app, mock_connection_service, mock_management_api, mock_gateway_pool
+    ):
+        """agent_chat should route through record_activity (not touch_activity)."""
+        from unittest.mock import AsyncMock
+
+        mock_connection_service.get_connection.return_value = {
+            "user_id": "test-user",
+            "org_id": None,
+        }
+        mock_gateway_pool.record_activity = AsyncMock()
+        # Guard: if agent_chat still calls touch_activity, fail loudly (None is not callable).
+        mock_gateway_pool.touch_activity = None
+
+        with (
+            patch(
+                "core.services.usage_service.check_budget",
+                new_callable=AsyncMock,
+                return_value={"allowed": True},
+            ),
+            patch("routers.websocket_chat._process_agent_chat_background"),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+                response = await client.post(
+                    "/ws/message",
+                    headers={"x-connection-id": "conn-abc"},
+                    json={"type": "agent_chat", "agent_id": "a1", "message": "hello"},
+                )
+
+        assert response.status_code == 200
+        mock_gateway_pool.record_activity.assert_awaited_once_with("test-user")

--- a/apps/backend/tests/unit/test_main_lifespan.py
+++ b/apps/backend/tests/unit/test_main_lifespan.py
@@ -1,0 +1,26 @@
+"""Tests for backend lifespan startup/shutdown wiring."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_safe_idle_checker_emits_crash_metric_on_exception():
+    """When the reaper (idle checker) raises, we MUST emit gateway.idle_checker.crash.
+
+    Task 9's CloudWatch alarm hardcodes this exact metric name — any deviation
+    means the alarm never fires when the reaper dies silently.
+    """
+    from main import _safe_idle_checker
+
+    failing_pool = MagicMock()
+    failing_pool.run_idle_checker = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with (
+        patch("main.get_gateway_pool", return_value=failing_pool),
+        patch("main.put_metric") as mock_put_metric,
+    ):
+        await _safe_idle_checker()
+
+    mock_put_metric.assert_any_call("gateway.idle_checker.crash")

--- a/apps/frontend/src/components/chat/ChatLayout.tsx
+++ b/apps/frontend/src/components/chat/ChatLayout.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { ProvisioningStepper } from "@/components/chat/ProvisioningStepper";
 import { HealthIndicator } from "@/components/chat/HealthIndicator";
 import { useGateway } from "@/hooks/useGateway";
+import { useActivityPing } from "@/hooks/useActivityPing";
 import { useApi } from "@/lib/api";
 import { useAgents, getAgentModelString, type Agent } from "@/hooks/useAgents";
 import { useBilling } from "@/hooks/useBilling";
@@ -66,6 +67,9 @@ export function ChatLayout({
   const { agents, defaultId, createAgent, deleteAgent, updateAgent } = useAgents();
   const { refresh: refreshBilling, account } = useBilling();
   const { nodeConnected } = useGateway();
+  // Emit throttled user_active pings so the backend scale-to-zero reaper
+  // can keep idle free-tier containers running while the user is active.
+  useActivityPing();
   const searchParams = useSearchParams();
 
   const [userSelectedId, setUserSelectedId] = useState<string | null>(null);

--- a/apps/frontend/src/hooks/__tests__/useActivityPing.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useActivityPing.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-// Mock useGateway to observe send() calls.
+// Mock useGateway to observe send() calls. Mutable so individual tests can
+// simulate the pre-Task-8 state where useGateway does not yet expose `send`.
 const send = vi.fn();
+let mockGatewayValue: { send?: typeof send; isConnected: boolean } = {
+  send,
+  isConnected: true,
+};
 vi.mock('../useGateway', () => ({
-  useGateway: () => ({
-    send,
-    isConnected: true,
-  }),
+  useGateway: () => mockGatewayValue,
 }));
 
 function setVisibility(state: 'visible' | 'hidden') {
@@ -28,6 +30,7 @@ describe('useActivityPing', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     send.mockReset();
+    mockGatewayValue = { send, isConnected: true };
     setVisibility('visible');
   });
 
@@ -126,5 +129,23 @@ describe('useActivityPing', () => {
       vi.advanceTimersByTime(6_000);
     });
     expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when gateway has no send method (pre-Task-8 state)', async () => {
+    // The real useGateway context does not yet expose a raw `send` method;
+    // that wiring lands in Task 8. Until then the hook must be a no-op
+    // rather than crashing with `TypeError: send is not a function`.
+    mockGatewayValue = { isConnected: true };
+    const useActivityPing = await importHook();
+    renderHook(() => useActivityPing());
+
+    expect(() => {
+      act(() => {
+        window.dispatchEvent(new MouseEvent('mousemove'));
+        vi.advanceTimersByTime(6_000);
+      });
+    }).not.toThrow();
+
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/hooks/__tests__/useActivityPing.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useActivityPing.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock useGateway to observe send() calls.
+const send = vi.fn();
+vi.mock('../useGateway', () => ({
+  useGateway: () => ({
+    send,
+    isConnected: true,
+  }),
+}));
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    value: state,
+    configurable: true,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+async function importHook() {
+  // Import late so the useGateway mock is already installed.
+  const mod = await import('../useActivityPing');
+  return mod.useActivityPing;
+}
+
+describe('useActivityPing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    send.mockReset();
+    setVisibility('visible');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends one user_active when interacting on a visible tab', async () => {
+    const useActivityPing = await importHook();
+    renderHook(() => useActivityPing());
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+    });
+    act(() => {
+      vi.advanceTimersByTime(6_000);  // drain interval
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith({ type: 'user_active' });
+  });
+
+  it('coalesces 100 mousemoves within the 60s gate', async () => {
+    const useActivityPing = await importHook();
+    renderHook(() => useActivityPing());
+
+    act(() => {
+      for (let i = 0; i < 100; i++) {
+        window.dispatchEvent(new MouseEvent('mousemove'));
+      }
+    });
+    act(() => {
+      vi.advanceTimersByTime(6_000);
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends a second ping after 60s of additional interaction', async () => {
+    const useActivityPing = await importHook();
+    renderHook(() => useActivityPing());
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      vi.advanceTimersByTime(6_000);
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(61_000);
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      vi.advanceTimersByTime(6_000);
+    });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not send while tab is hidden', async () => {
+    const useActivityPing = await importHook();
+    renderHook(() => useActivityPing());
+
+    setVisibility('hidden');
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does not send when visible but idle', async () => {
+    const useActivityPing = await importHook();
+    renderHook(() => useActivityPing());
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('resumes sending when tab becomes visible again during interaction', async () => {
+    const useActivityPing = await importHook();
+    renderHook(() => useActivityPing());
+
+    setVisibility('hidden');
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(send).not.toHaveBeenCalled();
+
+    setVisibility('visible');
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      vi.advanceTimersByTime(6_000);
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/hooks/useActivityPing.ts
+++ b/apps/frontend/src/hooks/useActivityPing.ts
@@ -7,12 +7,13 @@ const DRAIN_INTERVAL_MS = 5_000;
 /**
  * Subset of the gateway API this hook depends on. The real `useGateway`
  * context is expected to expose a raw `send(message)` method alongside
- * `isConnected`; the wiring that adds it lives in a separate task. Cast
- * through this shape so the hook stays self-contained and the tests can
- * mock `useGateway` with just the two fields it actually uses.
+ * `isConnected`; the wiring that adds it lives in a separate task. `send`
+ * is marked optional because the hook ships before that wiring — a
+ * runtime guard keeps the hook a no-op until `send` is present, rather
+ * than throwing a `TypeError` on the first drain.
  */
 interface ActivityGateway {
-  send: (message: { type: 'user_active' }) => void;
+  send?: (message: { type: 'user_active' }) => void;
   isConnected: boolean;
 }
 
@@ -42,6 +43,7 @@ export function useActivityPing(): void {
     const drain = () => {
       if (!pendingRef.current) return;
       if (document.visibilityState !== 'visible') return;
+      if (typeof send !== 'function') return;
       const now = Date.now();
       if (now - lastPingRef.current < PING_INTERVAL_MS) return;
       send({ type: 'user_active' });

--- a/apps/frontend/src/hooks/useActivityPing.ts
+++ b/apps/frontend/src/hooks/useActivityPing.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+import { useGateway } from './useGateway';
+
+const PING_INTERVAL_MS = 60_000;
+const DRAIN_INTERVAL_MS = 5_000;
+
+/**
+ * Subset of the gateway API this hook depends on. The real `useGateway`
+ * context is expected to expose a raw `send(message)` method alongside
+ * `isConnected`; the wiring that adds it lives in a separate task. Cast
+ * through this shape so the hook stays self-contained and the tests can
+ * mock `useGateway` with just the two fields it actually uses.
+ */
+interface ActivityGateway {
+  send: (message: { type: 'user_active' }) => void;
+  isConnected: boolean;
+}
+
+/**
+ * Emits a throttled `user_active` WebSocket message while the user is
+ * interacting with a visible tab. Used by the backend scale-to-zero reaper
+ * to decide when to stop free-tier containers.
+ *
+ * At most one `send` per `PING_INTERVAL_MS`. Never sends while the tab is
+ * hidden. Interaction events (click, keydown, mousemove, scroll) set a
+ * pending flag; a periodic drain at `DRAIN_INTERVAL_MS` checks the flag,
+ * the visibility state, and the last-ping gate before sending.
+ */
+export function useActivityPing(): void {
+  const { send, isConnected } = useGateway() as unknown as ActivityGateway;
+  const lastPingRef = useRef(0);
+  const pendingRef = useRef(false);
+
+  useEffect(() => {
+    if (!isConnected) return;
+
+    const onInteraction = () => {
+      if (document.visibilityState !== 'visible') return;
+      pendingRef.current = true;
+    };
+
+    const drain = () => {
+      if (!pendingRef.current) return;
+      if (document.visibilityState !== 'visible') return;
+      const now = Date.now();
+      if (now - lastPingRef.current < PING_INTERVAL_MS) return;
+      send({ type: 'user_active' });
+      lastPingRef.current = now;
+      pendingRef.current = false;
+    };
+
+    const drainer = window.setInterval(drain, DRAIN_INTERVAL_MS);
+
+    const events = ['click', 'keydown', 'mousemove', 'scroll'] as const;
+    events.forEach((e) =>
+      window.addEventListener(e, onInteraction, { passive: true }),
+    );
+    document.addEventListener('visibilitychange', onInteraction);
+
+    return () => {
+      window.clearInterval(drainer);
+      events.forEach((e) => window.removeEventListener(e, onInteraction));
+      document.removeEventListener('visibilitychange', onInteraction);
+    };
+  }, [isConnected, send]);
+}

--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -68,6 +68,7 @@ interface GatewayContextValue {
   nodeConnected: boolean;
   error: string | null;
   reconnectAttempt: number;
+  send: (payload: unknown) => void;
   sendReq: (method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<unknown>;
   sendChat: (agentId: string, message: string) => void;
   onEvent: (handler: (event: string, data: unknown) => void) => () => void;
@@ -383,6 +384,19 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  // ---- send (raw fire-and-forget) ----
+
+  // Fire-and-forget send for best-effort signals (e.g. user_active pings
+  // for the free-tier scale-to-zero reaper). Silent no-op when the socket
+  // isn't open — callers retry on their own cadence.
+  const send = useCallback((payload: unknown): void => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    ws.send(JSON.stringify(payload));
+  }, []);
+
   // ---- Subscription helpers ----
 
   const onEvent = useCallback(
@@ -406,8 +420,8 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
   );
 
   const value = useMemo(
-    () => ({ isConnected, nodeConnected, error, reconnectAttempt, sendReq, sendChat, onEvent, onChatMessage, reconnect }),
-    [isConnected, nodeConnected, error, reconnectAttempt, sendReq, sendChat, onEvent, onChatMessage, reconnect],
+    () => ({ isConnected, nodeConnected, error, reconnectAttempt, send, sendReq, sendChat, onEvent, onChatMessage, reconnect }),
+    [isConnected, nodeConnected, error, reconnectAttempt, send, sendReq, sendChat, onEvent, onChatMessage, reconnect],
   );
 
   return (

--- a/apps/infra/lib/stacks/observability-stack.ts
+++ b/apps/infra/lib/stacks/observability-stack.ts
@@ -386,38 +386,52 @@ export class ObservabilityStack extends cdk.Stack {
     // -------------------------------------------------------------------
     // Free-tier scale-to-zero reaper alarms
     // -------------------------------------------------------------------
-    // Three alarms protect the free-tier idle-reaper:
-    //   1. ReaperCrashAlarm  — pages on any gateway.idle_checker.crash in 5 min.
-    //   2. ReaperNoStopsAlarm (child) — no gateway.idle.scale_to_zero events
-    //      in the last 24h.
-    //   3. ReaperHasRunningAlarm (child) — at least one free-tier container
-    //      is still running (gateway.running.count >= 1 in 24h).
-    //   4. ReaperDeadCompositeAlarm — composite of (2) AND (3): the reaper
-    //      is dead iff nothing has been stopped in 24h WHILE something is
-    //      running. Only the composite pages — the child alarms feed it.
+    // Two alarms protect the free-tier idle-reaper:
+    //   P12 (heartbeat): sample-count of gateway.running.count over the last
+    //        10 min. Task 5's reaper emits gauge("gateway.running.count", ...)
+    //        unconditionally every 60s cycle, so sample presence IS the
+    //        heartbeat. Alive => ~10 samples/10min; dead => 0 samples => alarm.
+    //        This replaces an earlier allOf(no-stops, has-running) composite
+    //        that false-paged in legitimate scenarios (e.g., free user stays
+    //        active so running.count>=1 but no one goes idle 5+ min, or a
+    //        fresh deploy before any reap has occurred).
+    //   P13 (crash): any gateway.idle_checker.crash in the last 5 min.
     //
     // Metric names MUST match the backend exactly:
-    //   - gateway.idle.scale_to_zero  (emitted at connection_pool.py:~984)
-    //   - gateway.running.count       (emitted by the DDB-backed reaper)
+    //   - gateway.running.count       (emitted by the DDB-backed reaper, Task 5)
     //   - gateway.idle_checker.crash  (emitted at main.py:~62)
     const reaperDims = { env: this.envName, service: "isol8-backend" };
 
-    const scaleToZeroMetric = new cloudwatch.Metric({
-      namespace: "Isol8",
-      metricName: "gateway.idle.scale_to_zero",
-      statistic: "Sum",
-      period: cdk.Duration.hours(24),
-      dimensionsMap: reaperDims,
-    });
-
-    const runningCountMetric = new cloudwatch.Metric({
+    // P12: reaper heartbeat. SampleCount on gateway.running.count.
+    // Reaper emits this gauge every ~60s regardless of workload, so absence
+    // of samples = reaper loop is dead. Expect ~10 samples per 10-min window
+    // when healthy; threshold 5 tolerates one skipped cycle.
+    const heartbeatMetric = new cloudwatch.Metric({
       namespace: "Isol8",
       metricName: "gateway.running.count",
-      statistic: "Maximum",
-      period: cdk.Duration.hours(24),
+      statistic: "SampleCount",
+      period: cdk.Duration.minutes(10),
       dimensionsMap: reaperDims,
     });
 
+    const heartbeatAlarm = new cloudwatch.Alarm(this, "ReaperHeartbeatAlarm", {
+      alarmName: `isol8-${this.envName}-P12-reaper-dead`,
+      alarmDescription:
+        "PAGE: free-tier reaper has emitted no heartbeat in 10 minutes. " +
+        "Task 5 emits gateway.running.count every 60s regardless of whether " +
+        "any container was actually reaped, so absence of samples = reaper " +
+        "loop is dead.",
+      metric: heartbeatMetric,
+      threshold: 5,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+    });
+    heartbeatAlarm.addAlarmAction(
+      new cloudwatch_actions.SnsAction(this.pageTopic),
+    );
+
+    // P13: any reaper crash in the last 5 min.
     const crashMetric = new cloudwatch.Metric({
       namespace: "Isol8",
       metricName: "gateway.idle_checker.crash",
@@ -426,66 +440,8 @@ export class ObservabilityStack extends cdk.Stack {
       dimensionsMap: reaperDims,
     });
 
-    // Child alarm: no scale-to-zero events in 24h.
-    // BREACHING on missing data — silent reaper is the whole problem.
-    const noStopsAlarm = new cloudwatch.Alarm(this, "ReaperNoStopsAlarm", {
-      alarmName: `isol8-${this.envName}-reaper-dead-no-stops`,
-      alarmDescription:
-        "Free-tier reaper has not stopped any container in 24h. " +
-        "Child of reaper-dead composite — only the composite pages.",
-      metric: scaleToZeroMetric,
-      threshold: 1,
-      evaluationPeriods: 1,
-      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
-    });
-
-    // Child alarm: at least one free-tier container running in 24h.
-    const hasRunningAlarm = new cloudwatch.Alarm(
-      this,
-      "ReaperHasRunningAlarm",
-      {
-        alarmName: `isol8-${this.envName}-reaper-dead-has-running`,
-        alarmDescription:
-          "At least one free-tier container is running. Child of " +
-          "reaper-dead composite — only the composite pages.",
-        metric: runningCountMetric,
-        threshold: 1,
-        evaluationPeriods: 1,
-        comparisonOperator:
-          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      },
-    );
-
-    // Composite: reaper is dead iff both children are firing simultaneously.
-    const reaperDeadComposite = new cloudwatch.CompositeAlarm(
-      this,
-      "ReaperDeadCompositeAlarm",
-      {
-        compositeAlarmName: `isol8-${this.envName}-reaper-dead`,
-        alarmDescription:
-          "PAGE: free-tier reaper appears dead (no scale-to-zero in 24h " +
-          "while containers are running).",
-        alarmRule: cloudwatch.AlarmRule.allOf(
-          cloudwatch.AlarmRule.fromAlarm(
-            noStopsAlarm,
-            cloudwatch.AlarmState.ALARM,
-          ),
-          cloudwatch.AlarmRule.fromAlarm(
-            hasRunningAlarm,
-            cloudwatch.AlarmState.ALARM,
-          ),
-        ),
-      },
-    );
-    reaperDeadComposite.addAlarmAction(
-      new cloudwatch_actions.SnsAction(this.pageTopic),
-    );
-
-    // Standalone: any reaper crash in the last 5 min.
     const reaperCrashAlarm = new cloudwatch.Alarm(this, "ReaperCrashAlarm", {
-      alarmName: `isol8-${this.envName}-reaper-crash`,
+      alarmName: `isol8-${this.envName}-P13-reaper-crash`,
       alarmDescription: "PAGE: free-tier reaper threw an exception.",
       metric: crashMetric,
       threshold: 1,

--- a/apps/infra/lib/stacks/observability-stack.ts
+++ b/apps/infra/lib/stacks/observability-stack.ts
@@ -382,6 +382,121 @@ export class ObservabilityStack extends cdk.Stack {
     p10.addAlarmAction(new cloudwatch_actions.SnsAction(this.pageTopic));
 
     // P11: chat-canary-fail — deferred (requires canary infrastructure)
+
+    // -------------------------------------------------------------------
+    // Free-tier scale-to-zero reaper alarms
+    // -------------------------------------------------------------------
+    // Three alarms protect the free-tier idle-reaper:
+    //   1. ReaperCrashAlarm  — pages on any gateway.idle_checker.crash in 5 min.
+    //   2. ReaperNoStopsAlarm (child) — no gateway.idle.scale_to_zero events
+    //      in the last 24h.
+    //   3. ReaperHasRunningAlarm (child) — at least one free-tier container
+    //      is still running (gateway.running.count >= 1 in 24h).
+    //   4. ReaperDeadCompositeAlarm — composite of (2) AND (3): the reaper
+    //      is dead iff nothing has been stopped in 24h WHILE something is
+    //      running. Only the composite pages — the child alarms feed it.
+    //
+    // Metric names MUST match the backend exactly:
+    //   - gateway.idle.scale_to_zero  (emitted at connection_pool.py:~984)
+    //   - gateway.running.count       (emitted by the DDB-backed reaper)
+    //   - gateway.idle_checker.crash  (emitted at main.py:~62)
+    const reaperDims = { env: this.envName, service: "isol8-backend" };
+
+    const scaleToZeroMetric = new cloudwatch.Metric({
+      namespace: "Isol8",
+      metricName: "gateway.idle.scale_to_zero",
+      statistic: "Sum",
+      period: cdk.Duration.hours(24),
+      dimensionsMap: reaperDims,
+    });
+
+    const runningCountMetric = new cloudwatch.Metric({
+      namespace: "Isol8",
+      metricName: "gateway.running.count",
+      statistic: "Maximum",
+      period: cdk.Duration.hours(24),
+      dimensionsMap: reaperDims,
+    });
+
+    const crashMetric = new cloudwatch.Metric({
+      namespace: "Isol8",
+      metricName: "gateway.idle_checker.crash",
+      statistic: "Sum",
+      period: cdk.Duration.minutes(5),
+      dimensionsMap: reaperDims,
+    });
+
+    // Child alarm: no scale-to-zero events in 24h.
+    // BREACHING on missing data — silent reaper is the whole problem.
+    const noStopsAlarm = new cloudwatch.Alarm(this, "ReaperNoStopsAlarm", {
+      alarmName: `isol8-${this.envName}-reaper-dead-no-stops`,
+      alarmDescription:
+        "Free-tier reaper has not stopped any container in 24h. " +
+        "Child of reaper-dead composite — only the composite pages.",
+      metric: scaleToZeroMetric,
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+    });
+
+    // Child alarm: at least one free-tier container running in 24h.
+    const hasRunningAlarm = new cloudwatch.Alarm(
+      this,
+      "ReaperHasRunningAlarm",
+      {
+        alarmName: `isol8-${this.envName}-reaper-dead-has-running`,
+        alarmDescription:
+          "At least one free-tier container is running. Child of " +
+          "reaper-dead composite — only the composite pages.",
+        metric: runningCountMetric,
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      },
+    );
+
+    // Composite: reaper is dead iff both children are firing simultaneously.
+    const reaperDeadComposite = new cloudwatch.CompositeAlarm(
+      this,
+      "ReaperDeadCompositeAlarm",
+      {
+        compositeAlarmName: `isol8-${this.envName}-reaper-dead`,
+        alarmDescription:
+          "PAGE: free-tier reaper appears dead (no scale-to-zero in 24h " +
+          "while containers are running).",
+        alarmRule: cloudwatch.AlarmRule.allOf(
+          cloudwatch.AlarmRule.fromAlarm(
+            noStopsAlarm,
+            cloudwatch.AlarmState.ALARM,
+          ),
+          cloudwatch.AlarmRule.fromAlarm(
+            hasRunningAlarm,
+            cloudwatch.AlarmState.ALARM,
+          ),
+        ),
+      },
+    );
+    reaperDeadComposite.addAlarmAction(
+      new cloudwatch_actions.SnsAction(this.pageTopic),
+    );
+
+    // Standalone: any reaper crash in the last 5 min.
+    const reaperCrashAlarm = new cloudwatch.Alarm(this, "ReaperCrashAlarm", {
+      alarmName: `isol8-${this.envName}-reaper-crash`,
+      alarmDescription: "PAGE: free-tier reaper threw an exception.",
+      metric: crashMetric,
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    reaperCrashAlarm.addAlarmAction(
+      new cloudwatch_actions.SnsAction(this.pageTopic),
+    );
   }
 
   // =========================================================================

--- a/apps/infra/test/observability-stack.test.ts
+++ b/apps/infra/test/observability-stack.test.ts
@@ -162,28 +162,23 @@ describe("ObservabilityStack", () => {
   // Free-tier scale-to-zero reaper alarms
   // ---------------------------------------------------------------------
 
-  test("creates the reaper-crash alarm with the gateway.idle_checker.crash metric", () => {
-    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
-      MetricName: "gateway.idle_checker.crash",
-      Namespace: "Isol8",
-    });
-  });
-
-  test("creates the reaper-dead composite alarm", () => {
-    template.resourceCountIs("AWS::CloudWatch::CompositeAlarm", 1);
-  });
-
-  test("creates the no-stops alarm using gateway.idle.scale_to_zero", () => {
-    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
-      MetricName: "gateway.idle.scale_to_zero",
-      Namespace: "Isol8",
-    });
-  });
-
-  test("creates the has-running alarm using gateway.running.count", () => {
+  test("creates the reaper heartbeat alarm on SampleCount(gateway.running.count)", () => {
     template.hasResourceProperties("AWS::CloudWatch::Alarm", {
       MetricName: "gateway.running.count",
       Namespace: "Isol8",
+      Statistic: "SampleCount",
+      ComparisonOperator: "LessThanThreshold",
+      Threshold: 5,
+      TreatMissingData: "breaching",
+    });
+  });
+
+  test("creates the reaper-crash alarm on Sum(gateway.idle_checker.crash)", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "gateway.idle_checker.crash",
+      Namespace: "Isol8",
+      Statistic: "Sum",
+      Threshold: 1,
     });
   });
 });

--- a/apps/infra/test/observability-stack.test.ts
+++ b/apps/infra/test/observability-stack.test.ts
@@ -157,4 +157,33 @@ describe("ObservabilityStack", () => {
       },
     });
   });
+
+  // ---------------------------------------------------------------------
+  // Free-tier scale-to-zero reaper alarms
+  // ---------------------------------------------------------------------
+
+  test("creates the reaper-crash alarm with the gateway.idle_checker.crash metric", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "gateway.idle_checker.crash",
+      Namespace: "Isol8",
+    });
+  });
+
+  test("creates the reaper-dead composite alarm", () => {
+    template.resourceCountIs("AWS::CloudWatch::CompositeAlarm", 1);
+  });
+
+  test("creates the no-stops alarm using gateway.idle.scale_to_zero", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "gateway.idle.scale_to_zero",
+      Namespace: "Isol8",
+    });
+  });
+
+  test("creates the has-running alarm using gateway.running.count", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      MetricName: "gateway.running.count",
+      Namespace: "Isol8",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Free-tier ECS containers were staying alive 48+ hours against a 5-minute idle SLA. Root cause: "active" was defined as "backend holds an open WebSocket to the container," so closing a browser tab popped the user from the reaper's in-memory tracker before the 5-minute timer could fire — `desiredCount=1` persisted indefinitely. In prod at investigation time: 1 free-tier org container alive ~48h, 1 orphan (no billing row) alive ~44h.

Fix redefines "active" as **"user is interacting with the visible tab"** and rebuilds the reaper around DynamoDB-persisted state so redeploys, disconnects, and orphans are all handled.

### What changed

- **Frontend** emits throttled `user_active` WS pings on `click`/`keydown`/`mousemove`/`scroll` while the tab is visible. At most 1 ping per 60s. `useActivityPing` hook wired into `ChatLayout`. Added a raw `send(payload)` method on the `useGateway` context.
- **Backend** `record_activity(owner_id)` on the gateway pool persists `last_active_at` to the containers DDB row (coalesced to 1 write per 30s per owner). Both `agent_chat` and `user_active` dispatch paths call it.
- **Reaper** rewritten to walk `container_repo.get_by_status("running")` every 60s instead of `self._connections`. Disconnected-but-still-running containers are now reap-eligible (the actual root-cause fix). Orphans (no billing row) default to free tier. Honors `TIER_CONFIG[tier].scale_to_zero` flag instead of a hardcoded `"free"` string. Stops via conditional `mark_stopped_if_running` (race-safe).
- **Deleted** `self._last_activity` dict + `touch_activity` method — DDB is now the single source of truth; backend redeploys no longer reset every user's timer.
- **Observability:** `P12-reaper-dead` (SampleCount on `gateway.running.count` — pages when reaper stops emitting) and `P13-reaper-crash` (on `gateway.idle_checker.crash`).

### Deploy-day behavior

The 2 currently-stale prod containers have `last_active_at = null` → reaped on the first cycle (~60s after deploy). Owners hit one ~30s cold start on next visit, same as all future returns after idle.

### Blast-radius containment

- **Paid tiers explicitly excluded** — reaper gates on `TIER_CONFIG[plan_tier].scale_to_zero` (only `True` for free). Verified by `test_skips_paid_tier`.
- **Active free users aren't reaped** — pings persist `last_active_at`; reaper only stops when > 5 min old. Verified by `test_skips_not_yet_idle`.
- **Reaper failures are observable** — billing lookup fails → skip that user, continue; reaper task crashes → P13 alarm; reaper stops emitting silently → P12 alarm (BREACHING on missing samples).
- **Hot-path latency:** `agent_chat` adds one coalesced DDB UpdateItem per 30s. Wrapped in try/except — DDB flakiness can't break chat.
- **Frontend failures benign:** `send()` is fire-and-forget no-op on closed WS; hook defensively guards against undefined `send`.
- **No DDB migration** — `last_active_at` is optional; missing → treated as epoch 0 → reaped on first cycle.
- **Rollback:** single `git revert` of the merge commit; new DDB attribute stays harmlessly in rows, unused.

### Design docs

- Spec: `docs/superpowers/specs/2026-04-13-free-tier-scale-to-zero-design.md`
- Plan: `docs/superpowers/plans/2026-04-13-free-tier-scale-to-zero.md`

## Test plan

- [x] Full backend pytest — **649/649** pass
- [x] Full infra jest — **13/13** pass
- [x] Frontend targeted: `useActivityPing.test.ts` — **7/7** pass (8 pre-existing failures in unrelated `BotSetupWizard`/`MyChannelsSection`/`AgentChannelsSection`/`MessageList` verified identical on origin/main)
- [x] Reaper regression test `test_reaps_disconnected_idle_free_user` would have caught the original bug
- [x] Orphan, null-timestamp, paid-skip, config-flag, billing-failure, WS-visibility, Z-suffix parsing all covered
- [ ] Dev/LocalStack integration smoke — recommend running before merging to prod
- [ ] Post-deploy: watch `gateway.idle.scale_to_zero` + `gateway.running.count` metrics for first 60 min; confirm the 2 currently-stale prod containers get `desiredCount=0` within the first reaper cycle
- [ ] Alarm validation: verify P12/P13 are in CloudWatch after infra deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)