### PR TITLE
hotfix: pass workspace to agents.create (broken by PR #267)

### DIFF
--- a/apps/frontend/src/components/chat/ChatLayout.tsx
+++ b/apps/frontend/src/components/chat/ChatLayout.tsx
@@ -403,8 +403,9 @@ export function ChatLayout({
           existingIds={agents.map((a) => a.id)}
           onCancel={() => setCreateFormOpen(false)}
           onCreate={async (name) => {
-            // No `workspace` override: OpenClaw appends /{agentId} to
-            // agents.defaults.workspace so the agent lands at workspaces/{id}/.
+            // OpenClaw's agents.create requires a non-empty `workspace` —
+            // see useAgents.createAgent, which fills in the default path
+            // (.openclaw/workspaces/{id}) when omitted.
             await createAgent({ name });
             setCreateFormOpen(false);
           }}

--- a/apps/frontend/src/components/control/panels/AgentCreateForm.tsx
+++ b/apps/frontend/src/components/control/panels/AgentCreateForm.tsx
@@ -42,10 +42,13 @@ export function AgentCreateForm({ existingIds, onCreated, onCancel }: AgentCreat
     try {
       await callRpc("agents.create", {
         name: name.trim(),
-        // No `workspace` override: OpenClaw appends /{agentId} to
-        // agents.defaults.workspace automatically, so the agent lands at
-        // workspaces/{agentId}/. Matches main's explicit workspaces/main
-        // override — every agent uses the same scheme.
+        // OpenClaw's agents.create requires a non-empty `workspace` string —
+        // it does NOT inherit agents.defaults.workspace at create time
+        // (only at runtime via resolveAgentWorkspaceDir). Pass the same
+        // path the default would resolve to, so the agent lands at
+        // .openclaw/workspaces/{id}/ on EFS — matching main's explicit
+        // workspaces/main override.
+        workspace: ".openclaw/workspaces/" + normalizedId,
         reasoningDefault: "stream",
       });
       posthog?.capture("agent_created", { agent_name: name.trim() });

--- a/apps/frontend/src/hooks/useAgents.ts
+++ b/apps/frontend/src/hooks/useAgents.ts
@@ -48,11 +48,20 @@ export function useAgents() {
   const defaultId = data?.defaultId;
 
   const createAgent = useCallback(
-    // `workspace` is optional — omit it to let OpenClaw apply its default
-    // (`{agents.defaults.workspace}/{agentId}` → `workspaces/{id}/`). Only
-    // pass a value when you need a non-standard path.
+    // OpenClaw's agents.create requires a non-empty `workspace` string
+    // (it does NOT inherit agents.defaults.workspace at create time).
+    // When the caller omits `workspace`, we fill in the same path the
+    // default would resolve to at runtime — .openclaw/workspaces/{id} —
+    // so the agent lands on EFS without the caller knowing about path
+    // conventions.
     async (params: { name: string; workspace?: string; emoji?: string }) => {
-      await callRpc("agents.create", params);
+      const normalizedId = params.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "");
+      const workspace = params.workspace ?? `.openclaw/workspaces/${normalizedId}`;
+      await callRpc("agents.create", { ...params, workspace });
       mutate();
     },
     [callRpc, mutate],


### PR DESCRIPTION
## Summary

PR #267 removed the \`workspace\` param from \`agents.create\` calls on the assumption that OpenClaw would inherit \`agents.defaults.workspace\`. That assumption is wrong — OpenClaw's \`AgentsCreateParamsSchema\` requires a non-empty \`workspace\` string at create time (\`openclaw/src/gateway/protocol/schema/agents-models-skills.ts:60\`). Inheritance only kicks in at runtime via \`resolveAgentWorkspaceDir\`.

CloudWatch logs (prod openclaw, user 2) confirm every agents.create since the deploy returned:

\`\`\`
errorCode=INVALID_REQUEST errorMessage=invalid agents.create params: must have required property 'workspace'
\`\`\`

## Fix

Pass \`workspace: ".openclaw/workspaces/{normalizedId}"\` — the same path the default would resolve to. Lands the agent on EFS at the same place PR #267 intended.

- \`AgentCreateForm.tsx\` — explicit param
- \`useAgents.createAgent\` — defaults \`workspace\` when caller omits it (keeps \`ChatLayout\` callsite working without changes there)

## Test plan

- [x] Frontend typecheck + lint clean
- [ ] Post-deploy: create a new agent in dev/prod, verify it succeeds and lands at \`workspaces/{id}/\` on EFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)