### PR TITLE
fix(viewer): hide top-level config files from Workspace tab

### DIFF
--- a/apps/frontend/src/components/chat/FileViewer.tsx
+++ b/apps/frontend/src/components/chat/FileViewer.tsx
@@ -62,7 +62,14 @@ export function FileViewer({ agentId, initialFilePath, onClose }: FileViewerProp
   const relativeFilePath = selectedPath;
 
   // Workspace tab data
-  const { files: wsFiles, isLoading: wsTreeLoading, refresh: wsRefresh } = useWorkspaceTree(agentId);
+  const { files: wsRawFiles, isLoading: wsTreeLoading, refresh: wsRefresh } = useWorkspaceTree(agentId);
+  // Hide top-level allowlisted config files from the Workspace tab — they
+  // already get a curated home in the Config tab. Nested files of the same
+  // name (e.g. uploads/SOUL.md) still show; the filter is path-aware.
+  const wsFiles = React.useMemo(
+    () => wsRawFiles.filter((f) => !(CONFIG_ALLOWLIST.includes(f.name) && !f.path.includes("/"))),
+    [wsRawFiles],
+  );
   const { file: wsFile, isLoading: wsFileLoading, error: wsFileError } = useWorkspaceFile(
     activeTab === "workspace" ? agentId : null,
     activeTab === "workspace" ? relativeFilePath : null,


### PR DESCRIPTION
## Summary

After PR #267 normalized the workspace layout, the 7 OpenClaw-seeded config files (SOUL.md, MEMORY.md, TOOLS.md, IDENTITY.md, USER.md, HEARTBEAT.md, AGENTS.md) showed up in **both** the Workspace tab (as part of the full tree) and the Config tab (curated personality view). User reported the duplication as confusing.

## Fix

Filter top-level allowlisted config files out of the Workspace tab's tree. Each tab now has a single responsibility:

- **Config tab** = personality / config (curated, with ghost entries for missing files)
- **Workspace tab** = work product (plans, notes, uploads, runtime dirs, etc.)

Path-aware filter: only top-level entries whose names match the allowlist are hidden. A nested file like \`uploads/SOUL.md\` still appears in the Workspace tab.

One-file change to \`FileViewer.tsx\`. Backend untouched.

## Test plan

- [x] Frontend typecheck clean
- [ ] Post-deploy: open file viewer for main agent — Workspace tab no longer shows SOUL.md/MEMORY.md/etc. at the root; Config tab still shows them

🤖 Generated with [Claude Code](https://claude.com/claude-code)