### PR TITLE
feat(obs): cold-start, record_activity, per-tier metrics + dashboard

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -868,6 +868,7 @@ class GatewayConnectionPool:
             wrote = await container_repo.update_last_active(owner_id, utc_now_iso())
         except Exception:
             logger.warning("record_activity: DDB write failed for %s", owner_id, exc_info=True)
+            put_metric("gateway.record_activity.count", dimensions={"outcome": "error"})
             # Compute the backdate from a FRESH time.time() — not the pre-await
             # `now` — so a slow DDB call (e.g. partial outage) can't itself
             # consume the entire retry-floor window and admit the next ping
@@ -876,7 +877,11 @@ class GatewayConnectionPool:
             return
 
         if not wrote:
+            put_metric("gateway.record_activity.count", dimensions={"outcome": "noop"})
             _LAST_DDB_WRITE[owner_id] = time.time() - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
+            return
+
+        put_metric("gateway.record_activity.count", dimensions={"outcome": "success"})
 
     async def _create_connection(self, user_id: str, ip: str, token: str) -> GatewayConnection:
         """Create and connect a new GatewayConnection."""
@@ -1022,6 +1027,36 @@ class GatewayConnectionPool:
 
         now_ts = time.time()
         stopped: list[str] = []
+        # Per-cycle billing cache: one DDB read per unique owner per cycle, even
+        # if the row appears in both the per-tier-breakdown count and the
+        # idle-eligible reap path below.
+        tier_cache: Dict[str, str] = {}
+
+        async def _resolve_tier(oid: str) -> str | None:
+            if oid in tier_cache:
+                return tier_cache[oid]
+            try:
+                account = await billing_repo.get_by_owner_id(oid)
+            except Exception:
+                logger.warning("idle_checker: billing lookup failed for %s, skipping", oid)
+                return None
+            plan_tier = (account or {}).get("plan_tier", "free")
+            tier_cache[oid] = plan_tier
+            return plan_tier
+
+        # Per-tier running-container breakdown — useful for at-a-glance
+        # "how many free vs paid are running right now" without log scraping.
+        tier_counts: Dict[str, int] = {}
+        for row in rows:
+            tier = await _resolve_tier(row["owner_id"])
+            if tier is None:
+                continue
+            tier_counts[tier] = tier_counts.get(tier, 0) + 1
+        try:
+            for tier, count in tier_counts.items():
+                gauge("gateway.running.count.by_tier", count, dimensions={"tier": tier})
+        except Exception:
+            pass
 
         for row in rows:
             owner_id = row["owner_id"]
@@ -1041,13 +1076,12 @@ class GatewayConnectionPool:
             if now_ts - last_active_epoch < _IDLE_TIMEOUT:
                 continue
 
-            # Resolve tier; missing billing row is treated as free (orphan policy).
-            try:
-                account = await billing_repo.get_by_owner_id(owner_id)
-            except Exception:
-                logger.warning("idle_checker: billing lookup failed for %s, skipping", owner_id)
+            # Tier was already resolved + cached above for the per-tier breakdown;
+            # this lookup hits the cache, no extra DDB read.
+            plan_tier = await _resolve_tier(owner_id)
+            if plan_tier is None:
+                # billing lookup failed earlier; skip this cycle (already logged).
                 continue
-            plan_tier = (account or {}).get("plan_tier", "free")
 
             if not TIER_CONFIG.get(plan_tier, {}).get("scale_to_zero", False):
                 continue

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -1029,16 +1029,22 @@ class GatewayConnectionPool:
         stopped: list[str] = []
         # Per-cycle billing cache: one DDB read per unique owner per cycle, even
         # if the row appears in both the per-tier-breakdown count and the
-        # idle-eligible reap path below.
+        # idle-eligible reap path below. `failed_lookups` caches the negative
+        # case so a transient billing outage doesn't double the read amp +
+        # log noise (Codex P2 on PR #273).
         tier_cache: Dict[str, str] = {}
+        failed_lookups: set[str] = set()
 
         async def _resolve_tier(oid: str) -> str | None:
             if oid in tier_cache:
                 return tier_cache[oid]
+            if oid in failed_lookups:
+                return None
             try:
                 account = await billing_repo.get_by_owner_id(oid)
             except Exception:
                 logger.warning("idle_checker: billing lookup failed for %s, skipping", oid)
+                failed_lookups.add(oid)
                 return None
             plan_tier = (account or {}).get("plan_tier", "free")
             tier_cache[oid] = plan_tier

--- a/apps/backend/routers/container.py
+++ b/apps/backend/routers/container.py
@@ -13,6 +13,7 @@ from core.auth import AuthContext, get_current_user, resolve_owner_id
 from core.config import settings
 from core.containers import get_ecs_manager
 from core.containers.ecs_manager import EcsManagerError
+from core.observability.metrics import put_metric, timing
 from core.repositories import billing_repo, container_repo
 
 logger = logging.getLogger(__name__)
@@ -105,9 +106,13 @@ async def container_provision(
     existing = await container_repo.get_by_owner_id(owner_id)
     if existing:
         if existing.get("status") == "stopped":
-            # Container was scaled to zero -- restart it
+            # Container was scaled to zero -- restart it. This is the
+            # cold-start path; emit a metric so we can answer "how often do
+            # users hit a cold start" and "how long does the restart take".
             try:
-                await get_ecs_manager().start_user_service(owner_id)
+                with timing("gateway.cold_start.latency"):
+                    await get_ecs_manager().start_user_service(owner_id)
+                put_metric("gateway.cold_start.count", dimensions={"outcome": "ok"})
                 logger.info("Restarted stopped container for owner %s", owner_id)
                 return {
                     "status": "provisioning",
@@ -116,6 +121,7 @@ async def container_provision(
                     "already_existed": True,
                 }
             except EcsManagerError as e:
+                put_metric("gateway.cold_start.count", dimensions={"outcome": "error"})
                 logger.error("Restart failed for stopped container, owner %s: %s", owner_id, e)
                 raise HTTPException(status_code=503, detail=str(e))
         return {

--- a/apps/backend/tests/unit/gateway/test_connection_pool.py
+++ b/apps/backend/tests/unit/gateway/test_connection_pool.py
@@ -236,6 +236,10 @@ async def test_record_activity_retry_backdate_uses_post_await_time():
             "core.gateway.connection_pool.time.time",
             side_effect=lambda: next(times),
         ),
+        # Suppress put_metric so its internal time.time() call doesn't consume
+        # values from our `times` iterator. We're testing the backdate stamp,
+        # not metric emission (covered separately).
+        patch("core.gateway.connection_pool.put_metric"),
     ):
         await pool.record_activity("user_1")
 
@@ -243,6 +247,83 @@ async def test_record_activity_retry_backdate_uses_post_await_time():
     # Fixed version stamps at 105.0 - 28 = 77.0 (post-await fresh time).
     expected = 105.0 - (_DDB_WRITE_COOLDOWN - _DDB_WRITE_RETRY_FLOOR)
     assert _LAST_DDB_WRITE["user_1"] == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
+async def test_record_activity_emits_outcome_metric_on_success():
+    """Observability: each record_activity call emits a count metric tagged
+    with outcome=success / noop / error so we can graph the breakdown."""
+    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.update_last_active",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("core.gateway.connection_pool.put_metric") as mock_put_metric,
+    ):
+        await pool.record_activity("user_1")
+
+    outcomes = [
+        c.kwargs.get("dimensions", {}).get("outcome")
+        for c in mock_put_metric.call_args_list
+        if c.args and c.args[0] == "gateway.record_activity.count"
+    ]
+    assert outcomes == ["success"]
+
+
+@pytest.mark.asyncio
+async def test_record_activity_emits_outcome_metric_on_noop():
+    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.update_last_active",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch("core.gateway.connection_pool.put_metric") as mock_put_metric,
+    ):
+        await pool.record_activity("user_1")
+
+    outcomes = [
+        c.kwargs.get("dimensions", {}).get("outcome")
+        for c in mock_put_metric.call_args_list
+        if c.args and c.args[0] == "gateway.record_activity.count"
+    ]
+    assert outcomes == ["noop"]
+
+
+@pytest.mark.asyncio
+async def test_record_activity_emits_outcome_metric_on_error():
+    from core.gateway.connection_pool import GatewayConnectionPool, _LAST_DDB_WRITE
+
+    _LAST_DDB_WRITE.clear()
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.update_last_active",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("ddb blip"),
+        ),
+        patch("core.gateway.connection_pool.put_metric") as mock_put_metric,
+    ):
+        await pool.record_activity("user_1")
+
+    outcomes = [
+        c.kwargs.get("dimensions", {}).get("outcome")
+        for c in mock_put_metric.call_args_list
+        if c.args and c.args[0] == "gateway.record_activity.count"
+    ]
+    assert outcomes == ["error"]
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/unit/gateway/test_idle_checker.py
+++ b/apps/backend/tests/unit/gateway/test_idle_checker.py
@@ -332,3 +332,38 @@ async def test_reap_once_emits_per_tier_running_count_breakdown():
     breakdown = {c.kwargs.get("dimensions", {}).get("tier"): c.args[1] for c in by_tier_calls}
     # Two free users + the orphan (defaulted to free) = 3 free, 1 starter.
     assert breakdown == {"free": 3, "starter": 1}
+
+
+@pytest.mark.asyncio
+async def test_reap_once_caches_billing_lookup_failures_within_cycle():
+    """Codex P2 regression on PR #273: a failed billing lookup must be cached
+    for the rest of the cycle, otherwise the per-tier breakdown loop AND the
+    idle-eligible reap loop both trigger a DDB get_by_owner_id call for the
+    same failing owner — doubling read pressure and warning-log noise."""
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    old_ts = _iso(datetime.now(timezone.utc) - timedelta(minutes=30))
+    pool = GatewayConnectionPool(management_api=None)
+
+    # Same owner appears once in get_by_status. We expect billing to be
+    # called exactly once even though _resolve_tier is invoked twice in
+    # the cycle (once for the per-tier breakdown, once for the reap path).
+    rows = [
+        {"owner_id": "user_billing_broken", "status": "running", "last_active_at": old_ts},
+    ]
+
+    mock_billing = AsyncMock(side_effect=RuntimeError("billing down"))
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+        patch("core.repositories.billing_repo.get_by_owner_id", new=mock_billing),
+        patch("core.containers.get_ecs_manager"),
+    ):
+        await pool._reap_once()
+
+    # Without the per-cycle failure cache, billing would be called twice.
+    assert mock_billing.await_count == 1

--- a/apps/backend/tests/unit/gateway/test_idle_checker.py
+++ b/apps/backend/tests/unit/gateway/test_idle_checker.py
@@ -286,3 +286,49 @@ async def test_reap_once_emits_both_gauges():
     open_call = next(c for c in mock_gauge.call_args_list if c.args[0] == "gateway.connection.open")
     assert running_call.args[1] == 1  # one row from get_by_status
     assert open_call.args[1] == 2  # two entries in pool._connections
+
+
+@pytest.mark.asyncio
+async def test_reap_once_emits_per_tier_running_count_breakdown():
+    """Observability: in addition to the single gateway.running.count gauge,
+    the reaper emits gateway.running.count.by_tier with a `tier` dimension so
+    we can answer 'how many free vs paid containers are running right now'
+    without log scraping."""
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    pool = GatewayConnectionPool(management_api=None)
+
+    rows = [
+        {"owner_id": "user_free_a", "status": "running"},
+        {"owner_id": "user_free_b", "status": "running"},
+        {"owner_id": "user_starter", "status": "running"},
+        {"owner_id": "user_orphan", "status": "running"},
+    ]
+
+    async def fake_billing(oid):
+        return {
+            "user_free_a": {"plan_tier": "free"},
+            "user_free_b": {"plan_tier": "free"},
+            "user_starter": {"plan_tier": "starter"},
+        }.get(oid)  # user_orphan returns None → defaults to "free"
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new=AsyncMock(side_effect=fake_billing),
+        ),
+        patch("core.containers.get_ecs_manager"),
+        patch("core.gateway.connection_pool.gauge") as mock_gauge,
+    ):
+        await pool._reap_once()
+
+    # Filter only the by_tier gauge calls.
+    by_tier_calls = [c for c in mock_gauge.call_args_list if c.args and c.args[0] == "gateway.running.count.by_tier"]
+    breakdown = {c.kwargs.get("dimensions", {}).get("tier"): c.args[1] for c in by_tier_calls}
+    # Two free users + the orphan (defaulted to free) = 3 free, 1 starter.
+    assert breakdown == {"free": 3, "starter": 1}

--- a/apps/backend/tests/unit/routers/test_container_provision_metrics.py
+++ b/apps/backend/tests/unit/routers/test_container_provision_metrics.py
@@ -1,0 +1,90 @@
+"""Tests for cold-start observability in container_provision."""
+
+import os
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+def _make_timing_mock():
+    """Build a MagicMock that also works as a context manager for `with timing(...):`."""
+
+    @contextmanager
+    def fake_cm(*_args, **_kwargs):
+        yield
+
+    m = MagicMock(side_effect=fake_cm)
+    return m
+
+
+@pytest.mark.asyncio
+async def test_cold_start_emits_count_and_latency_on_success():
+    """When a stopped container is restarted, the route emits both
+    gateway.cold_start.count (outcome=ok) and a gateway.cold_start.latency
+    timing wrapper around the start_user_service call."""
+    from routers.container import container_provision
+
+    auth = MagicMock()
+    auth.user_id = "user_returning"
+    auth.org_id = None
+
+    fake_ecs = MagicMock()
+    fake_ecs.start_user_service = AsyncMock()
+
+    fake_timing = _make_timing_mock()
+
+    with (
+        patch(
+            "routers.container.container_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"status": "stopped", "service_name": "openclaw-foo"},
+        ),
+        patch("routers.container.get_ecs_manager", return_value=fake_ecs),
+        patch("routers.container.put_metric") as mock_put_metric,
+        patch("routers.container.timing", fake_timing),
+    ):
+        result = await container_provision(auth=auth)
+
+    assert result["status"] == "provisioning"
+
+    # `timing()` was used to wrap start_user_service.
+    fake_timing.assert_called_once_with("gateway.cold_start.latency")
+    # `put_metric()` was called with cold_start.count + outcome=ok.
+    count_calls = [c for c in mock_put_metric.call_args_list if c.args and c.args[0] == "gateway.cold_start.count"]
+    assert any(c.kwargs.get("dimensions", {}).get("outcome") == "ok" for c in count_calls)
+
+
+@pytest.mark.asyncio
+async def test_cold_start_emits_error_outcome_on_failure():
+    """If start_user_service raises EcsManagerError, the route emits
+    gateway.cold_start.count with outcome=error and re-raises HTTPException."""
+    from fastapi import HTTPException
+
+    from core.containers.ecs_manager import EcsManagerError
+    from routers.container import container_provision
+
+    auth = MagicMock()
+    auth.user_id = "user_returning"
+    auth.org_id = None
+
+    fake_ecs = MagicMock()
+    fake_ecs.start_user_service = AsyncMock(side_effect=EcsManagerError("ECS down"))
+
+    with (
+        patch(
+            "routers.container.container_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"status": "stopped", "service_name": "openclaw-foo"},
+        ),
+        patch("routers.container.get_ecs_manager", return_value=fake_ecs),
+        patch("routers.container.put_metric") as mock_put_metric,
+        patch("routers.container.timing", _make_timing_mock()),
+    ):
+        with pytest.raises(HTTPException):
+            await container_provision(auth=auth)
+
+    count_calls = [c for c in mock_put_metric.call_args_list if c.args and c.args[0] == "gateway.cold_start.count"]
+    assert any(c.kwargs.get("dimensions", {}).get("outcome") == "error" for c in count_calls)

--- a/apps/frontend/src/hooks/__tests__/useActivityPing.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useActivityPing.test.ts
@@ -12,6 +12,12 @@ vi.mock('../useGateway', () => ({
   useGateway: () => mockGatewayValue,
 }));
 
+// Mock posthog so we can assert capture() calls.
+const posthogCapture = vi.fn();
+vi.mock('posthog-js', () => ({
+  default: { capture: (...args: unknown[]) => posthogCapture(...args) },
+}));
+
 function setVisibility(state: 'visible' | 'hidden') {
   Object.defineProperty(document, 'visibilityState', {
     value: state,
@@ -30,6 +36,7 @@ describe('useActivityPing', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     send.mockReset();
+    posthogCapture.mockReset();
     mockGatewayValue = { send, isConnected: true };
     setVisibility('visible');
   });
@@ -147,5 +154,31 @@ describe('useActivityPing', () => {
     }).not.toThrow();
 
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it('captures a posthog event for each ping with interval_ms', async () => {
+    const useActivityPing = await importHook();
+    renderHook(() => useActivityPing());
+
+    // First ping → interval_ms is null (no prior ping to measure from).
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      vi.advanceTimersByTime(6_000);
+    });
+    expect(posthogCapture).toHaveBeenCalledTimes(1);
+    expect(posthogCapture).toHaveBeenLastCalledWith('activity_ping_sent', {
+      interval_ms: null,
+    });
+
+    // Second ping → interval_ms is the elapsed time since the first.
+    act(() => {
+      vi.advanceTimersByTime(61_000);
+      window.dispatchEvent(new MouseEvent('mousemove'));
+      vi.advanceTimersByTime(6_000);
+    });
+    expect(posthogCapture).toHaveBeenCalledTimes(2);
+    const secondCall = posthogCapture.mock.calls[1];
+    expect(secondCall[0]).toBe('activity_ping_sent');
+    expect(secondCall[1].interval_ms).toBeGreaterThanOrEqual(60_000);
   });
 });

--- a/apps/frontend/src/hooks/useActivityPing.ts
+++ b/apps/frontend/src/hooks/useActivityPing.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import posthog from 'posthog-js';
 import { useGateway } from './useGateway';
 
 const PING_INTERVAL_MS = 60_000;
@@ -47,6 +48,16 @@ export function useActivityPing(): void {
       const now = Date.now();
       if (now - lastPingRef.current < PING_INTERVAL_MS) return;
       send({ type: 'user_active' });
+      // Client-side telemetry: lets us debug "why isn't my container staying
+      // alive" by checking PostHog before assuming a backend issue. Capture
+      // the inter-ping interval so we can confirm the throttle is working.
+      try {
+        posthog.capture('activity_ping_sent', {
+          interval_ms: lastPingRef.current === 0 ? null : now - lastPingRef.current,
+        });
+      } catch {
+        // PostHog not initialised (no key) — that's expected in dev.
+      }
       lastPingRef.current = now;
       pendingRef.current = false;
     };

--- a/apps/infra/lib/stacks/observability-stack.ts
+++ b/apps/infra/lib/stacks/observability-stack.ts
@@ -1754,6 +1754,132 @@ def handler(event, context):
       }),
     );
 
+    // ----- Row 3.5: Free-tier scale-to-zero (4 widgets) -----
+    // Source-of-truth for the heartbeat is the P12 alarm (reaper-dead) — these
+    // widgets are for at-a-glance visibility, not gating.
+    dashboard.addWidgets(
+      new cloudwatch.GraphWidget({
+        title: "Running containers (gauge)",
+        left: [
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.running.count",
+            statistic: "Maximum",
+            dimensionsMap: dims,
+          }),
+        ],
+        width: 6,
+        height: 6,
+      }),
+      new cloudwatch.GraphWidget({
+        title: "Running by tier",
+        left: [
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.running.count.by_tier",
+            statistic: "Maximum",
+            dimensionsMap: { ...dims, tier: "free" },
+            label: "free",
+          }),
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.running.count.by_tier",
+            statistic: "Maximum",
+            dimensionsMap: { ...dims, tier: "starter" },
+            label: "starter",
+          }),
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.running.count.by_tier",
+            statistic: "Maximum",
+            dimensionsMap: { ...dims, tier: "pro" },
+            label: "pro",
+          }),
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.running.count.by_tier",
+            statistic: "Maximum",
+            dimensionsMap: { ...dims, tier: "enterprise" },
+            label: "enterprise",
+          }),
+        ],
+        width: 6,
+        height: 6,
+      }),
+      new cloudwatch.GraphWidget({
+        title: "Cold starts & latency",
+        left: [
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.cold_start.count",
+            statistic: "Sum",
+            dimensionsMap: { ...dims, outcome: "ok" },
+            label: "cold starts (ok)",
+          }),
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.cold_start.count",
+            statistic: "Sum",
+            dimensionsMap: { ...dims, outcome: "error" },
+            label: "cold starts (error)",
+          }),
+        ],
+        right: [
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.cold_start.latency",
+            statistic: "p50",
+            dimensionsMap: dims,
+            label: "p50 latency",
+          }),
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.cold_start.latency",
+            statistic: "p99",
+            dimensionsMap: dims,
+            label: "p99 latency",
+          }),
+        ],
+        width: 6,
+        height: 6,
+      }),
+      new cloudwatch.GraphWidget({
+        title: "record_activity outcomes & scale-to-zero events",
+        left: [
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.record_activity.count",
+            statistic: "Sum",
+            dimensionsMap: { ...dims, outcome: "success" },
+            label: "success",
+          }),
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.record_activity.count",
+            statistic: "Sum",
+            dimensionsMap: { ...dims, outcome: "noop" },
+            label: "noop (cold-start race)",
+          }),
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.record_activity.count",
+            statistic: "Sum",
+            dimensionsMap: { ...dims, outcome: "error" },
+            label: "error (DDB)",
+          }),
+          new cloudwatch.Metric({
+            namespace: "Isol8",
+            metricName: "gateway.idle.scale_to_zero",
+            statistic: "Sum",
+            dimensionsMap: { ...dims, tier: "free" },
+            label: "scale-to-zero (free)",
+          }),
+        ],
+        width: 6,
+        height: 6,
+      }),
+    );
+
     // ----- Row 4: Channels & Billing (4 widgets) -----
     dashboard.addWidgets(
       new cloudwatch.GraphWidget({

--- a/apps/infra/test/observability-stack.test.ts
+++ b/apps/infra/test/observability-stack.test.ts
@@ -181,4 +181,23 @@ describe("ObservabilityStack", () => {
       Threshold: 1,
     });
   });
+
+  // ---------------------------------------------------------------------
+  // Scale-to-zero dashboard widgets (smoke tests — confirm rendered into
+  // the CloudFormation Dashboard body, not a typo)
+  // ---------------------------------------------------------------------
+
+  test("dashboard widgets reference the new scale-to-zero metrics", () => {
+    const dashboards = template.findResources("AWS::CloudWatch::Dashboard");
+    const bodies = Object.values(dashboards).map((r) =>
+      JSON.stringify(r.Properties.DashboardBody),
+    );
+    const allBodies = bodies.join("");
+
+    // Each new metric should appear at least once in the dashboard body.
+    expect(allBodies).toContain("gateway.running.count.by_tier");
+    expect(allBodies).toContain("gateway.cold_start.count");
+    expect(allBodies).toContain("gateway.cold_start.latency");
+    expect(allBodies).toContain("gateway.record_activity.count");
+  });
 });


### PR DESCRIPTION
## Summary

Closes the observability gaps surfaced after PR #265 / #269 / #272 shipped. Lets us answer at-a-glance questions that previously required log scraping.

### What you can now graph / alarm on

| Metric | Dimensions | What it answers |
|---|---|---|
| \`gateway.cold_start.count\` | \`outcome\` (ok / error) | how often free users hit a cold start; how often the restart fails |
| \`gateway.cold_start.latency\` | — | distribution of \`start_user_service\` latency (p50 / p99) |
| \`gateway.record_activity.count\` | \`outcome\` (success / noop / error) | is the cold-start race firing more than expected; are DDB writes silently failing; is the abuse floor tripping |
| \`gateway.running.count.by_tier\` | \`tier\` (free / starter / pro / enterprise) | how many free vs paid containers right now |

Plus a new dashboard row in the \`isol8-{env}-orr\` CloudWatch dashboard with 4 widgets covering all of the above.

### Frontend

\`useActivityPing\` now \`posthog.capture('activity_ping_sent', { interval_ms })\` on each ping. Lets you debug "why isn't my container staying alive" client-side before assuming a backend issue.

### Implementation notes

- **Per-tier breakdown** caches billing lookups within a reap cycle (one DDB \`get_by_owner_id\` per unique owner per cycle, even if the row is also evaluated for reaping). At small scale this is trivial; at large scale the cache prevents read amplification.
- **Cold-start metrics** wrap only the \`status=stopped → start_user_service\` branch in \`container_provision\`. Fresh-provision (new user) is excluded — different code path, different latency profile.
- **PostHog event** wrapped in try/catch so dev environments without \`NEXT_PUBLIC_POSTHOG_KEY\` set don't throw.

## Test plan

- [x] 6 new backend tests for outcome-metric emission (success / noop / error on \`record_activity\`; ok / error on \`cold_start\`; per-tier breakdown).
- [x] 1 new frontend test asserting \`posthog.capture('activity_ping_sent', ...)\` is called per ping with correct \`interval_ms\`.
- [x] 1 new infra test asserting the dashboard JSON contains references to each new metric name.
- [x] All existing tests still pass (66 backend + 8 frontend + 13 infra).
- [ ] CI green
- [ ] Post-deploy smoke: open the \`isol8-prod-orr\` dashboard and confirm the new widgets render with data within 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)