### PR TITLE
fix(gateway): add 2s retry floor on record_activity no-op/exception

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -864,19 +864,19 @@ class GatewayConnectionPool:
         from core.dynamodb import utc_now_iso
         from core.repositories import container_repo
 
-        # Backdating `last_write` to (now - cooldown + floor) gates the next
-        # record_activity call until _DDB_WRITE_RETRY_FLOOR seconds have passed.
-        retry_backdate = now - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
-
         try:
             wrote = await container_repo.update_last_active(owner_id, utc_now_iso())
         except Exception:
             logger.warning("record_activity: DDB write failed for %s", owner_id, exc_info=True)
-            _LAST_DDB_WRITE[owner_id] = retry_backdate
+            # Compute the backdate from a FRESH time.time() — not the pre-await
+            # `now` — so a slow DDB call (e.g. partial outage) can't itself
+            # consume the entire retry-floor window and admit the next ping
+            # immediately. Codex P2 on PR #269.
+            _LAST_DDB_WRITE[owner_id] = time.time() - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
             return
 
         if not wrote:
-            _LAST_DDB_WRITE[owner_id] = retry_backdate
+            _LAST_DDB_WRITE[owner_id] = time.time() - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
 
     async def _create_connection(self, user_id: str, ip: str, token: str) -> GatewayConnection:
         """Create and connect a new GatewayConnection."""

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -32,6 +32,7 @@ _GRACE_PERIOD = 30  # seconds before closing idle connection
 _IDLE_CHECK_INTERVAL = 60  # seconds between idle checks
 _IDLE_TIMEOUT = 300  # 5 minutes of inactivity before scale-to-zero
 _DDB_WRITE_COOLDOWN = 30.0  # seconds between per-owner last_active_at writes
+_DDB_WRITE_RETRY_FLOOR = 2.0  # minimum seconds between retries after a no-op / exception
 
 # Per-owner cooldown map. Module-level so it survives pool reconstruction in tests
 # and across pool singletons. Values are the last epoch-seconds we wrote to DDB.
@@ -843,11 +844,16 @@ class GatewayConnectionPool:
         seconds. Callers are not expected to throttle; fire for every event.
 
         Cooldown is claimed *before* the await to deflect a thundering herd of
-        concurrent pings, but is released if the write turns out to be a no-op
-        (row missing or still `status=stopped`) or if the await raises. Both
-        cases need the next ping to retry immediately — most importantly on
-        cold start, where the first ping can land while the row is still
-        flipping from `stopped` to `running`.
+        concurrent pings. On a no-op write (row missing or still `status=stopped`)
+        or an exception, the cooldown is *backdated* so the next retry is allowed
+        in ~_DDB_WRITE_RETRY_FLOOR seconds — not immediately. Two reasons:
+
+        1. Cold-start UX: when a user returns after idle, their first ping may
+           land while the row is still flipping from `stopped` to `running`.
+           Retry quickly, but don't wait a full 30s.
+        2. Abuse floor: an authenticated user flooding `user_active` against
+           their own stopped container can't burn unbounded DDB WCU on
+           conditional-check failures — retries bounded to 1 per _DDB_WRITE_RETRY_FLOOR.
         """
         now = time.time()
         last = _LAST_DDB_WRITE.get(owner_id, 0.0)
@@ -858,15 +864,19 @@ class GatewayConnectionPool:
         from core.dynamodb import utc_now_iso
         from core.repositories import container_repo
 
+        # Backdating `last_write` to (now - cooldown + floor) gates the next
+        # record_activity call until _DDB_WRITE_RETRY_FLOOR seconds have passed.
+        retry_backdate = now - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
+
         try:
             wrote = await container_repo.update_last_active(owner_id, utc_now_iso())
         except Exception:
             logger.warning("record_activity: DDB write failed for %s", owner_id, exc_info=True)
-            _LAST_DDB_WRITE.pop(owner_id, None)
+            _LAST_DDB_WRITE[owner_id] = retry_backdate
             return
 
         if not wrote:
-            _LAST_DDB_WRITE.pop(owner_id, None)
+            _LAST_DDB_WRITE[owner_id] = retry_backdate
 
     async def _create_connection(self, user_id: str, ip: str, token: str) -> GatewayConnection:
         """Create and connect a new GatewayConnection."""

--- a/apps/backend/tests/unit/gateway/test_connection_pool.py
+++ b/apps/backend/tests/unit/gateway/test_connection_pool.py
@@ -87,13 +87,47 @@ async def test_record_activity_different_users_not_coalesced():
 
 
 @pytest.mark.asyncio
-async def test_record_activity_releases_cooldown_on_noop_write():
-    """Cold-start regression: when update_last_active returns False (row still
-    status=stopped before start_user_service has flipped it), the cooldown
-    must be released so the next ping retries immediately. Otherwise the
-    reaper could see a null last_active_at on the next cycle and stop an
-    actively-used container.
+async def test_record_activity_backdates_cooldown_on_noop_write():
+    """When update_last_active returns False (cold-start row=stopped, or
+    missing row, or attacker pinging their own stopped container), the
+    cooldown is BACKDATED to allow retry in ~_DDB_WRITE_RETRY_FLOOR seconds
+    — not popped, not held the full 30s. Bounds DDB write rate during
+    stopped-container windows.
     """
+    from core.gateway.connection_pool import (
+        _DDB_WRITE_COOLDOWN,
+        _DDB_WRITE_RETRY_FLOOR,
+        _LAST_DDB_WRITE,
+        GatewayConnectionPool,
+    )
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with patch(
+        "core.repositories.container_repo.update_last_active",
+        new_callable=AsyncMock,
+        return_value=False,
+    ) as mock_update:
+        before = time.time()
+        await pool.record_activity("user_1")
+        after = time.time()
+
+    mock_update.assert_awaited_once()
+    # Cooldown stamp should be back-dated to ≈ now - (cooldown - retry_floor),
+    # i.e. the next allowed retry is exactly _DDB_WRITE_RETRY_FLOOR away.
+    stamp = _LAST_DDB_WRITE["user_1"]
+    expected_min = before - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
+    expected_max = after - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
+    assert expected_min <= stamp <= expected_max
+
+
+@pytest.mark.asyncio
+async def test_record_activity_retry_floor_gates_back_to_back_noop_writes():
+    """Attack scenario: an authenticated user floods user_active against
+    their own stopped container. Each ping would hit DDB on a conditional
+    UpdateItem (which fails but still bills WCU). The retry floor caps this
+    at one DDB call per _DDB_WRITE_RETRY_FLOOR seconds."""
     from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
 
     _LAST_DDB_WRITE.clear()
@@ -104,34 +138,70 @@ async def test_record_activity_releases_cooldown_on_noop_write():
         new_callable=AsyncMock,
         return_value=False,
     ) as mock_update:
-        await pool.record_activity("user_1")
+        # 5 back-to-back pings (no time passes). Only the first should reach
+        # DDB; the next 4 are gated by the backdated cooldown.
+        for _ in range(5):
+            await pool.record_activity("user_1")
 
-    mock_update.assert_awaited_once()
-    # Cooldown must NOT be set; next ping should go through.
-    assert "user_1" not in _LAST_DDB_WRITE
+    assert mock_update.await_count == 1
 
 
 @pytest.mark.asyncio
-async def test_record_activity_retries_immediately_after_noop_write():
-    """Companion to the above: after a no-op write, a second ping in the
-    same instant should fire another write — cooldown was released, so no
-    30s lockout."""
-    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+async def test_record_activity_retries_after_retry_floor_elapses():
+    """After ≥_DDB_WRITE_RETRY_FLOOR seconds have passed since a no-op,
+    the next ping is allowed through. Confirms the floor is a *gate*, not
+    a permanent lockout."""
+    from core.gateway.connection_pool import (
+        _DDB_WRITE_RETRY_FLOOR,
+        _LAST_DDB_WRITE,
+        GatewayConnectionPool,
+    )
 
     _LAST_DDB_WRITE.clear()
     pool = GatewayConnectionPool(management_api=None)
 
-    # First call: row is stopped, returns False. Second call: row is now
-    # running, returns True. Both should reach update_last_active.
     with patch(
         "core.repositories.container_repo.update_last_active",
         new_callable=AsyncMock,
-        side_effect=[False, True],
+        return_value=False,
     ) as mock_update:
         await pool.record_activity("user_1")
+        # Roll the stamp back by retry-floor + 1s to simulate elapsed time.
+        _LAST_DDB_WRITE["user_1"] -= _DDB_WRITE_RETRY_FLOOR + 1
         await pool.record_activity("user_1")
 
     assert mock_update.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_record_activity_retry_floor_also_gates_after_ddb_exception():
+    """Symmetric to the no-op case: a DDB exception backdates the cooldown
+    too. Prevents DDB outages from amplifying into a write storm once the
+    service comes back up."""
+    from core.gateway.connection_pool import (
+        _DDB_WRITE_COOLDOWN,
+        _DDB_WRITE_RETRY_FLOOR,
+        _LAST_DDB_WRITE,
+        GatewayConnectionPool,
+    )
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with patch(
+        "core.repositories.container_repo.update_last_active",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("ddb blip"),
+    ) as mock_update:
+        before = time.time()
+        await pool.record_activity("user_1")
+        after = time.time()
+
+    mock_update.assert_awaited_once()
+    stamp = _LAST_DDB_WRITE["user_1"]
+    expected_min = before - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
+    expected_max = after - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
+    assert expected_min <= stamp <= expected_max
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/unit/gateway/test_connection_pool.py
+++ b/apps/backend/tests/unit/gateway/test_connection_pool.py
@@ -205,6 +205,47 @@ async def test_record_activity_retry_floor_also_gates_after_ddb_exception():
 
 
 @pytest.mark.asyncio
+async def test_record_activity_retry_backdate_uses_post_await_time():
+    """Codex P2 regression: the retry-floor stamp must be computed from
+    time AFTER the DDB await, not before. Otherwise a slow update_last_active
+    call (e.g. partial DDB outage) consumes the entire 30s cooldown by the
+    time we get to the backdate line, and the next ping is admitted
+    immediately — the opposite of the intended bound."""
+    from core.gateway.connection_pool import (
+        _DDB_WRITE_COOLDOWN,
+        _DDB_WRITE_RETRY_FLOOR,
+        _LAST_DDB_WRITE,
+        GatewayConnectionPool,
+    )
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    # Two time.time readings: 100.0 inside the entry-gate, then 105.0 inside
+    # the post-await backdate (simulating a 5-second slow DDB call without
+    # an actual sleep).
+    times = iter([100.0, 105.0])
+
+    with (
+        patch(
+            "core.repositories.container_repo.update_last_active",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "core.gateway.connection_pool.time.time",
+            side_effect=lambda: next(times),
+        ),
+    ):
+        await pool.record_activity("user_1")
+
+    # Buggy version would stamp at 100.0 - 28 = 72.0 (pre-await `now`).
+    # Fixed version stamps at 105.0 - 28 = 77.0 (post-await fresh time).
+    expected = 105.0 - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
+    assert _LAST_DDB_WRITE["user_1"] == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
 async def test_close_user_no_longer_references_last_activity():
     """Regression for Task 4: close_user used to pop _last_activity, now that
     dict is gone. This test ensures close_user runs cleanly for a user it's


### PR DESCRIPTION
## Summary

Hardening follow-up to PR #265. Codex flagged that popping the DDB cooldown on a no-op write (commit `44666768`'s fix for the cold-start race) leaves the door open for an authenticated user to flood `user_active` against their own stopped container and burn unbounded DDB WCU on conditional-check failures (~1 WCU per ping, no per-owner rate limit).

This PR replaces the **pop** with a **backdate** to `now - (cooldown - retry_floor)`. Next retry allowed in ~2s, not 30s, not immediate. Same logic applies to the exception path so DDB outages don't amplify into write storms on recovery.

### Behavior table

| Scenario | Before | After |
|---|---|---|
| Happy path (container running) | 1 write / 30s | 1 write / 30s (unchanged) |
| Cold-start (~1-5s window) | 1 write per ping until row flips to `running` | 1 write per 2s until row flips |
| Attacker flooding while stopped | unbounded DDB WCU | max 1 write per 2s per owner |
| DDB throw mid-flight | immediate retry | retry in 2s |

Cold-start UX: race window is typically 1-5s, so 2s catches it on the first or second retry — no perceptible change.

## Test plan

- [x] \`pool.record_activity\` backdates the cooldown to \`now - (cooldown - retry_floor)\` on no-op (\`test_record_activity_backdates_cooldown_on_noop_write\`)
- [x] 5 back-to-back pings against a stopped container only fire 1 DDB call (\`test_record_activity_retry_floor_gates_back_to_back_noop_writes\`)
- [x] After \`_DDB_WRITE_RETRY_FLOOR\` elapses, next ping IS allowed through (\`test_record_activity_retries_after_retry_floor_elapses\`)
- [x] Exception path is symmetric to no-op path (\`test_record_activity_retry_floor_also_gates_after_ddb_exception\`)
- [x] Existing tests still pass: 17/17 in \`tests/unit/gateway/\`
- [ ] CI green
- [ ] Post-deploy: spot-check \`gateway.idle.scale_to_zero\` metric continues firing on prod (no regression to the reaper itself; this only changes write-rate semantics during failure paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)