### PR TITLE
fix(frontend): wrap PostHogPageview in Suspense (unblock prod deploy)

### DIFF
--- a/apps/frontend/src/components/PostHogProvider.tsx
+++ b/apps/frontend/src/components/PostHogProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { Suspense, useEffect, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useAuth, useUser } from "@clerk/nextjs";
 import posthog from "posthog-js";
@@ -62,7 +62,14 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <PHProvider client={posthog}>
-      <PostHogPageview />
+      {/* Suspense required: PostHogPageview reads useSearchParams(), which
+          forces the whole subtree out of static prerendering unless isolated
+          in a Suspense boundary. Without this, pages like /_not-found fail
+          prerender with the CSR-bailout error. PostHogPageview renders null
+          so fallback={null} is a true no-op. */}
+      <Suspense fallback={null}>
+        <PostHogPageview />
+      </Suspense>
       <PostHogIdentify />
       {children}
     </PHProvider>


### PR DESCRIPTION
## Summary

The Vercel prod deploy has been failing since the PostHog integration (#263) landed with:

\`\`\`
⨯ useSearchParams() should be wrapped in a suspense boundary at page "/404"
Error occurred prerendering page "/_not-found"
⨯ Next.js build worker exited with code: 1
\`\`\`

Root cause: \`PostHogProvider\` wraps the root \`app/layout.tsx\`, and its \`PostHogPageview\` child reads \`useSearchParams()\`. Per the Next.js docs, any component using \`useSearchParams()\` without a \`<Suspense>\` boundary forces the whole subtree out of static prerendering. That cascades into \`/_not-found\` (which Next.js always prerenders) failing the build and taking the whole \`DeployVercelProd\` job down.

Fix: wrap \`<PostHogPageview />\` in \`<Suspense fallback={null}>\`. \`PostHogPageview\` itself returns \`null\`, so the fallback is a true no-op — no visible change, no behavior change, just lets the rest of the tree prerender.

## Impact

- **Restores prod frontend deploys.** Latest couple of merges to main (including #265, which deployed the backend reaper successfully but left the frontend stale) have the backend + infra live in prod but the frontend bundle hasn't updated.
- **No runtime behavior change.** \`PostHogPageview\` still captures pageviews client-side via the same \`useEffect\`.
- **No behavior change for pages that don't use searchParams.** Affected only: the prerender-time classification of static vs dynamic pages.

## Verification

\`\`\`
$ pnpm run build
...
Route (app)
┌ ○ /
├ ○ /_not-found          ← now prerendered as static (was failing)
├ ○ /auth/desktop-callback
├ ƒ /chat
├ ○ /onboarding
├ ○ /privacy
├ ƒ /sign-in/[[...sign-in]]
├ ƒ /sign-up/[[...sign-up]]
├ ○ /support
└ ○ /terms
\`\`\`

## Test plan

- [x] Local \`pnpm run build\` succeeds; \`/_not-found\` listed as static (○).
- [ ] CI Lint & Build passes on this branch.
- [ ] On merge, DeployVercelProd (currently failing on \`main\`) completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)