### PR TITLE
feat: tier-based policy enforcement on openclaw.json

### DIFF
--- a/apps/backend/core/config.py
+++ b/apps/backend/core/config.py
@@ -30,6 +30,12 @@ class Settings(BaseSettings):
     AWS_REGION: str = os.getenv("AWS_REGION", "us-east-1")
     BEDROCK_ENABLED: bool = os.getenv("BEDROCK_ENABLED", "true").lower() == "true"
 
+    # Config reconciler mode (drift detection/correction for openclaw.json on EFS)
+    #   off     -- reconciler disabled (default)
+    #   report  -- detect drift and log/emit metrics, do not mutate
+    #   enforce -- detect drift and rewrite openclaw.json to match desired state
+    CONFIG_RECONCILER_MODE: str = "off"
+
     # CORS Configuration (comma-separated origins; deployed values set by Terraform)
     CORS_ORIGINS: str = "http://localhost:3000,http://localhost:5173"
 

--- a/apps/backend/core/repositories/container_repo.py
+++ b/apps/backend/core/repositories/container_repo.py
@@ -201,6 +201,25 @@ async def list_active_owners() -> list[str]:
     Deliberately excludes 'provisioning' — during that phase the backend
     itself is writing openclaw.json, and the reconciler must not race with
     it. The reconciler starts caring once the container is fully running.
+
+    Paginates via LastEvaluatedKey so fleets whose status-index page exceeds
+    DynamoDB's 1MB response cap are fully enumerated (otherwise later pages
+    would be silently dropped, leaving some users unreconciled).
     """
-    rows = await get_by_status("running")
-    return [r["owner_id"] for r in rows if "owner_id" in r]
+    table = _get_table()
+    owners: list[str] = []
+    last_key = None
+    while True:
+        query_kwargs: dict = {
+            "IndexName": "status-index",
+            "KeyConditionExpression": Key("status").eq("running"),
+            "ProjectionExpression": "owner_id",
+        }
+        if last_key:
+            query_kwargs["ExclusiveStartKey"] = last_key
+        response = await run_in_thread(table.query, **query_kwargs)
+        owners.extend(item["owner_id"] for item in response.get("Items", []) if "owner_id" in item)
+        last_key = response.get("LastEvaluatedKey")
+        if not last_key:
+            break
+    return owners

--- a/apps/backend/core/repositories/container_repo.py
+++ b/apps/backend/core/repositories/container_repo.py
@@ -192,3 +192,15 @@ async def get_reconciler_grace(owner_id: str) -> int:
         return 0
     # DDB returns numbers as Decimal -- coerce to int.
     return int(value)
+
+
+async def list_active_owners() -> list[str]:
+    """Return owner_ids for containers with status='running'. Used by the
+    config reconciler to enumerate targets.
+
+    Deliberately excludes 'provisioning' — during that phase the backend
+    itself is writing openclaw.json, and the reconciler must not race with
+    it. The reconciler starts caring once the container is fully running.
+    """
+    rows = await get_by_status("running")
+    return [r["owner_id"] for r in rows if "owner_id" in r]

--- a/apps/backend/core/repositories/container_repo.py
+++ b/apps/backend/core/repositories/container_repo.py
@@ -167,3 +167,28 @@ async def mark_stopped_if_running(owner_id: str) -> bool:
 async def delete(owner_id: str) -> None:
     table = _get_table()
     await run_in_thread(table.delete_item, Key={"owner_id": owner_id})
+
+
+async def set_reconciler_grace(owner_id: str, seconds: int = 5) -> dict | None:
+    """Write `reconciler_grace_until = now + seconds` to this owner's container
+    row. The reconciler checks this before reverting so admin / backend-initiated
+    writes aren't immediately undone by a concurrent reconciler tick.
+
+    No-op if the row doesn't exist (returns None).
+    """
+    import time
+
+    return await update_fields(owner_id, {"reconciler_grace_until": int(time.time()) + seconds})
+
+
+async def get_reconciler_grace(owner_id: str) -> int:
+    """Return the reconciler_grace_until timestamp (epoch seconds) for this
+    owner, or 0 if unset or the row doesn't exist."""
+    existing = await get_by_owner_id(owner_id)
+    if existing is None:
+        return 0
+    value = existing.get("reconciler_grace_until")
+    if value is None:
+        return 0
+    # DDB returns numbers as Decimal -- coerce to int.
+    return int(value)

--- a/apps/backend/core/services/config_patcher.py
+++ b/apps/backend/core/services/config_patcher.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 import tempfile
+import threading
 from typing import Any, Callable
 
 from core.config import settings
@@ -16,53 +17,113 @@ logger = logging.getLogger(__name__)
 
 _efs_mount_path = settings.EFS_MOUNT_PATH
 
+# POSIX fcntl/lockf locks are per-process: two threads in the same process
+# do NOT block each other via fcntl. Since the reconciler and the patch
+# endpoint both run in the backend process and dispatch to the default
+# thread-pool executor via ``asyncio.to_thread``, we need an in-process
+# lock to serialize them. The fcntl lock still matters for cross-process
+# serialization (e.g. a fleet cleanup script run alongside the backend).
+_owner_locks: dict[str, threading.Lock] = {}
+_owner_locks_guard = threading.Lock()
+
+
+def _get_owner_lock(owner_id: str) -> threading.Lock:
+    with _owner_locks_guard:
+        lock = _owner_locks.get(owner_id)
+        if lock is None:
+            lock = threading.Lock()
+            _owner_locks[owner_id] = lock
+        return lock
+
 
 class ConfigPatchError(Exception):
     pass
 
 
-def _deep_merge(base: dict, patch: dict) -> dict:
+def deep_merge(base: dict, patch: dict) -> dict:
     """Deep-merge patch into base. Dicts are merged recursively. Non-dict values are replaced."""
     result = copy.deepcopy(base)
     for key, value in patch.items():
         if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-            result[key] = _deep_merge(result[key], value)
+            result[key] = deep_merge(result[key], value)
         else:
             result[key] = copy.deepcopy(value)
     return result
 
 
-async def _locked_rmw(
+async def locked_rmw(
     owner_id: str,
     mutate_fn: Callable[[dict], bool],
     log_context: str,
 ) -> None:
     """Locked read-modify-write skeleton for openclaw.json on EFS.
 
-    Resolves the owner's config path, raises ConfigPatchError if missing,
-    acquires an exclusive fcntl.lockf on openclaw.json, reads + parses JSON,
-    invokes ``mutate_fn(current)`` to apply per-call mutation logic in place.
-
-    ``mutate_fn`` returns True if the config was modified and a write is
-    needed, or False to signal a no-op (skip backup + write entirely).
-
-    On a write, takes a .bak backup, validates serializability, atomically
-    renames a tempfile into place, and chowns to uid/gid 1000 if running
-    as root. Releases the lock in a finally block. Logs success with
-    ``log_context``.
+    Lock contract:
+      - Resolves the owner's config path; raises ConfigPatchError if the
+        file is missing (callers must pre-seed the config before patching).
+      - Acquires a per-owner ``threading.Lock`` first to serialize concurrent
+        callers within this process (POSIX fcntl locks are per-process and
+        do NOT block sibling threads), then an exclusive ``fcntl.lockf``
+        on the file descriptor for cross-process coordination.
+        ``fcntl.lockf`` (advisory, POSIX) is used instead of ``flock``
+        because ``flock`` is broken over NFS/EFS.
+      - Defends against the rename/orphan race: if another writer renamed
+        a new inode into place while we were acquiring the fcntl lock,
+        our fd's inode differs from ``config_path``'s inode — we drop the
+        lock, re-open, and re-acquire until the two match.
+      - Reads + parses JSON from the same fd to avoid TOCTOU / double-open.
+      - Invokes ``mutate_fn(current)`` to apply per-call mutation logic
+        in place. ``mutate_fn`` returns True if the config was modified
+        and a write is needed, or False to signal a no-op (skip backup +
+        write entirely).
+      - On a write: takes a .bak backup, validates serializability,
+        atomically writes a tempfile in the same directory and renames
+        it into place, and chowns to uid/gid 1000 if running as root
+        (matches the OpenClaw container's ``node`` user).
+      - Releases the fcntl lock in a ``finally`` block, closes the fd,
+        and releases the in-process owner lock. Logs success at INFO
+        with ``log_context``.
     """
     config_dir = os.path.join(_efs_mount_path, owner_id)
     config_path = os.path.join(config_dir, "openclaw.json")
     backup_path = os.path.join(config_dir, "openclaw.json.bak")
 
+    owner_lock = _get_owner_lock(owner_id)
+
     def _do_rmw():
+        # Serialize within this process first (fcntl is per-process only;
+        # two threads in the same process will not block each other on
+        # fcntl.lockf). The fcntl lock below still matters for cross-process
+        # coordination (e.g. the fleet cleanup script alongside the backend).
+        owner_lock.acquire()
         lock_fd = None
         try:
-            try:
-                lock_fd = open(config_path, "r+")
-            except FileNotFoundError:
-                raise ConfigPatchError(f"Config not found for owner {owner_id}")
-            fcntl.lockf(lock_fd, fcntl.LOCK_EX)
+            # Re-open loop: every successful writer atomically renames a new
+            # inode into ``config_path``, which orphans any fd a concurrent
+            # cross-process waiter already opened. After acquiring the lock,
+            # compare our fd's inode to the one currently at ``config_path``
+            # — if they differ, a rename happened while we were waiting;
+            # drop the lock, reopen, and re-acquire. Loop until stable.
+            while True:
+                try:
+                    candidate = open(config_path, "r+")
+                except FileNotFoundError:
+                    raise ConfigPatchError(f"Config not found for owner {owner_id}")
+                fcntl.lockf(candidate, fcntl.LOCK_EX)
+                try:
+                    fd_ino = os.fstat(candidate.fileno()).st_ino
+                    path_ino = os.stat(config_path).st_ino
+                except FileNotFoundError:
+                    # Path vanished between lock + stat; retry.
+                    fcntl.lockf(candidate, fcntl.LOCK_UN)
+                    candidate.close()
+                    continue
+                if fd_ino == path_ino:
+                    lock_fd = candidate
+                    break
+                # Orphan fd — a writer replaced the inode while we waited.
+                fcntl.lockf(candidate, fcntl.LOCK_UN)
+                candidate.close()
 
             # Read from the same fd we hold the lock on (avoid TOCTOU + double-open).
             lock_fd.seek(0)
@@ -94,6 +155,7 @@ async def _locked_rmw(
             if lock_fd:
                 fcntl.lockf(lock_fd, fcntl.LOCK_UN)
                 lock_fd.close()
+            owner_lock.release()
 
     await asyncio.to_thread(_do_rmw)
 
@@ -107,12 +169,12 @@ async def patch_openclaw_config(owner_id: str, patch: dict) -> None:
     """
 
     def _mutate(current: dict) -> bool:
-        merged = _deep_merge(current, patch)
+        merged = deep_merge(current, patch)
         current.clear()
         current.update(merged)
         return True  # always write, even for empty patches
 
-    await _locked_rmw(owner_id, _mutate, f"patch keys={list(patch.keys())}")
+    await locked_rmw(owner_id, _mutate, f"patch keys={list(patch.keys())}")
 
 
 async def append_to_openclaw_config_list(
@@ -149,7 +211,7 @@ async def append_to_openclaw_config_list(
         existing.append(value)
         return True
 
-    await _locked_rmw(owner_id, _mutate, f"append path={path} value={value!r}")
+    await locked_rmw(owner_id, _mutate, f"append path={path} value={value!r}")
 
 
 async def remove_from_openclaw_config_list(
@@ -190,7 +252,7 @@ async def remove_from_openclaw_config_list(
         cursor[leaf_key] = filtered
         return True
 
-    await _locked_rmw(owner_id, _mutate, f"remove path={path}")
+    await locked_rmw(owner_id, _mutate, f"remove path={path}")
 
 
 async def delete_openclaw_config_path(
@@ -224,4 +286,4 @@ async def delete_openclaw_config_path(
         del cursor[leaf_key]
         return True
 
-    await _locked_rmw(owner_id, _mutate, f"delete path={path}")
+    await locked_rmw(owner_id, _mutate, f"delete path={path}")

--- a/apps/backend/core/services/config_policy.py
+++ b/apps/backend/core/services/config_policy.py
@@ -8,6 +8,7 @@ expected value from helpers in core/containers/config.py.
 import copy
 from typing import Any, Literal, TypedDict
 
+from core.config import TIER_CONFIG
 from core.containers.config import (
     _TIER_ALLOWED_MODEL_IDS,
     _models_for_tier,
@@ -31,6 +32,8 @@ class PolicyViolation(TypedDict):
 def _expected_providers(tier: str) -> dict:
     """The one provider block this tier is allowed to run: amazon-bedrock
     with exactly the tier's model list. No other providers permitted."""
+    # NOTE: hardcodes us-east-1 because Isol8 is single-region (see CLAUDE.md).
+    # If we go multi-region, thread `region` through from caller.
     return {
         "amazon-bedrock": {
             "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -44,6 +47,10 @@ def _expected_providers(tier: str) -> dict:
 def _providers_match(actual: Any, expected: dict) -> bool:
     """Strict equality check. Providers block must match exactly — any extra
     provider, any extra/missing model, any changed field is a violation."""
+    # NOTE: strict `==` is order-sensitive for the `models` list. Both
+    # `write_openclaw_config` and `_expected_providers` derive the list from
+    # `_models_for_tier` so order is shared. If either side re-orders, every
+    # clean config will flip to a violation.
     return actual == expected
 
 
@@ -68,6 +75,22 @@ def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
                 "reason": f"providers block for tier={effective_tier} must match the tier's allowlist",
                 "expected": expected_providers,
                 "actual": actual_providers,
+            }
+        )
+
+    # 2. agents.defaults.model.primary — must be in tier allowlist
+    primary = config.get("agents", {}).get("defaults", {}).get("model", {}).get("primary", "")
+    bare_primary = primary.removeprefix("amazon-bedrock/")
+    if bare_primary not in _TIER_ALLOWED_MODEL_IDS[effective_tier]:
+        expected_primary = (
+            f"amazon-bedrock/{TIER_CONFIG[effective_tier]['primary_model'].removeprefix('amazon-bedrock/')}"
+        )
+        violations.append(
+            {
+                "field": "agents.defaults.model.primary",
+                "reason": f"primary model {primary!r} is not allowed for tier={effective_tier}",
+                "expected": expected_primary,
+                "actual": primary,
             }
         )
 

--- a/apps/backend/core/services/config_policy.py
+++ b/apps/backend/core/services/config_policy.py
@@ -8,6 +8,11 @@ expected value from helpers in core/containers/config.py.
 import copy
 from typing import Any, Literal, TypedDict
 
+from core.containers.config import (
+    _TIER_ALLOWED_MODEL_IDS,
+    _models_for_tier,
+)
+
 LockedField = Literal[
     "models.providers",
     "agents.defaults.models",
@@ -23,13 +28,50 @@ class PolicyViolation(TypedDict):
     actual: Any
 
 
+def _expected_providers(tier: str) -> dict:
+    """The one provider block this tier is allowed to run: amazon-bedrock
+    with exactly the tier's model list. No other providers permitted."""
+    return {
+        "amazon-bedrock": {
+            "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "api": "bedrock-converse-stream",
+            "auth": "aws-sdk",
+            "models": _models_for_tier(tier),
+        },
+    }
+
+
+def _providers_match(actual: Any, expected: dict) -> bool:
+    """Strict equality check. Providers block must match exactly — any extra
+    provider, any extra/missing model, any changed field is a violation."""
+    return actual == expected
+
+
 def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
     """Return a list of locked-field violations for this config at this tier.
 
     Empty list means the config is legal. Each violation has enough info
     to revert (field, expected value) and for audit (reason, actual value).
     """
-    return []
+    violations: list[PolicyViolation] = []
+
+    # Tier fallback: unknown tier → free-tier allowlist (default-deny).
+    effective_tier = tier if tier in _TIER_ALLOWED_MODEL_IDS else "free"
+
+    # 1. models.providers — strict match against tier's allowed block
+    actual_providers = config.get("models", {}).get("providers", {})
+    expected_providers = _expected_providers(effective_tier)
+    if not _providers_match(actual_providers, expected_providers):
+        violations.append(
+            {
+                "field": "models.providers",
+                "reason": f"providers block for tier={effective_tier} must match the tier's allowlist",
+                "expected": expected_providers,
+                "actual": actual_providers,
+            }
+        )
+
+    return violations
 
 
 def apply_reverts(config: dict, violations: list[PolicyViolation]) -> dict:

--- a/apps/backend/core/services/config_policy.py
+++ b/apps/backend/core/services/config_policy.py
@@ -94,6 +94,30 @@ def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
             }
         )
 
+    # 3. agents.defaults.models — keys must all be in tier allowlist
+    models_map = config.get("agents", {}).get("defaults", {}).get("models", {})
+    if isinstance(models_map, dict):
+        illegal_keys = [
+            k for k in models_map if k.removeprefix("amazon-bedrock/") not in _TIER_ALLOWED_MODEL_IDS[effective_tier]
+        ]
+        if illegal_keys:
+            # Build expected: filter out illegal entries, ensure primary is present.
+            # Reuse write_openclaw_config's helper via a direct import.
+            from core.containers.config import _agent_models_for_tier
+
+            expected_primary = (
+                f"amazon-bedrock/{TIER_CONFIG[effective_tier]['primary_model'].removeprefix('amazon-bedrock/')}"
+            )
+            expected_models = _agent_models_for_tier(effective_tier, expected_primary)
+            violations.append(
+                {
+                    "field": "agents.defaults.models",
+                    "reason": f"agents.defaults.models contains non-allowlisted keys for tier={effective_tier}: {illegal_keys}",
+                    "expected": expected_models,
+                    "actual": models_map,
+                }
+            )
+
     return violations
 
 

--- a/apps/backend/core/services/config_policy.py
+++ b/apps/backend/core/services/config_policy.py
@@ -1,0 +1,40 @@
+"""Tier-aware policy for openclaw.json locked fields.
+
+Pure, side-effect-free. Takes a config dict and a tier name, returns a list
+of field-level violations. Apply reverts by computing the authoritative
+expected value from helpers in core/containers/config.py.
+"""
+
+import copy
+from typing import Any, Literal, TypedDict
+
+LockedField = Literal[
+    "models.providers",
+    "agents.defaults.models",
+    "agents.defaults.model.primary",
+    "channels.accounts",
+]
+
+
+class PolicyViolation(TypedDict):
+    field: LockedField
+    reason: str
+    expected: Any
+    actual: Any
+
+
+def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
+    """Return a list of locked-field violations for this config at this tier.
+
+    Empty list means the config is legal. Each violation has enough info
+    to revert (field, expected value) and for audit (reason, actual value).
+    """
+    return []
+
+
+def apply_reverts(config: dict, violations: list[PolicyViolation]) -> dict:
+    """Return a deep copy of config with each violating field replaced by
+    its expected value. Non-violating fields — including OpenClaw's `meta`
+    block and everything else — are preserved untouched.
+    """
+    return copy.deepcopy(config)

--- a/apps/backend/core/services/config_policy.py
+++ b/apps/backend/core/services/config_policy.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, TypedDict
 from core.config import TIER_CONFIG
 from core.containers.config import (
     _TIER_ALLOWED_MODEL_IDS,
+    _agent_models_for_tier,
     _models_for_tier,
 )
 
@@ -102,9 +103,6 @@ def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
         ]
         if illegal_keys:
             # Build expected: filter out illegal entries, ensure primary is present.
-            # Reuse write_openclaw_config's helper via a direct import.
-            from core.containers.config import _agent_models_for_tier
-
             expected_primary = (
                 f"amazon-bedrock/{TIER_CONFIG[effective_tier]['primary_model'].removeprefix('amazon-bedrock/')}"
             )
@@ -117,6 +115,27 @@ def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
                     "actual": models_map,
                 }
             )
+
+    # 4. channels.{provider}.accounts — free tier must have no accounts
+    if effective_tier == "free":
+        channels = config.get("channels", {})
+        if isinstance(channels, dict):
+            offending: dict[str, dict] = {}
+            for provider, provider_cfg in channels.items():
+                if not isinstance(provider_cfg, dict):
+                    continue
+                accounts = provider_cfg.get("accounts", {})
+                if isinstance(accounts, dict) and accounts:
+                    offending[provider] = accounts
+            if offending:
+                violations.append(
+                    {
+                        "field": "channels.accounts",
+                        "reason": f"free tier cannot have channel accounts; found: {sorted(offending.keys())}",
+                        "expected": {p: {} for p in offending},
+                        "actual": offending,
+                    }
+                )
 
     return violations
 

--- a/apps/backend/core/services/config_policy.py
+++ b/apps/backend/core/services/config_policy.py
@@ -93,11 +93,30 @@ def _providers_match(actual: Any, expected: dict) -> bool:
     return True
 
 
+def _safe_dict(root: Any, *path: str) -> dict:
+    """Walk ``root[path[0]][path[1]]…`` and return the value at the end if it
+    is a dict, otherwise ``{}``. Any non-dict intermediate short-circuits to
+    ``{}``. Used so malformed configs (e.g. ``{"models": null}``) yield a
+    violation rather than an ``AttributeError`` deep in ``evaluate``.
+    """
+    cursor: Any = root
+    for segment in path:
+        if not isinstance(cursor, dict):
+            return {}
+        cursor = cursor.get(segment)
+    return cursor if isinstance(cursor, dict) else {}
+
+
 def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
     """Return a list of locked-field violations for this config at this tier.
 
     Empty list means the config is legal. Each violation has enough info
     to revert (field, expected value) and for audit (reason, actual value).
+
+    Malformed inputs (non-dict ``models``, non-dict ``agents.defaults``,
+    non-string ``primary``, etc.) are tolerated: each nested access is
+    guarded so the offending block is treated as missing/invalid and surfaces
+    as a normal violation (which ``apply_reverts`` then normalizes).
     """
     violations: list[PolicyViolation] = []
 
@@ -105,7 +124,7 @@ def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
     effective_tier = tier if tier in _TIER_ALLOWED_MODEL_IDS else "free"
 
     # 1. models.providers — strict match against tier's allowed block
-    actual_providers = config.get("models", {}).get("providers", {})
+    actual_providers = _safe_dict(config, "models", "providers")
     expected_providers = _expected_providers(effective_tier)
     if not _providers_match(actual_providers, expected_providers):
         violations.append(
@@ -118,7 +137,9 @@ def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
         )
 
     # 2. agents.defaults.model.primary — must be in tier allowlist
-    primary = config.get("agents", {}).get("defaults", {}).get("model", {}).get("primary", "")
+    model_block = _safe_dict(config, "agents", "defaults", "model")
+    primary_raw = model_block.get("primary", "")
+    primary = primary_raw if isinstance(primary_raw, str) else ""
     bare_primary = primary.removeprefix("amazon-bedrock/")
     if bare_primary not in _TIER_ALLOWED_MODEL_IDS[effective_tier]:
         expected_primary = (
@@ -129,12 +150,12 @@ def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
                 "field": "agents.defaults.model.primary",
                 "reason": f"primary model {primary!r} is not allowed for tier={effective_tier}",
                 "expected": expected_primary,
-                "actual": primary,
+                "actual": primary_raw,
             }
         )
 
     # 3. agents.defaults.models — keys must all be in tier allowlist
-    models_map = config.get("agents", {}).get("defaults", {}).get("models", {})
+    models_map = _safe_dict(config, "agents", "defaults", "models")
     if isinstance(models_map, dict):
         illegal_keys = [
             k for k in models_map if k.removeprefix("amazon-bedrock/") not in _TIER_ALLOWED_MODEL_IDS[effective_tier]
@@ -156,7 +177,7 @@ def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
 
     # 4. channels.{provider}.accounts — free tier must have no accounts
     if effective_tier == "free":
-        channels = config.get("channels", {})
+        channels = _safe_dict(config, "channels")
         if isinstance(channels, dict):
             offending: dict[str, dict] = {}
             for provider, provider_cfg in channels.items():

--- a/apps/backend/core/services/config_policy.py
+++ b/apps/backend/core/services/config_policy.py
@@ -140,9 +140,36 @@ def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
     return violations
 
 
+def _set_dotted(target: dict, dotted: str, value: Any) -> None:
+    """Set `target[a][b][c] = value` for dotted='a.b.c'. Creates intermediate
+    dicts as needed."""
+    parts = dotted.split(".")
+    cursor = target
+    for segment in parts[:-1]:
+        if segment not in cursor or not isinstance(cursor[segment], dict):
+            cursor[segment] = {}
+        cursor = cursor[segment]
+    cursor[parts[-1]] = value
+
+
 def apply_reverts(config: dict, violations: list[PolicyViolation]) -> dict:
     """Return a deep copy of config with each violating field replaced by
-    its expected value. Non-violating fields — including OpenClaw's `meta`
-    block and everything else — are preserved untouched.
+    its expected value. Non-violating fields are preserved untouched.
+
+    Special-cases `channels.accounts` since that's a collection of per-provider
+    sub-fields, not a single dotted path.
     """
-    return copy.deepcopy(config)
+    result = copy.deepcopy(config)
+    for v in violations:
+        field = v["field"]
+        expected = v["expected"]
+        if field == "channels.accounts":
+            # expected is {provider: {} ...}; write into channels.{provider}.accounts
+            channels = result.setdefault("channels", {})
+            for provider in expected:
+                provider_cfg = channels.setdefault(provider, {})
+                if isinstance(provider_cfg, dict):
+                    provider_cfg["accounts"] = {}
+        else:
+            _set_dotted(result, field, copy.deepcopy(expected))
+    return result

--- a/apps/backend/core/services/config_policy.py
+++ b/apps/backend/core/services/config_policy.py
@@ -8,7 +8,7 @@ expected value from helpers in core/containers/config.py.
 import copy
 from typing import Any, Literal, TypedDict
 
-from core.config import TIER_CONFIG
+from core.config import TIER_CONFIG, settings
 from core.containers.config import (
     _TIER_ALLOWED_MODEL_IDS,
     _agent_models_for_tier,
@@ -32,12 +32,15 @@ class PolicyViolation(TypedDict):
 
 def _expected_providers(tier: str) -> dict:
     """The one provider block this tier is allowed to run: amazon-bedrock
-    with exactly the tier's model list. No other providers permitted."""
-    # NOTE: hardcodes us-east-1 because Isol8 is single-region (see CLAUDE.md).
-    # If we go multi-region, thread `region` through from caller.
+    with exactly the tier's model list. No other providers permitted.
+
+    Region comes from ``settings.AWS_REGION`` so this matches what
+    ``write_openclaw_config`` writes at provisioning time — otherwise any
+    non-us-east-1 deploy would flip every clean config into drift.
+    """
     return {
         "amazon-bedrock": {
-            "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "baseUrl": f"https://bedrock-runtime.{settings.AWS_REGION}.amazonaws.com",
             "api": "bedrock-converse-stream",
             "auth": "aws-sdk",
             "models": _models_for_tier(tier),

--- a/apps/backend/core/services/config_policy.py
+++ b/apps/backend/core/services/config_policy.py
@@ -46,13 +46,48 @@ def _expected_providers(tier: str) -> dict:
 
 
 def _providers_match(actual: Any, expected: dict) -> bool:
-    """Strict equality check. Providers block must match exactly — any extra
-    provider, any extra/missing model, any changed field is a violation."""
-    # NOTE: strict `==` is order-sensitive for the `models` list. Both
-    # `write_openclaw_config` and `_expected_providers` derive the list from
-    # `_models_for_tier` so order is shared. If either side re-orders, every
-    # clean config will flip to a violation.
-    return actual == expected
+    """Strict equality check against a canonical form. Providers block must
+    match exactly — any extra provider, any extra/missing model, any changed
+    field is a violation.
+
+    Canonicalizes before comparison so list ordering of ``models`` does not
+    matter: provider top-level keys compared as sets, per-provider non-``models``
+    fields compared as dicts, ``models`` compared as ``{id: model}`` maps.
+    Each model's full content is still strictly checked — only the list-order
+    invariant is loosened.
+    """
+    if not isinstance(actual, dict):
+        return False
+
+    if set(actual.keys()) != set(expected.keys()):
+        return False
+
+    for provider, expected_cfg in expected.items():
+        actual_cfg = actual.get(provider)
+        if not isinstance(actual_cfg, dict) or not isinstance(expected_cfg, dict):
+            return False
+
+        # Non-models keys must match exactly (baseUrl, api, auth, ...).
+        actual_non_models = {k: v for k, v in actual_cfg.items() if k != "models"}
+        expected_non_models = {k: v for k, v in expected_cfg.items() if k != "models"}
+        if actual_non_models != expected_non_models:
+            return False
+
+        # Models list: compare as {id: model} dict to ignore ordering but keep
+        # content-strict comparison on every model entry.
+        actual_models = actual_cfg.get("models", [])
+        expected_models = expected_cfg.get("models", [])
+        if not isinstance(actual_models, list) or not isinstance(expected_models, list):
+            return False
+        try:
+            actual_by_id = {m["id"]: m for m in actual_models}
+            expected_by_id = {m["id"]: m for m in expected_models}
+        except (TypeError, KeyError):
+            return False
+        if actual_by_id != expected_by_id:
+            return False
+
+    return True
 
 
 def evaluate(config: dict, tier: str) -> list[PolicyViolation]:

--- a/apps/backend/core/services/config_reconciler.py
+++ b/apps/backend/core/services/config_reconciler.py
@@ -17,11 +17,10 @@ import os
 import time
 
 from core.config import settings
-from core.constants import SYSTEM_ACTOR_ID
 from core.observability.metrics import put_metric
 from core.repositories import billing_repo, container_repo
 from core.services import config_policy
-from core.services.config_patcher import _locked_rmw
+from core.services.config_patcher import locked_rmw
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +76,7 @@ class ConfigReconciler:
         put_metric(
             "config.reconciler.tick.duration",
             value=(time.monotonic() - started) * 1000.0,
+            unit="Milliseconds",
             dimensions={"mode": settings.CONFIG_RECONCILER_MODE},
         )
 
@@ -142,7 +142,7 @@ class ConfigReconciler:
                 return True
 
             try:
-                await _locked_rmw(owner_id, _mutate, "policy_revert")
+                await locked_rmw(owner_id, _mutate, "policy_revert")
             except Exception as e:
                 logger.exception("reconciler: revert failed for owner=%s: %s", owner_id, e)
                 put_metric("config.reconciler.errors", dimensions={"kind": "revert"})
@@ -156,7 +156,10 @@ class ConfigReconciler:
                     tier,
                     reverted_fields,
                 )
-                await _write_audit(owner_id, tier, reverted_fields)
+                # Revert events are observable via the logger.info above
+                # (CloudWatch) and the config.drift.reverted metric. No
+                # dedicated audit log table — those two channels give us
+                # sufficient observability for this loop.
             # Mtime moved from our own write; refresh cache from the fresh stat.
             try:
                 self._last_seen_mtime[owner_id] = await asyncio.to_thread(os.path.getmtime, path)
@@ -186,18 +189,3 @@ class ConfigReconciler:
 def _read_json(path: str) -> dict:
     with open(path, "r") as f:
         return json.load(f)
-
-
-async def _write_audit(owner_id: str, tier: str, fields: list[str]) -> None:
-    """Best-effort audit log; swallow failures (audit should never break the loop)."""
-    try:
-        from core.repositories import audit_log_repo  # type: ignore
-
-        await audit_log_repo.create(
-            actor_id=SYSTEM_ACTOR_ID,
-            action="config_policy_revert",
-            owner_id=owner_id,
-            metadata={"tier": tier, "fields": fields},
-        )
-    except Exception:
-        logger.debug("audit log write failed", exc_info=True)

--- a/apps/backend/core/services/config_reconciler.py
+++ b/apps/backend/core/services/config_reconciler.py
@@ -60,7 +60,14 @@ class ConfigReconciler:
         logger.info("config_reconciler stopped")
 
     async def _tick(self) -> None:
-        if settings.CONFIG_RECONCILER_MODE == "off":
+        # Validate the mode at entry so typos ("Off", "ENFORCE", "enforce ",
+        # an unset default, …) early-exit before we enumerate owners or hit
+        # DDB / EFS. Anything other than the two valid run modes is treated
+        # as off; unknown values get a single warning per tick.
+        mode = settings.CONFIG_RECONCILER_MODE
+        if mode not in ("report", "enforce"):
+            if mode != "off":
+                logger.warning("unknown CONFIG_RECONCILER_MODE=%r, treating as off", mode)
             return
         owners = await container_repo.list_active_owners()
         if not owners:
@@ -113,6 +120,10 @@ class ConfigReconciler:
             # Admin just wrote; don't fight them.
             return
 
+        # Mode was already validated in _tick; only "report" or "enforce"
+        # reach this point. We re-read it here (rather than threading it as
+        # a param) because the value can flip mid-tick and we want each
+        # owner's branch to honor the latest setting.
         mode = settings.CONFIG_RECONCILER_MODE
 
         if mode == "report":
@@ -174,9 +185,6 @@ class ConfigReconciler:
             except FileNotFoundError:
                 self._last_seen.pop(owner_id, None)
             return
-
-        # Unknown mode — behave as off.
-        logger.warning("unknown CONFIG_RECONCILER_MODE=%r, treating as off", mode)
 
     async def _resolve_tier(self, owner_id: str) -> str | None:
         cached = self._tier_cache.get(owner_id)

--- a/apps/backend/core/services/config_reconciler.py
+++ b/apps/backend/core/services/config_reconciler.py
@@ -36,7 +36,11 @@ class ConfigReconciler:
         self._tier_cache_ttl = tier_cache_ttl
         self._tick_interval = tick_interval
         self._stop = asyncio.Event()
-        self._last_seen_mtime: dict[str, float] = {}
+        # Cache key combines mtime AND tier so a plan change alone (without a
+        # file edit) still triggers re-evaluation once the tier-cache TTL
+        # expires. Otherwise a paid→free downgrade where the user hasn't
+        # touched openclaw.json would never be observed.
+        self._last_seen: dict[str, tuple[float, str]] = {}
         self._tier_cache: dict[str, tuple[str, float]] = {}
 
     def stop(self) -> None:
@@ -93,12 +97,15 @@ class ConfigReconciler:
         except FileNotFoundError:
             return
 
-        if self._last_seen_mtime.get(owner_id) == mtime:
-            return
-
         tier = await self._resolve_tier(owner_id)
         if tier is None:
             # Fail-open: don't lock a user out of their own plan due to our DDB error.
+            return
+
+        # Short-circuit only when BOTH the file and the user's tier are
+        # unchanged since the last tick. A tier change with an untouched
+        # file must still re-evaluate (paid→free downgrade case).
+        if self._last_seen.get(owner_id) == (mtime, tier):
             return
 
         grace_until = await container_repo.get_reconciler_grace(owner_id)
@@ -125,7 +132,7 @@ class ConfigReconciler:
                     tier,
                     [v["field"] for v in violations],
                 )
-            self._last_seen_mtime[owner_id] = mtime
+            self._last_seen[owner_id] = (mtime, tier)
             return
 
         if mode == "enforce":
@@ -162,9 +169,10 @@ class ConfigReconciler:
                 # sufficient observability for this loop.
             # Mtime moved from our own write; refresh cache from the fresh stat.
             try:
-                self._last_seen_mtime[owner_id] = await asyncio.to_thread(os.path.getmtime, path)
+                new_mtime = await asyncio.to_thread(os.path.getmtime, path)
+                self._last_seen[owner_id] = (new_mtime, tier)
             except FileNotFoundError:
-                self._last_seen_mtime.pop(owner_id, None)
+                self._last_seen.pop(owner_id, None)
             return
 
         # Unknown mode — behave as off.

--- a/apps/backend/core/services/config_reconciler.py
+++ b/apps/backend/core/services/config_reconciler.py
@@ -1,0 +1,53 @@
+"""Backend reconciliation loop for openclaw.json tier policy.
+
+Polls every active user's config on EFS at ~1s cadence, evaluates it
+against the tier policy (core.services.config_policy), and reverts drift
+on locked fields only. Non-locked fields are never touched.
+
+Ships in three modes via CONFIG_RECONCILER_MODE:
+  - off: reconciler never starts
+  - report: reads + evaluates + logs, never writes (rollout phase A)
+  - enforce: reads + evaluates + reverts (rollout phase B, steady state)
+"""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigReconciler:
+    def __init__(
+        self,
+        efs_mount: str,
+        tier_cache_ttl: float = 60.0,
+        tick_interval: float = 1.0,
+    ):
+        self._efs_mount = efs_mount
+        self._tier_cache_ttl = tier_cache_ttl
+        self._tick_interval = tick_interval
+        self._stop = asyncio.Event()
+        self._last_seen_mtime: dict[str, float] = {}
+        self._tier_cache: dict[str, tuple[str, float]] = {}
+
+    def stop(self) -> None:
+        """Signal the loop to exit after its current tick."""
+        self._stop.set()
+
+    async def run_forever(self) -> None:
+        logger.info("config_reconciler started")
+        while not self._stop.is_set():
+            try:
+                await self._tick()
+            except Exception:
+                logger.exception("config_reconciler tick failed")
+            # Sleep until tick_interval elapses OR stop is set (whichever first).
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self._tick_interval)
+            except asyncio.TimeoutError:
+                pass
+        logger.info("config_reconciler stopped")
+
+    async def _tick(self) -> None:
+        """One pass over the active-owner set. No-op in the skeleton."""
+        return

--- a/apps/backend/core/services/config_reconciler.py
+++ b/apps/backend/core/services/config_reconciler.py
@@ -13,6 +13,8 @@ Ships in three modes via CONFIG_RECONCILER_MODE:
 import asyncio
 import logging
 
+from core.repositories import container_repo
+
 logger = logging.getLogger(__name__)
 
 
@@ -49,5 +51,34 @@ class ConfigReconciler:
         logger.info("config_reconciler stopped")
 
     async def _tick(self) -> None:
-        """One pass over the active-owner set. No-op in the skeleton."""
-        return
+        owners = await container_repo.list_active_owners()
+        if not owners:
+            return
+
+        sem = asyncio.Semaphore(20)
+
+        async def _one(owner_id: str):
+            async with sem:
+                try:
+                    await self._check_one(owner_id)
+                except Exception:
+                    logger.exception("config_reconciler failed for owner %s", owner_id)
+
+        await asyncio.gather(*[_one(o) for o in owners])
+
+    async def _check_one(self, owner_id: str) -> None:
+        import os
+
+        path = os.path.join(self._efs_mount, owner_id, "openclaw.json")
+        try:
+            mtime = await asyncio.to_thread(os.path.getmtime, path)
+        except FileNotFoundError:
+            # Container row says running but file not yet there; skip.
+            return
+
+        if self._last_seen_mtime.get(owner_id) == mtime:
+            return
+
+        # File changed (or first time seeing it); in this task, only record
+        # the mtime. Actual read + policy + revert lands in Task 11.
+        self._last_seen_mtime[owner_id] = mtime

--- a/apps/backend/core/services/config_reconciler.py
+++ b/apps/backend/core/services/config_reconciler.py
@@ -11,9 +11,17 @@ Ships in three modes via CONFIG_RECONCILER_MODE:
 """
 
 import asyncio
+import json
 import logging
+import os
+import time
 
-from core.repositories import container_repo
+from core.config import settings
+from core.constants import SYSTEM_ACTOR_ID
+from core.observability.metrics import put_metric
+from core.repositories import billing_repo, container_repo
+from core.services import config_policy
+from core.services.config_patcher import _locked_rmw
 
 logger = logging.getLogger(__name__)
 
@@ -33,17 +41,15 @@ class ConfigReconciler:
         self._tier_cache: dict[str, tuple[str, float]] = {}
 
     def stop(self) -> None:
-        """Signal the loop to exit after its current tick."""
         self._stop.set()
 
     async def run_forever(self) -> None:
-        logger.info("config_reconciler started")
+        logger.info("config_reconciler started mode=%s", settings.CONFIG_RECONCILER_MODE)
         while not self._stop.is_set():
             try:
                 await self._tick()
             except Exception:
                 logger.exception("config_reconciler tick failed")
-            # Sleep until tick_interval elapses OR stop is set (whichever first).
             try:
                 await asyncio.wait_for(self._stop.wait(), timeout=self._tick_interval)
             except asyncio.TimeoutError:
@@ -51,6 +57,8 @@ class ConfigReconciler:
         logger.info("config_reconciler stopped")
 
     async def _tick(self) -> None:
+        if settings.CONFIG_RECONCILER_MODE == "off":
+            return
         owners = await container_repo.list_active_owners()
         if not owners:
             return
@@ -64,21 +72,132 @@ class ConfigReconciler:
                 except Exception:
                     logger.exception("config_reconciler failed for owner %s", owner_id)
 
+        started = time.monotonic()
         await asyncio.gather(*[_one(o) for o in owners])
+        put_metric(
+            "config.reconciler.tick.duration",
+            value=(time.monotonic() - started) * 1000.0,
+            dimensions={"mode": settings.CONFIG_RECONCILER_MODE},
+        )
 
     async def _check_one(self, owner_id: str) -> None:
-        import os
+        # Defense-in-depth against path traversal: owner_ids come from Clerk +
+        # DynamoDB and are always safe, but this function now writes to EFS,
+        # so guard against unexpected slashes, dotfiles, or `..` segments.
+        if not owner_id or "/" in owner_id or ".." in owner_id or owner_id.startswith("."):
+            return
 
         path = os.path.join(self._efs_mount, owner_id, "openclaw.json")
         try:
             mtime = await asyncio.to_thread(os.path.getmtime, path)
         except FileNotFoundError:
-            # Container row says running but file not yet there; skip.
             return
 
         if self._last_seen_mtime.get(owner_id) == mtime:
             return
 
-        # File changed (or first time seeing it); in this task, only record
-        # the mtime. Actual read + policy + revert lands in Task 11.
-        self._last_seen_mtime[owner_id] = mtime
+        tier = await self._resolve_tier(owner_id)
+        if tier is None:
+            # Fail-open: don't lock a user out of their own plan due to our DDB error.
+            return
+
+        grace_until = await container_repo.get_reconciler_grace(owner_id)
+        if grace_until > int(time.time()):
+            # Admin just wrote; don't fight them.
+            return
+
+        mode = settings.CONFIG_RECONCILER_MODE
+
+        if mode == "report":
+            # Read without a lock (we're not writing); evaluate; log.
+            try:
+                config = await asyncio.to_thread(_read_json, path)
+            except (OSError, json.JSONDecodeError) as e:
+                logger.warning("reconciler: failed to read %s: %s", path, e)
+                put_metric("config.reconciler.errors", dimensions={"kind": "read"})
+                return
+            violations = config_policy.evaluate(config, tier)
+            if violations:
+                put_metric("config.drift.reported", dimensions={"tier": tier})
+                logger.info(
+                    "reconciler(report) drift for owner=%s tier=%s fields=%s",
+                    owner_id,
+                    tier,
+                    [v["field"] for v in violations],
+                )
+            self._last_seen_mtime[owner_id] = mtime
+            return
+
+        if mode == "enforce":
+            reverted_fields: list[str] = []
+
+            def _mutate(current: dict) -> bool:
+                violations = config_policy.evaluate(current, tier)
+                if not violations:
+                    return False
+                reverted = config_policy.apply_reverts(current, violations)
+                current.clear()
+                current.update(reverted)
+                reverted_fields.extend(v["field"] for v in violations)
+                return True
+
+            try:
+                await _locked_rmw(owner_id, _mutate, "policy_revert")
+            except Exception as e:
+                logger.exception("reconciler: revert failed for owner=%s: %s", owner_id, e)
+                put_metric("config.reconciler.errors", dimensions={"kind": "revert"})
+                return
+
+            if reverted_fields:
+                put_metric("config.drift.reverted", dimensions={"tier": tier})
+                logger.info(
+                    "reconciler(enforce) reverted owner=%s tier=%s fields=%s",
+                    owner_id,
+                    tier,
+                    reverted_fields,
+                )
+                await _write_audit(owner_id, tier, reverted_fields)
+            # Mtime moved from our own write; refresh cache from the fresh stat.
+            try:
+                self._last_seen_mtime[owner_id] = await asyncio.to_thread(os.path.getmtime, path)
+            except FileNotFoundError:
+                self._last_seen_mtime.pop(owner_id, None)
+            return
+
+        # Unknown mode — behave as off.
+        logger.warning("unknown CONFIG_RECONCILER_MODE=%r, treating as off", mode)
+
+    async def _resolve_tier(self, owner_id: str) -> str | None:
+        cached = self._tier_cache.get(owner_id)
+        now = time.monotonic()
+        if cached and now - cached[1] < self._tier_cache_ttl:
+            return cached[0]
+        try:
+            account = await billing_repo.get_by_owner_id(owner_id)
+        except Exception:
+            logger.exception("reconciler: billing_repo lookup failed for owner=%s", owner_id)
+            put_metric("config.reconciler.errors", dimensions={"kind": "tier_lookup"})
+            return None
+        tier = (account or {}).get("plan_tier", "free")
+        self._tier_cache[owner_id] = (tier, now)
+        return tier
+
+
+def _read_json(path: str) -> dict:
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+async def _write_audit(owner_id: str, tier: str, fields: list[str]) -> None:
+    """Best-effort audit log; swallow failures (audit should never break the loop)."""
+    try:
+        from core.repositories import audit_log_repo  # type: ignore
+
+        await audit_log_repo.create(
+            actor_id=SYSTEM_ACTOR_ID,
+            action="config_policy_revert",
+            owner_id=owner_id,
+            metadata={"tier": tier, "fields": fields},
+        )
+    except Exception:
+        logger.debug("audit log write failed", exc_info=True)

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -74,6 +74,21 @@ async def lifespan(app: FastAPI):
 
     idle_checker_task = asyncio.create_task(_safe_idle_checker())
 
+    from core.services.config_reconciler import ConfigReconciler
+
+    reconciler = ConfigReconciler(efs_mount=settings.EFS_MOUNT_PATH)
+
+    async def _safe_reconciler():
+        if settings.CONFIG_RECONCILER_MODE == "off":
+            logger.info("config_reconciler disabled (CONFIG_RECONCILER_MODE=off)")
+            return
+        try:
+            await reconciler.run_forever()
+        except Exception:
+            logger.exception("config_reconciler crashed")
+
+    reconciler_task = asyncio.create_task(_safe_reconciler())
+
     yield
 
     # Shutdown
@@ -86,6 +101,11 @@ async def lifespan(app: FastAPI):
         pass
     try:
         await worker_task
+    except asyncio.CancelledError:
+        pass
+    reconciler.stop()
+    try:
+        await reconciler_task
     except asyncio.CancelledError:
         pass
     await shutdown_containers()

--- a/apps/backend/routers/config.py
+++ b/apps/backend/routers/config.py
@@ -18,8 +18,10 @@ from core.auth import (
 )
 from core.containers.config import read_openclaw_config_from_efs
 from core.repositories import billing_repo
+from core.services import config_policy
 from core.services.config_patcher import (
     ConfigPatchError,
+    deep_merge,
     patch_openclaw_config,
 )
 
@@ -137,9 +139,7 @@ async def patch_config(
     except Exception:
         logger.exception("EFS read failed for owner_id=%s; treating current config as {}", owner_id)
         current = {}
-    merged = _deep_merge_for_policy(current, body.patch)
-
-    from core.services import config_policy
+    merged = deep_merge(current, body.patch)
 
     violations = config_policy.evaluate(merged, tier)
     if violations:
@@ -162,22 +162,3 @@ async def patch_config(
         raise HTTPException(status_code=404, detail=str(e))
 
     return {"status": "patched", "owner_id": owner_id}
-
-
-def _deep_merge_for_policy(base: dict, patch: dict) -> dict:
-    """Local deep-merge matching config_patcher._deep_merge semantics —
-    dicts merge recursively, non-dict values replace. Kept local to avoid
-    importing a private helper."""
-    import copy
-
-    result = copy.deepcopy(base) if not isinstance(base, dict) else dict(base)
-    if not isinstance(patch, dict):
-        return patch
-    for k, v in patch.items():
-        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
-            result[k] = _deep_merge_for_policy(result[k], v)
-        else:
-            import copy as _c
-
-            result[k] = _c.deepcopy(v)
-    return result

--- a/apps/backend/routers/config.py
+++ b/apps/backend/routers/config.py
@@ -105,29 +105,40 @@ async def _check_token_collision(owner_id: str, patch: dict) -> None:
     description=(
         "Deep-merges the patch into the caller's owner_id openclaw.json on EFS. "
         "Derives owner_id from auth context (org_id if org, else user_id). "
-        "Requires org_admin for org callers. Tier-gates channel fields."
+        "Requires org_admin for org callers. Tier-gates locked fields via config_policy."
     ),
 )
 async def patch_config(
     body: ConfigPatchBody,
     auth: AuthContext = Depends(get_current_user),
 ):
-    # Org admin check (personal context passes through)
     require_org_admin(auth)
-
     owner_id = resolve_owner_id(auth)
 
-    # Tier gate on channel fields
-    if _patch_touches_channels(body.patch):
-        account = await billing_repo.get_by_owner_id(owner_id)
-        tier = account.get("plan_tier", "free") if isinstance(account, dict) else "free"
-        if tier == "free":
-            raise HTTPException(
-                status_code=403,
-                detail="channels_require_paid_tier",
-            )
+    # Resolve tier and simulate the merged config to apply policy to the
+    # final state, not to the isolated patch (which might only toggle a
+    # scaffold flag while keeping the locked field legal).
+    account = await billing_repo.get_by_owner_id(owner_id)
+    tier = account.get("plan_tier", "free") if isinstance(account, dict) else "free"
 
-        # Bot token collision pre-check
+    current = await read_openclaw_config_from_efs(owner_id) or {}
+    merged = _deep_merge_for_policy(current, body.patch)
+
+    from core.services import config_policy
+
+    violations = config_policy.evaluate(merged, tier)
+    if violations:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "policy_violation",
+                "fields": [v["field"] for v in violations],
+                "reason": violations[0]["reason"],
+            },
+        )
+
+    # Bot-token collision pre-check (channels-specific; runs only if patch touches channels).
+    if _patch_touches_channels(body.patch):
         await _check_token_collision(owner_id, body.patch)
 
     try:
@@ -136,3 +147,22 @@ async def patch_config(
         raise HTTPException(status_code=404, detail=str(e))
 
     return {"status": "patched", "owner_id": owner_id}
+
+
+def _deep_merge_for_policy(base: dict, patch: dict) -> dict:
+    """Local deep-merge matching config_patcher._deep_merge semantics —
+    dicts merge recursively, non-dict values replace. Kept local to avoid
+    importing a private helper."""
+    import copy
+
+    result = copy.deepcopy(base) if not isinstance(base, dict) else dict(base)
+    if not isinstance(patch, dict):
+        return patch
+    for k, v in patch.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _deep_merge_for_policy(result[k], v)
+        else:
+            import copy as _c
+
+            result[k] = _c.deepcopy(v)
+    return result

--- a/apps/backend/routers/config.py
+++ b/apps/backend/routers/config.py
@@ -118,10 +118,25 @@ async def patch_config(
     # Resolve tier and simulate the merged config to apply policy to the
     # final state, not to the isolated patch (which might only toggle a
     # scaffold flag while keeping the locked field legal).
-    account = await billing_repo.get_by_owner_id(owner_id)
-    tier = account.get("plan_tier", "free") if isinstance(account, dict) else "free"
+    # Fail-closed: if the billing lookup blows up (e.g. DDB unavailable in
+    # contract/test envs, transient AWS error), assume the most restrictive
+    # tier so we never accidentally loosen policy when infra is degraded.
+    try:
+        account = await billing_repo.get_by_owner_id(owner_id)
+        tier = account.get("plan_tier", "free") if isinstance(account, dict) else "free"
+    except Exception:
+        logger.exception("billing lookup failed for owner_id=%s; defaulting to free tier", owner_id)
+        tier = "free"
 
-    current = await read_openclaw_config_from_efs(owner_id) or {}
+    # Fail-open on current-config read: if EFS is unreachable or read raises,
+    # treat current config as empty so the merged config is just the patch
+    # itself. The downstream patch_openclaw_config call will still 404 if the
+    # underlying file truly doesn't exist.
+    try:
+        current = await read_openclaw_config_from_efs(owner_id) or {}
+    except Exception:
+        logger.exception("EFS read failed for owner_id=%s; treating current config as {}", owner_id)
+        current = {}
     merged = _deep_merge_for_policy(current, body.patch)
 
     from core.services import config_policy

--- a/apps/backend/routers/config.py
+++ b/apps/backend/routers/config.py
@@ -130,27 +130,33 @@ async def patch_config(
         logger.exception("billing lookup failed for owner_id=%s; defaulting to free tier", owner_id)
         tier = "free"
 
-    # Fail-open on current-config read: if EFS is unreachable or read raises,
-    # treat current config as empty so the merged config is just the patch
-    # itself. The downstream patch_openclaw_config call will still 404 if the
-    # underlying file truly doesn't exist.
+    # Fail-open on current-config read errors: if EFS is unreachable or read
+    # raises, proceed without policy evaluation so the downstream
+    # patch_openclaw_config call can surface the real error (ConfigPatchError
+    # -> 404 when the file truly doesn't exist).
     try:
-        current = await read_openclaw_config_from_efs(owner_id) or {}
+        current = await read_openclaw_config_from_efs(owner_id)
     except Exception:
-        logger.exception("EFS read failed for owner_id=%s; treating current config as {}", owner_id)
-        current = {}
-    merged = deep_merge(current, body.patch)
+        logger.exception("EFS read failed for owner_id=%s; skipping policy check", owner_id)
+        current = None
 
-    violations = config_policy.evaluate(merged, tier)
-    if violations:
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "code": "policy_violation",
-                "fields": [v["field"] for v in violations],
-                "reason": violations[0]["reason"],
-            },
-        )
+    # Only run policy when we have a real current config. If the file is
+    # missing/unreadable, skip the policy check and let patch_openclaw_config
+    # surface the real error (ConfigPatchError -> 404). This preserves
+    # distinct error semantics: "your patch violates policy" vs "your config
+    # doesn't exist yet".
+    if current is not None:
+        merged = deep_merge(current, body.patch)
+        violations = config_policy.evaluate(merged, tier)
+        if violations:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "code": "policy_violation",
+                    "fields": [v["field"] for v in violations],
+                    "reason": violations[0]["reason"],
+                },
+            )
 
     # Bot-token collision pre-check (channels-specific; runs only if patch touches channels).
     if _patch_touches_channels(body.patch):

--- a/apps/backend/routers/updates.py
+++ b/apps/backend/routers/updates.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 
 from core.auth import AuthContext, get_current_user, require_org_admin, resolve_owner_id
 from core.observability.metrics import put_metric
-from core.repositories import update_repo
+from core.repositories import container_repo, update_repo
 from core.services.config_patcher import patch_openclaw_config, ConfigPatchError
 from core.services.update_service import apply_update, queue_fleet_image_update
 
@@ -153,6 +153,9 @@ async def patch_single_config(
     if auth.is_org_context:
         require_org_admin(auth)
 
+    # Tell the reconciler to stand down for 5s while we apply an admin override.
+    await container_repo.set_reconciler_grace(owner_id, seconds=5)
+
     try:
         await patch_openclaw_config(owner_id, body.patch)
     except ConfigPatchError as e:
@@ -197,6 +200,7 @@ async def patch_fleet_config(
     failed = 0
     for oid in owners:
         try:
+            await container_repo.set_reconciler_grace(oid, seconds=5)
             await patch_openclaw_config(oid, body.patch)
             patched += 1
         except ConfigPatchError:

--- a/apps/backend/scripts/reconcile_all_configs.py
+++ b/apps/backend/scripts/reconcile_all_configs.py
@@ -1,0 +1,82 @@
+"""One-shot fleet cleanup for config policy drift.
+
+Runs synchronously. Walks every active container, evaluates its openclaw.json
+against the tier policy, and reverts drift on locked fields. Prints a
+summary report at the end.
+
+Usage (from apps/backend/):
+    uv run python scripts/reconcile_all_configs.py [--dry-run]
+
+Dry-run prints what WOULD be reverted without writing. Use before flipping
+CONFIG_RECONCILER_MODE to enforce to confirm the blast radius.
+"""
+
+import argparse
+import asyncio
+import logging
+
+from core.containers.config import read_openclaw_config_from_efs
+from core.repositories import billing_repo, container_repo
+from core.services import config_policy
+from core.services.config_patcher import _locked_rmw
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("reconcile_all")
+
+
+async def reconcile_owner(owner_id: str, dry_run: bool) -> tuple[str, list[str]]:
+    account = await billing_repo.get_by_owner_id(owner_id)
+    tier = account.get("plan_tier", "free") if isinstance(account, dict) else "free"
+
+    config = await read_openclaw_config_from_efs(owner_id)
+    if config is None:
+        return ("no_config", [])
+
+    violations = config_policy.evaluate(config, tier)
+    if not violations:
+        return ("clean", [])
+
+    fields = [v["field"] for v in violations]
+    if dry_run:
+        return ("would_revert", fields)
+
+    def _mutate(current: dict) -> bool:
+        vs = config_policy.evaluate(current, tier)
+        if not vs:
+            return False
+        reverted = config_policy.apply_reverts(current, vs)
+        current.clear()
+        current.update(reverted)
+        return True
+
+    await _locked_rmw(owner_id, _mutate, "fleet_cleanup")
+    return ("reverted", fields)
+
+
+async def main(dry_run: bool) -> None:
+    owners = await container_repo.list_active_owners()
+    logger.info("found %d active containers", len(owners))
+
+    counts = {"clean": 0, "no_config": 0, "would_revert": 0, "reverted": 0, "error": 0}
+    for owner_id in owners:
+        try:
+            status, fields = await reconcile_owner(owner_id, dry_run)
+            counts[status] = counts.get(status, 0) + 1
+            if fields:
+                logger.info("%s owner=%s fields=%s", status, owner_id, fields)
+        except Exception as e:
+            counts["error"] += 1
+            logger.exception("error on owner=%s: %s", owner_id, e)
+
+    logger.info("summary: %s", counts)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be reverted, do not write.",
+    )
+    args = parser.parse_args()
+    asyncio.run(main(dry_run=args.dry_run))

--- a/apps/backend/scripts/reconcile_all_configs.py
+++ b/apps/backend/scripts/reconcile_all_configs.py
@@ -18,7 +18,7 @@ import logging
 from core.containers.config import read_openclaw_config_from_efs
 from core.repositories import billing_repo, container_repo
 from core.services import config_policy
-from core.services.config_patcher import _locked_rmw
+from core.services.config_patcher import locked_rmw
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger("reconcile_all")
@@ -49,7 +49,7 @@ async def reconcile_owner(owner_id: str, dry_run: bool) -> tuple[str, list[str]]
         current.update(reverted)
         return True
 
-    await _locked_rmw(owner_id, _mutate, "fleet_cleanup")
+    await locked_rmw(owner_id, _mutate, "fleet_cleanup")
     return ("reverted", fields)
 
 

--- a/apps/backend/tests/integration/test_config_reconciliation.py
+++ b/apps/backend/tests/integration/test_config_reconciliation.py
@@ -1,0 +1,98 @@
+"""Integration tests for the config reconciler against a real tmp filesystem
+and real fcntl.lockf locking (no mocks around the lock/IO layer).
+
+These catch bugs that unit mocks miss: lock semantics, atomic rename,
+concurrent writer races.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.containers.config import write_openclaw_config
+from core.services.config_reconciler import ConfigReconciler
+
+
+@pytest.mark.asyncio
+async def test_reconciler_reverts_drift_end_to_end(tmp_path, monkeypatch):
+    user = "user_e2e"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg = udir / "openclaw.json"
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    base["channels"]["telegram"]["accounts"] = {"bot1": {"botToken": "x"}}
+    cfg.write_text(json.dumps(base, indent=2))
+
+    # Patch the module-level _efs_mount_path used inside _locked_rmw.
+    monkeypatch.setattr("core.services.config_patcher._efs_mount_path", str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "enforce",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    r = ConfigReconciler(efs_mount=str(tmp_path), tick_interval=0.1)
+    await r._tick()
+
+    restored = json.loads(cfg.read_text())
+    assert restored["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/minimax.minimax-m2.5"
+    assert restored["channels"]["telegram"]["accounts"] == {}
+
+
+@pytest.mark.asyncio
+async def test_reconciler_serializes_with_config_patcher(tmp_path, monkeypatch):
+    """Fire a reconciler tick and a config_patcher patch in parallel.
+    The result must be a single valid JSON file (no interleaved writes)."""
+    import json as _json
+    from core.services import config_patcher
+
+    user = "user_par"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg = udir / "openclaw.json"
+    base = _json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    cfg.write_text(_json.dumps(base, indent=2))
+
+    monkeypatch.setattr("core.services.config_patcher._efs_mount_path", str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "enforce",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    await asyncio.gather(
+        r._tick(),
+        config_patcher.patch_openclaw_config(user, {"tools": {"web": {"fetch": {"enabled": False}}}}),
+    )
+
+    # File must still parse and contain both changes' non-conflicting pieces.
+    result = _json.loads(cfg.read_text())
+    assert result["tools"]["web"]["fetch"]["enabled"] is False

--- a/apps/backend/tests/integration/test_config_reconciliation.py
+++ b/apps/backend/tests/integration/test_config_reconciliation.py
@@ -26,7 +26,7 @@ async def test_reconciler_reverts_drift_end_to_end(tmp_path, monkeypatch):
     base["channels"]["telegram"]["accounts"] = {"bot1": {"botToken": "x"}}
     cfg.write_text(json.dumps(base, indent=2))
 
-    # Patch the module-level _efs_mount_path used inside _locked_rmw.
+    # Patch the module-level _efs_mount_path used inside locked_rmw.
     monkeypatch.setattr("core.services.config_patcher._efs_mount_path", str(tmp_path))
     monkeypatch.setattr(
         "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
@@ -57,7 +57,14 @@ async def test_reconciler_reverts_drift_end_to_end(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_reconciler_serializes_with_config_patcher(tmp_path, monkeypatch):
     """Fire a reconciler tick and a config_patcher patch in parallel.
-    The result must be a single valid JSON file (no interleaved writes)."""
+
+    Seeds a config with a drift the reconciler will revert AND a patch the
+    patcher will apply, targeting non-overlapping subtrees. Regardless of
+    which writer wins the lock first, the final state must contain both
+    outcomes: the patcher's ``tools.web.fetch.enabled=False`` and the
+    reconciler's reverted primary model. The file must still parse as valid
+    JSON (no interleaved writes).
+    """
     import json as _json
     from core.services import config_patcher
 
@@ -66,6 +73,8 @@ async def test_reconciler_serializes_with_config_patcher(tmp_path, monkeypatch):
     udir.mkdir()
     cfg = udir / "openclaw.json"
     base = _json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    # Seed drift the reconciler will revert.
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
     cfg.write_text(_json.dumps(base, indent=2))
 
     monkeypatch.setattr("core.services.config_patcher._efs_mount_path", str(tmp_path))
@@ -88,11 +97,17 @@ async def test_reconciler_serializes_with_config_patcher(tmp_path, monkeypatch):
     )
 
     r = ConfigReconciler(efs_mount=str(tmp_path))
+    # Both writers want to write; they touch disjoint subtrees so order is
+    # non-deterministic but both end states converge to the same expected
+    # outcome (patcher: tools.*, reconciler: agents.defaults.*).
     await asyncio.gather(
         r._tick(),
         config_patcher.patch_openclaw_config(user, {"tools": {"web": {"fetch": {"enabled": False}}}}),
     )
 
-    # File must still parse and contain both changes' non-conflicting pieces.
+    # File must still parse as valid JSON.
     result = _json.loads(cfg.read_text())
+    # Patcher's change landed.
     assert result["tools"]["web"]["fetch"]["enabled"] is False
+    # Reconciler's revert landed.
+    assert result["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/minimax.minimax-m2.5"

--- a/apps/backend/tests/unit/repositories/test_container_repo.py
+++ b/apps/backend/tests/unit/repositories/test_container_repo.py
@@ -334,3 +334,37 @@ async def test_mark_stopped_if_running_noop_when_row_missing(dynamodb_table):
     flipped = await container_repo.mark_stopped_if_running("user_never_existed")
 
     assert flipped is False
+
+
+@pytest.mark.asyncio
+async def test_list_active_owners_paginates_query(monkeypatch):
+    """list_active_owners must follow LastEvaluatedKey so fleets whose
+    status-index page exceeds DynamoDB's 1MB response cap are fully
+    enumerated."""
+    from core.repositories import container_repo
+
+    class _FakeTable:
+        def __init__(self):
+            self.calls = []
+
+        def query(self, **kwargs):
+            self.calls.append(kwargs)
+            # First call: page of 2 items + LastEvaluatedKey.
+            # Second call: final page of 1 item, no LastEvaluatedKey.
+            if "ExclusiveStartKey" not in kwargs:
+                return {
+                    "Items": [{"owner_id": "user_1"}, {"owner_id": "user_2"}],
+                    "LastEvaluatedKey": {"owner_id": "user_2"},
+                }
+            return {"Items": [{"owner_id": "user_3"}]}
+
+    fake = _FakeTable()
+    monkeypatch.setattr(container_repo, "_get_table", lambda: fake)
+
+    owners = await container_repo.list_active_owners()
+
+    assert owners == ["user_1", "user_2", "user_3"]
+    # Two calls: initial + one continuation.
+    assert len(fake.calls) == 2
+    assert "ExclusiveStartKey" not in fake.calls[0]
+    assert fake.calls[1]["ExclusiveStartKey"] == {"owner_id": "user_2"}

--- a/apps/backend/tests/unit/repositories/test_container_repo_grace.py
+++ b/apps/backend/tests/unit/repositories/test_container_repo_grace.py
@@ -1,0 +1,50 @@
+"""Tests for container_repo grace-window helpers."""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_set_reconciler_grace_writes_epoch_seconds():
+    from core.repositories import container_repo
+
+    with (
+        patch.object(
+            container_repo, "get_by_owner_id", AsyncMock(return_value={"owner_id": "u1", "id": "i", "created_at": "x"})
+        ),
+        patch.object(container_repo, "update_fields", AsyncMock(return_value={})) as mock_update,
+    ):
+        before = int(time.time())
+        await container_repo.set_reconciler_grace("u1", seconds=5)
+        after = int(time.time())
+
+    mock_update.assert_awaited_once()
+    args, _ = mock_update.call_args
+    owner_id, fields = args
+    assert owner_id == "u1"
+    assert "reconciler_grace_until" in fields
+    assert before + 5 <= fields["reconciler_grace_until"] <= after + 6
+
+
+@pytest.mark.asyncio
+async def test_get_reconciler_grace_returns_zero_when_unset():
+    from core.repositories import container_repo
+
+    with patch.object(container_repo, "get_by_owner_id", AsyncMock(return_value={"owner_id": "u1"})):
+        grace = await container_repo.get_reconciler_grace("u1")
+    assert grace == 0
+
+
+@pytest.mark.asyncio
+async def test_get_reconciler_grace_returns_stored_value():
+    from core.repositories import container_repo
+
+    with patch.object(
+        container_repo,
+        "get_by_owner_id",
+        AsyncMock(return_value={"owner_id": "u1", "reconciler_grace_until": 1234567890}),
+    ):
+        grace = await container_repo.get_reconciler_grace("u1")
+    assert grace == 1234567890

--- a/apps/backend/tests/unit/routers/test_config_router.py
+++ b/apps/backend/tests/unit/routers/test_config_router.py
@@ -364,3 +364,51 @@ def test_patch_config_accepts_non_locked_field_change(client):
         mock_patch.assert_awaited_once()
     finally:
         cleanup()
+
+
+def test_patch_config_missing_config_returns_404_not_403(client):
+    """When openclaw.json doesn't exist yet (read returns None), we must NOT
+    run policy evaluation against an empty {} (which would flag
+    models.providers as violating the tier allowlist and return a misleading
+    403 policy_violation). Instead the downstream patch must surface the real
+    404 not-found error, so callers can distinguish "your patch violates
+    policy" from "your config doesn't exist yet"."""
+    from core.services.config_patcher import ConfigPatchError
+
+    cleanup = _patch_auth(_personal_auth())
+    try:
+        with (
+            patch(
+                "routers.config.patch_openclaw_config",
+                AsyncMock(side_effect=ConfigPatchError("Config not found for owner user_personal")),
+            ) as mock_patch,
+            patch(
+                "routers.config.read_openclaw_config_from_efs",
+                AsyncMock(return_value=None),
+            ),
+            _mock_billing("free"),
+        ):
+            resp = client.patch(
+                "/api/v1/config",
+                # This patch WOULD violate policy (unauthorized provider) if
+                # policy evaluation ran against an empty current config.
+                json={
+                    "patch": {
+                        "models": {
+                            "providers": {
+                                "openai": {
+                                    "api": "openai",
+                                    "baseUrl": "x",
+                                    "models": [],
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+        assert resp.status_code == 404
+        assert "Config not found" in resp.json().get("detail", "")
+        # Downstream patch WAS called (i.e., we did not short-circuit with 403)
+        mock_patch.assert_awaited_once()
+    finally:
+        cleanup()

--- a/apps/backend/tests/unit/routers/test_config_router.py
+++ b/apps/backend/tests/unit/routers/test_config_router.py
@@ -11,6 +11,47 @@ os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
 from core.auth import AuthContext  # noqa: E402
 
 
+def _free_providers():
+    from core.containers.config import _models_for_tier
+
+    return {
+        "amazon-bedrock": {
+            "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "api": "bedrock-converse-stream",
+            "auth": "aws-sdk",
+            "models": _models_for_tier("free"),
+        },
+    }
+
+
+def _clean_base(tier: str) -> dict:
+    """Return a policy-clean openclaw.json base for *tier* (for
+    ``read_openclaw_config_from_efs`` mocks in tests that don't care about
+    the base config — just that it passes the policy gate)."""
+    from core.config import TIER_CONFIG
+    from core.containers.config import _agent_models_for_tier, _models_for_tier
+
+    primary = f"amazon-bedrock/{TIER_CONFIG[tier]['primary_model'].removeprefix('amazon-bedrock/')}"
+    return {
+        "models": {
+            "providers": {
+                "amazon-bedrock": {
+                    "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+                    "api": "bedrock-converse-stream",
+                    "auth": "aws-sdk",
+                    "models": _models_for_tier(tier),
+                },
+            },
+        },
+        "agents": {
+            "defaults": {
+                "model": {"primary": primary},
+                "models": _agent_models_for_tier(tier, primary),
+            },
+        },
+    }
+
+
 @pytest.fixture
 def client():
     from main import app
@@ -49,7 +90,14 @@ def _mock_billing(tier: str):
 def test_patch_config_personal_user_succeeds(client):
     cleanup = _patch_auth(_personal_auth())
     try:
-        with patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch, _mock_billing("starter"):
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch(
+                "routers.config.read_openclaw_config_from_efs",
+                AsyncMock(return_value=_clean_base("starter")),
+            ),
+            _mock_billing("starter"),
+        ):
             resp = client.patch(
                 "/api/v1/config",
                 json={"patch": {"channels": {"telegram": {"enabled": True}}}},
@@ -65,7 +113,14 @@ def test_patch_config_personal_user_succeeds(client):
 def test_patch_config_org_admin_succeeds(client):
     cleanup = _patch_auth(_org_admin_auth())
     try:
-        with patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch, _mock_billing("pro"):
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch(
+                "routers.config.read_openclaw_config_from_efs",
+                AsyncMock(return_value=_clean_base("pro")),
+            ),
+            _mock_billing("pro"),
+        ):
             resp = client.patch(
                 "/api/v1/config",
                 json={"patch": {"channels": {"telegram": {"enabled": True}}}},
@@ -80,7 +135,14 @@ def test_patch_config_org_admin_succeeds(client):
 def test_patch_config_org_member_rejected(client):
     cleanup = _patch_auth(_org_member_auth())
     try:
-        with patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch, _mock_billing("pro"):
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch(
+                "routers.config.read_openclaw_config_from_efs",
+                AsyncMock(return_value=_clean_base("pro")),
+            ),
+            _mock_billing("pro"),
+        ):
             resp = client.patch(
                 "/api/v1/config",
                 json={"patch": {"channels": {"telegram": {"enabled": True}}}},
@@ -94,13 +156,33 @@ def test_patch_config_org_member_rejected(client):
 def test_patch_config_free_tier_channels_rejected(client):
     cleanup = _patch_auth(_personal_auth())
     try:
-        with patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch, _mock_billing("free"):
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch(
+                "routers.config.read_openclaw_config_from_efs",
+                AsyncMock(
+                    return_value={
+                        "channels": {"telegram": {"enabled": True, "dmPolicy": "pairing"}},
+                        "models": {"providers": _free_providers()},
+                        "agents": {
+                            "defaults": {
+                                "model": {"primary": "amazon-bedrock/minimax.minimax-m2.5"},
+                                "models": {"amazon-bedrock/minimax.minimax-m2.5": {"alias": "MiniMax M2.5"}},
+                            }
+                        },
+                    }
+                ),
+            ),
+            _mock_billing("free"),
+        ):
             resp = client.patch(
                 "/api/v1/config",
-                json={"patch": {"channels": {"telegram": {"enabled": True}}}},
+                json={"patch": {"channels": {"telegram": {"accounts": {"a": {"botToken": "x"}}}}}},
             )
         assert resp.status_code == 403
-        assert "channels_require_paid_tier" in resp.json().get("detail", "")
+        detail = resp.json().get("detail", {})
+        assert detail.get("code") == "policy_violation"
+        assert "channels.accounts" in detail.get("fields", [])
         mock_patch.assert_not_called()
     finally:
         cleanup()
@@ -109,7 +191,14 @@ def test_patch_config_free_tier_channels_rejected(client):
 def test_patch_config_free_tier_non_channels_succeeds(client):
     cleanup = _patch_auth(_personal_auth())
     try:
-        with patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch, _mock_billing("free"):
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch(
+                "routers.config.read_openclaw_config_from_efs",
+                AsyncMock(return_value=_clean_base("free")),
+            ),
+            _mock_billing("free"),
+        ):
             resp = client.patch(
                 "/api/v1/config",
                 json={"patch": {"tools": {"profile": "full"}}},
@@ -136,12 +225,11 @@ def test_patch_config_rejects_token_collision(client):
     """Pasting a token already assigned to a different agent returns 409."""
     cleanup = _patch_auth(_personal_auth())
     try:
-        existing_cfg = {
-            "channels": {
-                "telegram": {
-                    "accounts": {
-                        "main": {"botToken": "SHARED_TOKEN"},
-                    },
+        existing_cfg = _clean_base("pro")
+        existing_cfg["channels"] = {
+            "telegram": {
+                "accounts": {
+                    "main": {"botToken": "SHARED_TOKEN"},
                 },
             },
         }
@@ -177,12 +265,11 @@ def test_patch_config_allows_overwriting_own_agent_token(client):
     """Updating the SAME agent's token is fine (overwrite)."""
     cleanup = _patch_auth(_personal_auth())
     try:
-        existing_cfg = {
-            "channels": {
-                "telegram": {
-                    "accounts": {
-                        "main": {"botToken": "OLD_TOKEN"},
-                    },
+        existing_cfg = _clean_base("pro")
+        existing_cfg["channels"] = {
+            "telegram": {
+                "accounts": {
+                    "main": {"botToken": "OLD_TOKEN"},
                 },
             },
         }
@@ -207,6 +294,71 @@ def test_patch_config_allows_overwriting_own_agent_token(client):
                         },
                     },
                 },
+            )
+        assert resp.status_code == 200
+        mock_patch.assert_awaited_once()
+    finally:
+        cleanup()
+
+
+def test_patch_config_rejects_unauthorized_provider_any_tier(client):
+    cleanup = _patch_auth(_personal_auth())
+    try:
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch(
+                "routers.config.read_openclaw_config_from_efs",
+                AsyncMock(
+                    return_value={
+                        "models": {"providers": _free_providers()},
+                        "agents": {
+                            "defaults": {
+                                "model": {"primary": "amazon-bedrock/minimax.minimax-m2.5"},
+                                "models": {"amazon-bedrock/minimax.minimax-m2.5": {"alias": "MiniMax M2.5"}},
+                            }
+                        },
+                    }
+                ),
+            ),
+            _mock_billing("pro"),
+        ):
+            resp = client.patch(
+                "/api/v1/config",
+                json={"patch": {"models": {"providers": {"openai": {"api": "openai", "baseUrl": "x", "models": []}}}}},
+            )
+        assert resp.status_code == 403
+        detail = resp.json().get("detail", {})
+        assert detail.get("code") == "policy_violation"
+        assert "models.providers" in detail.get("fields", [])
+        mock_patch.assert_not_called()
+    finally:
+        cleanup()
+
+
+def test_patch_config_accepts_non_locked_field_change(client):
+    cleanup = _patch_auth(_personal_auth())
+    try:
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch(
+                "routers.config.read_openclaw_config_from_efs",
+                AsyncMock(
+                    return_value={
+                        "models": {"providers": _free_providers()},
+                        "agents": {
+                            "defaults": {
+                                "model": {"primary": "amazon-bedrock/minimax.minimax-m2.5"},
+                                "models": {"amazon-bedrock/minimax.minimax-m2.5": {"alias": "MiniMax M2.5"}},
+                            }
+                        },
+                    }
+                ),
+            ),
+            _mock_billing("free"),
+        ):
+            resp = client.patch(
+                "/api/v1/config",
+                json={"patch": {"tools": {"web": {"search": {"enabled": False}}}}},
             )
         assert resp.status_code == 200
         mock_patch.assert_awaited_once()

--- a/apps/backend/tests/unit/routers/test_updates_grace.py
+++ b/apps/backend/tests/unit/routers/test_updates_grace.py
@@ -1,0 +1,38 @@
+"""Tests for admin-patch grace window on routers/updates.py."""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from main import app
+
+    return TestClient(app)
+
+
+def _patch_auth():
+    from core.auth import AuthContext, get_current_user
+    from main import app
+
+    app.dependency_overrides[get_current_user] = lambda: AuthContext(user_id="u_admin")
+    return lambda: app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_admin_single_config_patch_sets_grace(client):
+    cleanup = _patch_auth()
+    try:
+        with (
+            patch("routers.updates.patch_openclaw_config", AsyncMock()),
+            patch("routers.updates.container_repo.set_reconciler_grace", AsyncMock()) as set_grace,
+        ):
+            resp = client.patch("/api/v1/container/config/owner_1", json={"patch": {"tools": {}}})
+        assert resp.status_code == 200
+        set_grace.assert_awaited_once_with("owner_1", seconds=5)
+    finally:
+        cleanup()

--- a/apps/backend/tests/unit/services/test_config_policy.py
+++ b/apps/backend/tests/unit/services/test_config_policy.py
@@ -158,6 +158,40 @@ class TestEvaluate:
         violations = config_policy.evaluate(config, "free")
         assert not any(v["field"] == "channels.accounts" for v in violations)
 
+    def test_models_null_is_violation_not_crash(self):
+        config = {
+            "models": None,
+            "agents": {
+                "defaults": {
+                    "model": {"primary": "amazon-bedrock/minimax.minimax-m2.5"},
+                    "models": {},
+                }
+            },
+        }
+        violations = config_policy.evaluate(config, "free")
+        # Should emit a models.providers violation (treats null as empty),
+        # not raise an AttributeError.
+        assert any(v["field"] == "models.providers" for v in violations)
+
+    def test_agents_defaults_null_is_handled_safely(self):
+        config = {
+            "models": {"providers": {"amazon-bedrock": {"baseUrl": "x", "api": "y", "auth": "z", "models": []}}},
+            "agents": None,
+        }
+        # Should not raise; should flag primary as out-of-allowlist
+        # (empty string not in allowlist).
+        violations = config_policy.evaluate(config, "free")
+        assert any(v["field"] == "agents.defaults.model.primary" for v in violations)
+
+    def test_primary_non_string_is_handled_safely(self):
+        config = {
+            "models": {"providers": {"amazon-bedrock": {"baseUrl": "x", "api": "y", "auth": "z", "models": []}}},
+            "agents": {"defaults": {"model": {"primary": 42}, "models": {}}},
+        }
+        violations = config_policy.evaluate(config, "free")
+        # Should not raise; integer primary treated as "" (not in allowlist).
+        assert any(v["field"] == "agents.defaults.model.primary" for v in violations)
+
 
 class TestApplyReverts:
     """Tests for config_policy.apply_reverts()."""

--- a/apps/backend/tests/unit/services/test_config_policy.py
+++ b/apps/backend/tests/unit/services/test_config_policy.py
@@ -107,3 +107,19 @@ class TestEvaluate:
         config["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/claude-opus-4"
         violations = config_policy.evaluate(config, "pro")
         assert any(v["field"] == "agents.defaults.model.primary" for v in violations)
+
+    def test_free_tier_agents_models_with_qwen_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["agents"]["defaults"]["models"]["amazon-bedrock/qwen.qwen3-vl-235b-a22b"] = {
+            "alias": "Qwen3 VL 235B",
+        }
+        violations = config_policy.evaluate(config, "free")
+        assert any(v["field"] == "agents.defaults.models" for v in violations)
+
+    def test_paid_tier_agents_models_within_allowlist_no_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="pro")
+        config = json.loads(raw)
+        # Pro tier generator already includes both MiniMax and Qwen — clean.
+        violations = config_policy.evaluate(config, "pro")
+        assert not any(v["field"] == "agents.defaults.models" for v in violations)

--- a/apps/backend/tests/unit/services/test_config_policy.py
+++ b/apps/backend/tests/unit/services/test_config_policy.py
@@ -84,3 +84,26 @@ class TestEvaluate:
         )
         violations = config_policy.evaluate(config, "bogus-tier")
         assert any(v["field"] == "models.providers" for v in violations)
+
+    def test_free_tier_primary_changed_to_qwen_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+        violations = config_policy.evaluate(config, "free")
+        assert any(v["field"] == "agents.defaults.model.primary" for v in violations)
+
+    def test_paid_tier_primary_allowed_model_no_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="pro")
+        config = json.loads(raw)
+        # Pro tier's primary is already Qwen from write_openclaw_config, but
+        # swapping to MiniMax (also allowed on pro) should not be a violation.
+        config["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/minimax.minimax-m2.5"
+        violations = config_policy.evaluate(config, "pro")
+        assert not any(v["field"] == "agents.defaults.model.primary" for v in violations)
+
+    def test_paid_tier_primary_unknown_model_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="pro")
+        config = json.loads(raw)
+        config["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/claude-opus-4"
+        violations = config_policy.evaluate(config, "pro")
+        assert any(v["field"] == "agents.defaults.model.primary" for v in violations)

--- a/apps/backend/tests/unit/services/test_config_policy.py
+++ b/apps/backend/tests/unit/services/test_config_policy.py
@@ -35,3 +35,52 @@ class TestEvaluate:
         )
         config = json.loads(raw)
         assert config_policy.evaluate(config, "pro") == []
+
+    def test_extra_provider_added_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="starter")
+        config = json.loads(raw)
+        # Agent tries to add openai as a provider
+        config["models"]["providers"]["openai"] = {
+            "baseUrl": "https://api.openai.com",
+            "api": "openai",
+            "models": [{"id": "gpt-4o", "name": "GPT-4o"}],
+        }
+        violations = config_policy.evaluate(config, "starter")
+        fields = [v["field"] for v in violations]
+        assert "models.providers" in fields
+
+    def test_unauthorized_model_in_bedrock_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        # Agent adds qwen to a free-tier provider list
+        config["models"]["providers"]["amazon-bedrock"]["models"].append(
+            {
+                "id": "qwen.qwen3-vl-235b-a22b",
+                "name": "Qwen3 VL 235B",
+                "contextWindow": 128000,
+                "maxTokens": 8192,
+                "reasoning": False,
+                "input": ["text", "image"],
+                "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            }
+        )
+        violations = config_policy.evaluate(config, "free")
+        assert any(v["field"] == "models.providers" for v in violations)
+
+    def test_unknown_tier_falls_back_to_free(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        # Add qwen — illegal for free
+        config["models"]["providers"]["amazon-bedrock"]["models"].append(
+            {
+                "id": "qwen.qwen3-vl-235b-a22b",
+                "name": "X",
+                "contextWindow": 1,
+                "maxTokens": 1,
+                "reasoning": False,
+                "input": ["text"],
+                "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            }
+        )
+        violations = config_policy.evaluate(config, "bogus-tier")
+        assert any(v["field"] == "models.providers" for v in violations)

--- a/apps/backend/tests/unit/services/test_config_policy.py
+++ b/apps/backend/tests/unit/services/test_config_policy.py
@@ -123,3 +123,37 @@ class TestEvaluate:
         # Pro tier generator already includes both MiniMax and Qwen — clean.
         violations = config_policy.evaluate(config, "pro")
         assert not any(v["field"] == "agents.defaults.models" for v in violations)
+
+    def test_free_tier_telegram_account_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["channels"]["telegram"]["accounts"] = {
+            "my-agent": {"botToken": "1:abc"},
+        }
+        violations = config_policy.evaluate(config, "free")
+        fields = [v["field"] for v in violations]
+        assert "channels.accounts" in fields
+
+    def test_paid_tier_telegram_account_no_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="starter")
+        config = json.loads(raw)
+        config["channels"]["telegram"]["accounts"] = {
+            "my-agent": {"botToken": "1:abc"},
+        }
+        violations = config_policy.evaluate(config, "starter")
+        assert not any(v["field"] == "channels.accounts" for v in violations)
+
+    def test_free_tier_scaffold_channels_no_violation(self):
+        # write_openclaw_config ships enabled/dmPolicy flags for all providers
+        # but no accounts — should be clean on free.
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        violations = config_policy.evaluate(config, "free")
+        assert not any(v["field"] == "channels.accounts" for v in violations)
+
+    def test_free_tier_channels_with_empty_accounts_no_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["channels"]["telegram"]["accounts"] = {}
+        violations = config_policy.evaluate(config, "free")
+        assert not any(v["field"] == "channels.accounts" for v in violations)

--- a/apps/backend/tests/unit/services/test_config_policy.py
+++ b/apps/backend/tests/unit/services/test_config_policy.py
@@ -157,3 +157,59 @@ class TestEvaluate:
         config["channels"]["telegram"]["accounts"] = {}
         violations = config_policy.evaluate(config, "free")
         assert not any(v["field"] == "channels.accounts" for v in violations)
+
+
+class TestApplyReverts:
+    """Tests for config_policy.apply_reverts()."""
+
+    def test_revert_providers_restores_tier_allowlist(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["models"]["providers"]["openai"] = {"api": "openai", "models": []}
+        violations = config_policy.evaluate(config, "free")
+        reverted = config_policy.apply_reverts(config, violations)
+        assert "openai" not in reverted["models"]["providers"]
+        assert "amazon-bedrock" in reverted["models"]["providers"]
+
+    def test_revert_primary_restores_tier_default(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+        violations = config_policy.evaluate(config, "free")
+        reverted = config_policy.apply_reverts(config, violations)
+        assert reverted["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/minimax.minimax-m2.5"
+
+    def test_revert_channels_empties_accounts_for_violating_providers_only(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["channels"]["telegram"]["accounts"] = {"a": {"botToken": "x"}}
+        config["channels"]["discord"]["accounts"] = {"b": {"botToken": "y"}}
+        violations = config_policy.evaluate(config, "free")
+        reverted = config_policy.apply_reverts(config, violations)
+        assert reverted["channels"]["telegram"]["accounts"] == {}
+        assert reverted["channels"]["discord"]["accounts"] == {}
+        # Scaffold flags preserved
+        assert reverted["channels"]["telegram"]["enabled"] is True
+        assert reverted["channels"]["telegram"]["dmPolicy"] == "pairing"
+
+    def test_apply_reverts_preserves_meta_and_unrelated_keys(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["meta"] = {"lastTouchedVersion": "2026.4.5", "lastTouchedAt": "2026-04-12T19:43:24Z"}
+        config["tools"]["deny"].append("some-new-tool")
+        config["models"]["providers"]["openai"] = {"api": "openai"}
+        violations = config_policy.evaluate(config, "free")
+        reverted = config_policy.apply_reverts(config, violations)
+        # Meta preserved
+        assert reverted["meta"] == {"lastTouchedVersion": "2026.4.5", "lastTouchedAt": "2026-04-12T19:43:24Z"}
+        # Agent-mutable tool change preserved
+        assert "some-new-tool" in reverted["tools"]["deny"]
+        # Provider reverted
+        assert "openai" not in reverted["models"]["providers"]
+
+    def test_apply_reverts_empty_violations_is_identity(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        reverted = config_policy.apply_reverts(config, [])
+        assert reverted == config
+        assert reverted is not config  # deep-copy

--- a/apps/backend/tests/unit/services/test_config_policy.py
+++ b/apps/backend/tests/unit/services/test_config_policy.py
@@ -213,3 +213,30 @@ class TestApplyReverts:
         reverted = config_policy.apply_reverts(config, [])
         assert reverted == config
         assert reverted is not config  # deep-copy
+
+
+class TestRegionDerivation:
+    """Tests that _expected_providers derives region from settings.AWS_REGION
+    instead of hardcoding us-east-1."""
+
+    def test_providers_baseurl_derived_from_settings_region(self, monkeypatch):
+        """If the deploy runs in eu-west-1 (so write_openclaw_config emits
+        baseUrl=https://bedrock-runtime.eu-west-1.amazonaws.com), the policy
+        expected-providers block must use the same region, otherwise every
+        clean config would flip into `models.providers` drift."""
+        from core.config import settings
+
+        monkeypatch.setattr(settings, "AWS_REGION", "eu-west-1")
+
+        raw = write_openclaw_config(
+            region="eu-west-1",
+            gateway_token="t",
+            tier="starter",
+        )
+        config = json.loads(raw)
+
+        violations = config_policy.evaluate(config, "starter")
+        fields = [v["field"] for v in violations]
+        assert "models.providers" not in fields, (
+            f"clean eu-west-1 config should have no providers violation, got {violations}"
+        )

--- a/apps/backend/tests/unit/services/test_config_policy.py
+++ b/apps/backend/tests/unit/services/test_config_policy.py
@@ -1,0 +1,37 @@
+"""Tests for config_policy module."""
+
+import json
+
+from core.containers.config import write_openclaw_config
+from core.services import config_policy
+
+
+class TestEvaluate:
+    """Tests for config_policy.evaluate()."""
+
+    def test_clean_free_tier_config_has_no_violations(self):
+        raw = write_openclaw_config(
+            region="us-east-1",
+            gateway_token="t",
+            tier="free",
+        )
+        config = json.loads(raw)
+        assert config_policy.evaluate(config, "free") == []
+
+    def test_clean_starter_tier_config_has_no_violations(self):
+        raw = write_openclaw_config(
+            region="us-east-1",
+            gateway_token="t",
+            tier="starter",
+        )
+        config = json.loads(raw)
+        assert config_policy.evaluate(config, "starter") == []
+
+    def test_clean_pro_tier_config_has_no_violations(self):
+        raw = write_openclaw_config(
+            region="us-east-1",
+            gateway_token="t",
+            tier="pro",
+        )
+        config = json.loads(raw)
+        assert config_policy.evaluate(config, "pro") == []

--- a/apps/backend/tests/unit/services/test_config_reconciler.py
+++ b/apps/backend/tests/unit/services/test_config_reconciler.py
@@ -94,3 +94,118 @@ async def test_tick_handles_missing_config_file(tmp_path, monkeypatch):
 
     # Should not raise.
     await r._tick()
+
+
+@pytest.mark.asyncio
+async def test_tick_reverts_drift_in_enforce_mode(tmp_path, monkeypatch):
+    import json
+    from unittest.mock import AsyncMock
+
+    from core.containers.config import write_openclaw_config
+    from core.services.config_reconciler import ConfigReconciler
+
+    user = "user_drift"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg_path = udir / "openclaw.json"
+    # Start with a clean free-tier config, then mutate it in-file.
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    cfg_path.write_text(json.dumps(base, indent=2))
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr("core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE", "enforce", raising=False)
+    monkeypatch.setattr("core.services.config_patcher._efs_mount_path", str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    await r._tick()
+
+    on_disk = json.loads(cfg_path.read_text())
+    assert on_disk["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/minimax.minimax-m2.5"
+
+
+@pytest.mark.asyncio
+async def test_tick_report_mode_does_not_write(tmp_path, monkeypatch):
+    import json
+    from unittest.mock import AsyncMock
+
+    from core.containers.config import write_openclaw_config
+    from core.services.config_reconciler import ConfigReconciler
+
+    user = "user_report"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg_path = udir / "openclaw.json"
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    cfg_path.write_text(json.dumps(base, indent=2))
+    drift_mtime = cfg_path.stat().st_mtime
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr("core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE", "report", raising=False)
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    await r._tick()
+
+    # mtime unchanged → no write happened
+    assert cfg_path.stat().st_mtime == drift_mtime
+
+
+@pytest.mark.asyncio
+async def test_tick_honors_grace_window(tmp_path, monkeypatch):
+    import json
+    import time
+    from unittest.mock import AsyncMock
+
+    from core.containers.config import write_openclaw_config
+    from core.services.config_reconciler import ConfigReconciler
+
+    user = "user_grace"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg_path = udir / "openclaw.json"
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    cfg_path.write_text(json.dumps(base, indent=2))
+    pre_mtime = cfg_path.stat().st_mtime
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr("core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE", "enforce", raising=False)
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    # Grace is in the future → skip revert.
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=int(time.time()) + 30),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    await r._tick()
+    assert cfg_path.stat().st_mtime == pre_mtime

--- a/apps/backend/tests/unit/services/test_config_reconciler.py
+++ b/apps/backend/tests/unit/services/test_config_reconciler.py
@@ -174,6 +174,91 @@ async def test_tick_report_mode_does_not_write(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_tick_off_mode_no_op(tmp_path, monkeypatch):
+    """CONFIG_RECONCILER_MODE=off must short-circuit _tick before any
+    DDB / EFS / billing work."""
+    from unittest.mock import AsyncMock
+
+    from core.services.config_reconciler import ConfigReconciler
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "off",
+        raising=False,
+    )
+
+    list_owners = AsyncMock(return_value=["user_off"])
+    get_grace = AsyncMock(return_value=0)
+    get_billing = AsyncMock(return_value={"plan_tier": "free"})
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        list_owners,
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        get_grace,
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        get_billing,
+    )
+
+    await r._tick()
+
+    # off mode must short-circuit before any IO.
+    list_owners.assert_not_called()
+    get_grace.assert_not_called()
+    get_billing.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tick_unknown_mode_warns_and_no_op(tmp_path, monkeypatch, caplog):
+    """An unknown CONFIG_RECONCILER_MODE value must log a warning and
+    leave drift on disk (behave as ``off`` at the per-owner level)."""
+    import json
+    import logging
+    from unittest.mock import AsyncMock
+
+    from core.containers.config import write_openclaw_config
+    from core.services.config_reconciler import ConfigReconciler
+
+    user = "user_unknown_mode"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg_path = udir / "openclaw.json"
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    cfg_path.write_text(json.dumps(base, indent=2))
+    pre_mtime = cfg_path.stat().st_mtime
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "bogus",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await r._check_one(user)
+
+    # No write happened (drift stays on disk).
+    assert cfg_path.stat().st_mtime == pre_mtime
+    on_disk = json.loads(cfg_path.read_text())
+    assert on_disk["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    # Warning was logged.
+    assert any("unknown CONFIG_RECONCILER_MODE" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_tick_honors_grace_window(tmp_path, monkeypatch):
     import json
     import time

--- a/apps/backend/tests/unit/services/test_config_reconciler.py
+++ b/apps/backend/tests/unit/services/test_config_reconciler.py
@@ -259,6 +259,128 @@ async def test_tick_unknown_mode_warns_and_no_op(tmp_path, monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
+async def test_tick_re_evaluates_when_tier_changes_even_without_mtime_change(tmp_path, monkeypatch):
+    """Plan downgrade (paid→free) with no file edit: once the tier-cache TTL
+    lapses and the tier resolves to the new value, the reconciler must
+    re-read the config and revert now-illegal pro-only fields."""
+    import json
+    from unittest.mock import AsyncMock
+
+    from core.containers.config import write_openclaw_config
+    from core.services.config_reconciler import ConfigReconciler
+
+    user = "user_tier_change"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg_path = udir / "openclaw.json"
+    # Write a valid pro config (pro-tier primary model).
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="pro"))
+    cfg_path.write_text(json.dumps(base, indent=2))
+
+    # Use tier_cache_ttl=0 so each _resolve_tier call hits the mocked billing.
+    r = ConfigReconciler(efs_mount=str(tmp_path), tier_cache_ttl=0.0)
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "enforce",
+        raising=False,
+    )
+    monkeypatch.setattr("core.services.config_patcher._efs_mount_path", str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+
+    # Mutable tier to flip between ticks without touching the file.
+    current_tier = {"value": "pro"}
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(side_effect=lambda _oid: {"plan_tier": current_tier["value"]}),
+    )
+
+    open_count = 0
+    original_open = open
+
+    def tracked_open(path, *a, **kw):
+        nonlocal open_count
+        if str(path).endswith("openclaw.json"):
+            open_count += 1
+        return original_open(path, *a, **kw)
+
+    monkeypatch.setattr("builtins.open", tracked_open)
+
+    # First tick as pro: config is compliant. The file IS opened for evaluation.
+    await r._tick()
+    opens_after_pro = open_count
+    assert opens_after_pro >= 1, "first tick must open the file to evaluate it"
+
+    # Flip to free without touching the file.
+    current_tier["value"] = "free"
+
+    await r._tick()
+
+    # We MUST have re-opened the file on the second tick (tier changed).
+    assert open_count > opens_after_pro, "tier change must trigger re-read even with unchanged mtime"
+
+    # And now the pro-only primary must have been reverted to the free default.
+    on_disk = json.loads(cfg_path.read_text())
+    assert on_disk["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/minimax.minimax-m2.5"
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_when_both_mtime_and_tier_unchanged(tmp_path, monkeypatch):
+    """Two ticks in a row with identical mtime + identical tier must only
+    read the config file once."""
+    from unittest.mock import AsyncMock
+
+    from core.services.config_reconciler import ConfigReconciler
+
+    user = "user_stable"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg = udir / "openclaw.json"
+    cfg.write_text('{"models":{"providers":{}}}')
+
+    r = ConfigReconciler(efs_mount=str(tmp_path), tier_cache_ttl=0.0)
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "report",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    read_count = 0
+    original_open = open
+
+    def tracked_open(path, *a, **kw):
+        nonlocal read_count
+        if str(path).endswith("openclaw.json"):
+            read_count += 1
+        return original_open(path, *a, **kw)
+
+    monkeypatch.setattr("builtins.open", tracked_open)
+
+    await r._tick()
+    first_reads = read_count
+    await r._tick()
+    assert read_count == first_reads, "second tick with same mtime + same tier must not re-read config"
+
+
+@pytest.mark.asyncio
 async def test_tick_honors_grace_window(tmp_path, monkeypatch):
     import json
     import time

--- a/apps/backend/tests/unit/services/test_config_reconciler.py
+++ b/apps/backend/tests/unit/services/test_config_reconciler.py
@@ -1,0 +1,43 @@
+"""Tests for ConfigReconciler lifecycle + tick logic."""
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_reconciler_run_forever_exits_when_stop_set():
+    from core.services.config_reconciler import ConfigReconciler
+
+    r = ConfigReconciler(efs_mount="/tmp/does-not-exist-for-test")
+    task = asyncio.create_task(r.run_forever())
+
+    # Give it a moment to enter the loop, then stop it.
+    await asyncio.sleep(0.05)
+    r.stop()
+
+    # It should exit within one tick interval + a small margin.
+    await asyncio.wait_for(task, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_reconciler_swallows_tick_exceptions(monkeypatch, caplog):
+    """A raised exception inside _tick must not kill run_forever."""
+    from core.services.config_reconciler import ConfigReconciler
+
+    r = ConfigReconciler(efs_mount="/tmp")
+
+    call_count = 0
+
+    async def boom():
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("synthetic tick failure")
+
+    monkeypatch.setattr(r, "_tick", boom)
+
+    task = asyncio.create_task(r.run_forever())
+    await asyncio.sleep(2.2)  # enough for multiple tick attempts
+    r.stop()
+    await asyncio.wait_for(task, timeout=2.0)
+    assert call_count >= 2  # loop kept going despite exceptions

--- a/apps/backend/tests/unit/services/test_config_reconciler.py
+++ b/apps/backend/tests/unit/services/test_config_reconciler.py
@@ -214,8 +214,9 @@ async def test_tick_off_mode_no_op(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_tick_unknown_mode_warns_and_no_op(tmp_path, monkeypatch, caplog):
-    """An unknown CONFIG_RECONCILER_MODE value must log a warning and
-    leave drift on disk (behave as ``off`` at the per-owner level)."""
+    """An unknown CONFIG_RECONCILER_MODE value must log a warning at the
+    top of _tick and short-circuit before any DDB / EFS / billing work
+    (behave as ``off`` for the whole tick)."""
     import json
     import logging
     from unittest.mock import AsyncMock
@@ -238,17 +239,24 @@ async def test_tick_unknown_mode_warns_and_no_op(tmp_path, monkeypatch, caplog):
         "bogus",
         raising=False,
     )
+    list_owners = AsyncMock(return_value=[user])
+    get_grace = AsyncMock(return_value=0)
+    get_billing = AsyncMock(return_value={"plan_tier": "free"})
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        list_owners,
+    )
     monkeypatch.setattr(
         "core.services.config_reconciler.container_repo.get_reconciler_grace",
-        AsyncMock(return_value=0),
+        get_grace,
     )
     monkeypatch.setattr(
         "core.services.config_reconciler.billing_repo.get_by_owner_id",
-        AsyncMock(return_value={"plan_tier": "free"}),
+        get_billing,
     )
 
     with caplog.at_level(logging.WARNING):
-        await r._check_one(user)
+        await r._tick()
 
     # No write happened (drift stays on disk).
     assert cfg_path.stat().st_mtime == pre_mtime
@@ -256,6 +264,10 @@ async def test_tick_unknown_mode_warns_and_no_op(tmp_path, monkeypatch, caplog):
     assert on_disk["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
     # Warning was logged.
     assert any("unknown CONFIG_RECONCILER_MODE" in rec.message for rec in caplog.records)
+    # Early-exit: no IO at all.
+    list_owners.assert_not_called()
+    get_grace.assert_not_called()
+    get_billing.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -416,3 +428,49 @@ async def test_tick_honors_grace_window(tmp_path, monkeypatch):
 
     await r._tick()
     assert cfg_path.stat().st_mtime == pre_mtime
+
+
+@pytest.mark.asyncio
+async def test_tick_exits_early_on_unknown_mode(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from core.services.config_reconciler import ConfigReconciler
+
+    r = ConfigReconciler(efs_mount="/tmp/unused")
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "ENFORCE",  # mistyped
+        raising=False,
+    )
+    mock_list = AsyncMock(return_value=["owner_1"])
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        mock_list,
+    )
+
+    await r._tick()
+
+    # list_active_owners should not have been called — early return.
+    mock_list.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_exits_early_on_trailing_whitespace_mode(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from core.services.config_reconciler import ConfigReconciler
+
+    r = ConfigReconciler(efs_mount="/tmp/unused")
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "enforce ",  # trailing space
+        raising=False,
+    )
+    mock_list = AsyncMock(return_value=["owner_1"])
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        mock_list,
+    )
+
+    await r._tick()
+    mock_list.assert_not_awaited()

--- a/apps/backend/tests/unit/services/test_config_reconciler.py
+++ b/apps/backend/tests/unit/services/test_config_reconciler.py
@@ -41,3 +41,56 @@ async def test_reconciler_swallows_tick_exceptions(monkeypatch, caplog):
     r.stop()
     await asyncio.wait_for(task, timeout=2.0)
     assert call_count >= 2  # loop kept going despite exceptions
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_user_when_mtime_unchanged(tmp_path, monkeypatch):
+    from core.services.config_reconciler import ConfigReconciler
+
+    user_dir = tmp_path / "user_A"
+    user_dir.mkdir()
+    cfg = user_dir / "openclaw.json"
+    cfg.write_text('{"models":{"providers":{}}}')
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=["user_A"]),
+    )
+
+    read_count = 0
+    original_open = open
+
+    def tracked_open(path, *a, **kw):
+        nonlocal read_count
+        if str(path).endswith("openclaw.json"):
+            read_count += 1
+        return original_open(path, *a, **kw)
+
+    monkeypatch.setattr("builtins.open", tracked_open)
+
+    # First tick — mtime unseen, should read.
+    await r._tick()
+    first_reads = read_count
+
+    # Second tick — mtime unchanged, should skip read.
+    await r._tick()
+    assert read_count == first_reads, "second tick must not re-read unchanged file"
+
+
+@pytest.mark.asyncio
+async def test_tick_handles_missing_config_file(tmp_path, monkeypatch):
+    from core.services.config_reconciler import ConfigReconciler
+    from unittest.mock import AsyncMock
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=["ghost_user"]),
+    )
+
+    # Should not raise.
+    await r._tick()

--- a/apps/frontend/tests/e2e/config-policy.spec.ts
+++ b/apps/frontend/tests/e2e/config-policy.spec.ts
@@ -1,0 +1,258 @@
+/**
+ * Config policy enforcement E2E.
+ *
+ * These tests verify the config reconciler behaviour end-to-end:
+ *  1. Agent edits to NON-locked fields (e.g. cron) persist past one reconciler tick.
+ *  2. Agent attempts to change a LOCKED field (primary model) get reverted within
+ *     one reconciler tick window (~1–2s).
+ *
+ * Requirements to run:
+ *   - Backend deployment must have `CONFIG_RECONCILER_MODE=enforce`.
+ *   - The dev Clerk instance + test user must be reachable (same flow as
+ *     journey.spec.ts).
+ *   - WebSocket agent chat must be working against the target deployment
+ *     (journey.spec.ts currently skips chat due to a WS 500 during handshake).
+ *
+ * These tests are SKIPPED by default. To run them against a suitable staging
+ * deployment, set `E2E_CONFIG_POLICY=1` in the environment:
+ *
+ *   E2E_CONFIG_POLICY=1 pnpm run test:e2e config-policy.spec.ts
+ *
+ * They share the `isol8-e2e-testing@mailsac.com` Clerk account with the journey
+ * gate; do NOT run them in parallel with that gate (they rely on the same
+ * container being provisioned + subscribed, and the journey gate cancels its
+ * subscription on tear-down).
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import { clerkSetup } from '@clerk/testing/playwright';
+import { waitForRunning } from './helpers/provision';
+
+const E2E_EMAIL = 'isol8-e2e-testing@mailsac.com';
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000/api/v1';
+
+// Gate these tests behind an explicit opt-in env var. They need
+// CONFIG_RECONCILER_MODE=enforce on the backend + agent-chat working; neither
+// is guaranteed by the default E2E gate, so running them unconditionally would
+// produce flakes / false failures.
+const ENABLED = process.env.E2E_CONFIG_POLICY === '1';
+
+async function createSignInToken(): Promise<{ ticket: string; userId: string }> {
+  const secretKey = process.env.CLERK_SECRET_KEY;
+  if (!secretKey) throw new Error('[e2e] CLERK_SECRET_KEY not set');
+
+  const usersRes = await fetch(
+    `https://api.clerk.com/v1/users?email_address[]=${encodeURIComponent(E2E_EMAIL)}`,
+    { headers: { Authorization: `Bearer ${secretKey}` } },
+  );
+  if (!usersRes.ok) throw new Error(`[e2e] Users API ${usersRes.status}: ${await usersRes.text()}`);
+  const users = (await usersRes.json()) as Array<{ id: string }>;
+  if (!users.length) throw new Error(`[e2e] No user found for ${E2E_EMAIL}`);
+
+  const tokenRes = await fetch('https://api.clerk.com/v1/sign_in_tokens', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${secretKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: users[0].id }),
+  });
+  if (!tokenRes.ok) {
+    throw new Error(`[e2e] Sign-in token API ${tokenRes.status}: ${await tokenRes.text()}`);
+  }
+  const { token } = (await tokenRes.json()) as { token: string };
+  return { ticket: token, userId: users[0].id };
+}
+
+/**
+ * Sign in the shared E2E test user via a Clerk backend-issued ticket (no
+ * password/MFA). Mirrors the flow in journey.spec.ts; kept as a local helper
+ * here instead of exported because the ticket + setActive sequence is tied to
+ * this test's `page` lifecycle.
+ */
+async function signInE2EUser(page: Page): Promise<void> {
+  await clerkSetup();
+  await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => {
+      const w = window as Window & { Clerk?: { loaded?: boolean; client?: unknown } };
+      return w.Clerk?.loaded === true && w.Clerk?.client != null;
+    },
+    { timeout: 30_000 },
+  );
+
+  const { ticket } = await createSignInToken();
+  await page.evaluate(async (t: string) => {
+    const w = window as unknown as {
+      Clerk: {
+        client: { signIn: { create: (opts: Record<string, string>) => Promise<{ createdSessionId: string }> } };
+        setActive: (opts: { session: string }) => Promise<void>;
+      };
+    };
+    const si = await w.Clerk.client.signIn.create({ strategy: 'ticket', ticket: t });
+    await w.Clerk.setActive({ session: si.createdSessionId });
+  }, ticket);
+
+  const sid = await page.evaluate(() => {
+    const w = window as unknown as { Clerk?: { session?: { id?: string } } };
+    return w.Clerk?.session?.id ?? null;
+  });
+  if (!sid) throw new Error('[e2e] No session after sign-in token');
+}
+
+async function getTokenFrom(page: Page): Promise<string> {
+  return page.evaluate(async () => {
+    const w = window as Window & { Clerk?: { session?: { getToken: () => Promise<string> } } };
+    return (await w.Clerk?.session?.getToken()) ?? '';
+  });
+}
+
+/**
+ * Read the caller's current openclaw.json config via the same RPC the UI uses.
+ * Returns the parsed config object.
+ */
+async function readConfig(page: Page): Promise<Record<string, unknown>> {
+  const token = await getTokenFrom(page);
+  // /container/rpc proxies RPC to the user's OpenClaw gateway. `config.read`
+  // is the canonical read path used by the ConfigPanel.
+  const res = await fetch(`${API_URL}/container/rpc`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ method: 'config.read', params: {} }),
+  });
+  if (!res.ok) throw new Error(`config.read failed: ${res.status} ${await res.text()}`);
+  const data = (await res.json()) as { result?: Record<string, unknown> };
+  return data.result ?? {};
+}
+
+async function sendChatMessage(page: Page, text: string): Promise<void> {
+  const input = page.getByPlaceholder('Ask anything');
+  await expect(input).toBeVisible({ timeout: 30_000 });
+  await input.fill(text);
+  await page.getByTestId('send-button').click();
+}
+
+async function waitForAssistantResponse(page: Page, timeoutMs = 90_000): Promise<void> {
+  // Send-button swaps to stop-button while streaming; wait for it to swap back.
+  await expect(page.getByTestId('stop-button')).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId('send-button')).toBeVisible({ timeout: timeoutMs });
+}
+
+test.describe('Config policy enforcement', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.skip(!ENABLED, 'Requires CONFIG_RECONCILER_MODE=enforce + WS chat. Set E2E_CONFIG_POLICY=1 to run.');
+
+  let sharedPage: Page;
+  let originalConfig: Record<string, unknown> = {};
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(5 * 60_000);
+    const ctx = await browser.newContext({
+      extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+        ? { 'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET }
+        : {},
+    });
+    sharedPage = await ctx.newPage();
+    await signInE2EUser(sharedPage);
+
+    // Make sure the container is provisioned + healthy. The journey gate
+    // normally leaves one running; if not, POST /debug/provision is idempotent.
+    const token = await getTokenFrom(sharedPage);
+    const provisionRes = await fetch(`${API_URL}/debug/provision`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (provisionRes.status !== 200 && provisionRes.status !== 409) {
+      throw new Error(`[e2e] Provision failed: ${provisionRes.status}`);
+    }
+    await waitForRunning(API_URL, () => getTokenFrom(sharedPage), 5 * 60_000);
+
+    // Snapshot the config so we can restore it after the tests — the "agent
+    // changes X" scenarios mutate shared state on EFS.
+    originalConfig = await readConfig(sharedPage);
+
+    await sharedPage.goto(`${BASE_URL}/chat`, { waitUntil: 'domcontentloaded' });
+  });
+
+  test.afterAll(async () => {
+    // Best-effort restore: use the admin PATCH endpoint to put the config
+    // back the way we found it. We don't fail the suite if this errors —
+    // the reconciler would correct any locked-field drift on the next tick
+    // anyway, and the journey gate's own cleanup restores the rest.
+    try {
+      if (sharedPage && Object.keys(originalConfig).length > 0) {
+        const token = await getTokenFrom(sharedPage);
+        await fetch(`${API_URL}/config`, {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ patch: originalConfig }),
+        });
+      }
+    } catch (err) {
+      console.error('[e2e] afterAll config restore failed (non-fatal):', err);
+    }
+    await sharedPage?.context().close();
+  });
+
+  test('agent edits to non-locked fields persist past reconciler tick', async () => {
+    test.setTimeout(3 * 60_000);
+
+    // Ask the agent to add a cron job. `crons` is not a locked field — the
+    // policy allows users on any tier to define their own schedules.
+    await sendChatMessage(
+      sharedPage,
+      'Add a cron job with id "e2e-cron-test" that runs daily at 9am (schedule "0 9 * * *") ' +
+        'and triggers a noop. Confirm the exact id you used.',
+    );
+    await waitForAssistantResponse(sharedPage);
+
+    // Wait well past the 1s reconciler tick interval so any revert would have
+    // fired by now.
+    await sharedPage.waitForTimeout(3_000);
+
+    // Non-locked changes must survive. Assert via the RPC snapshot (more
+    // reliable than chasing a potentially virtualised config panel).
+    const config = await readConfig(sharedPage);
+    const crons = (config.crons ?? {}) as Record<string, unknown>;
+    expect(
+      Object.keys(crons),
+      'non-locked cron entry should persist past reconciler tick',
+    ).toContain('e2e-cron-test');
+  });
+
+  test('agent attempt to switch primary model gets reverted', async () => {
+    test.setTimeout(3 * 60_000);
+
+    // Ask the agent to switch its primary model. For the starter tier the
+    // policy pins primary to Qwen3 VL 235B — any other value is drift and
+    // must be reverted within one reconciler tick.
+    await sendChatMessage(
+      sharedPage,
+      'Switch your primary model to amazon-bedrock/minimax.minimax-m2.5 in the ' +
+        'agent defaults and confirm when done.',
+    );
+    await waitForAssistantResponse(sharedPage);
+
+    // Give the reconciler two ticks of headroom (default interval is 1s).
+    await sharedPage.waitForTimeout(3_000);
+
+    const config = await readConfig(sharedPage);
+    const primary = (((config.agents as Record<string, unknown> | undefined)
+      ?.defaults as Record<string, unknown> | undefined)
+      ?.model as Record<string, unknown> | undefined)?.primary;
+
+    // Whatever the agent wrote, the reconciler must have restored the
+    // tier-allowed primary. We assert it's NOT the minimax value the agent
+    // tried to set — a strict equality check to the starter-tier primary
+    // would couple this test to the exact model id, which may evolve.
+    expect(
+      primary,
+      'reconciler must revert agent-attempted primary-model change',
+    ).not.toBe('amazon-bedrock/minimax.minimax-m2.5');
+  });
+});

--- a/docs/superpowers/plans/2026-04-14-config-protection.md
+++ b/docs/superpowers/plans/2026-04-14-config-protection.md
@@ -1,0 +1,2171 @@
+# Config Protection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce tier-based restrictions on `openclaw.json` at the filesystem level via backend reconciliation, so agents cannot bypass policy by writing the file directly (either via gateway RPC or direct file tools).
+
+**Architecture:** Pure-policy module (`config_policy.py`) that evaluates a config dict against a tier and returns a list of field violations. A polling reconciler (`config_reconciler.py`) runs as a FastAPI lifespan task, mtime-gates its work, reads each active user's `openclaw.json` under the existing `fcntl.lockf` primitive, and reverts locked-field drift within ~1 second. Backend PATCH endpoint at `routers/config.py` shares the same policy for frontend/admin writes. Admin emergency endpoints set a 5s DDB grace window that the reconciler respects.
+
+**Tech Stack:** Python 3 / FastAPI / asyncio / boto3 DynamoDB / pytest / existing `config_patcher.py` locking primitives.
+
+**Spec:** `docs/superpowers/specs/2026-04-14-config-protection-design.md`
+
+---
+
+## File Map
+
+**Create:**
+- `apps/backend/core/services/config_policy.py` — pure policy module (evaluate + apply_reverts)
+- `apps/backend/core/services/config_reconciler.py` — asyncio polling loop
+- `apps/backend/scripts/reconcile_all_configs.py` — one-shot fleet cleanup
+- `apps/backend/tests/unit/services/test_config_policy.py`
+- `apps/backend/tests/unit/services/test_config_reconciler.py`
+- `apps/backend/tests/integration/test_config_reconciliation.py`
+
+**Modify:**
+- `apps/backend/core/config.py` — add `CONFIG_RECONCILER_MODE` setting
+- `apps/backend/core/repositories/container_repo.py` — add grace field helpers
+- `apps/backend/main.py` — start reconciler in lifespan
+- `apps/backend/routers/config.py` — swap custom channel check for policy eval on merged
+- `apps/backend/routers/updates.py` — set grace on admin patches
+- `apps/backend/tests/unit/routers/test_config_router.py` — update tests for new error shape + add model/provider cases
+
+---
+
+## Task 1: Policy module skeleton + clean-config test
+
+**Files:**
+- Create: `apps/backend/core/services/config_policy.py`
+- Create: `apps/backend/tests/unit/services/test_config_policy.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/backend/tests/unit/services/test_config_policy.py`:
+
+```python
+"""Tests for config_policy module."""
+import json
+
+import pytest
+
+from core.containers.config import write_openclaw_config
+from core.services import config_policy
+
+
+class TestEvaluate:
+    """Tests for config_policy.evaluate()."""
+
+    def test_clean_free_tier_config_has_no_violations(self):
+        raw = write_openclaw_config(
+            region="us-east-1",
+            gateway_token="t",
+            tier="free",
+        )
+        config = json.loads(raw)
+        assert config_policy.evaluate(config, "free") == []
+
+    def test_clean_starter_tier_config_has_no_violations(self):
+        raw = write_openclaw_config(
+            region="us-east-1",
+            gateway_token="t",
+            tier="starter",
+        )
+        config = json.loads(raw)
+        assert config_policy.evaluate(config, "starter") == []
+
+    def test_clean_pro_tier_config_has_no_violations(self):
+        raw = write_openclaw_config(
+            region="us-east-1",
+            gateway_token="t",
+            tier="pro",
+        )
+        config = json.loads(raw)
+        assert config_policy.evaluate(config, "pro") == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'core.services.config_policy'`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `apps/backend/core/services/config_policy.py`:
+
+```python
+"""Tier-aware policy for openclaw.json locked fields.
+
+Pure, side-effect-free. Takes a config dict and a tier name, returns a list
+of field-level violations. Apply reverts by computing the authoritative
+expected value from helpers in core/containers/config.py.
+"""
+
+import copy
+from typing import Any, Literal, TypedDict
+
+LockedField = Literal[
+    "models.providers",
+    "agents.defaults.models",
+    "agents.defaults.model.primary",
+    "channels.accounts",
+]
+
+
+class PolicyViolation(TypedDict):
+    field: LockedField
+    reason: str
+    expected: Any
+    actual: Any
+
+
+def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
+    """Return a list of locked-field violations for this config at this tier.
+
+    Empty list means the config is legal. Each violation has enough info
+    to revert (field, expected value) and for audit (reason, actual value).
+    """
+    return []
+
+
+def apply_reverts(config: dict, violations: list[PolicyViolation]) -> dict:
+    """Return a deep copy of config with each violating field replaced by
+    its expected value. Non-violating fields — including OpenClaw's `meta`
+    block and everything else — are preserved untouched.
+    """
+    return copy.deepcopy(config)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v`
+Expected: All three tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/core/services/config_policy.py apps/backend/tests/unit/services/test_config_policy.py
+git commit -m "feat(config-policy): module skeleton with clean-config regression tests"
+```
+
+---
+
+## Task 2: Policy — detect `models.providers` drift
+
+**Files:**
+- Modify: `apps/backend/core/services/config_policy.py`
+- Modify: `apps/backend/tests/unit/services/test_config_policy.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/backend/tests/unit/services/test_config_policy.py` inside `TestEvaluate`:
+
+```python
+    def test_extra_provider_added_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="starter")
+        config = json.loads(raw)
+        # Agent tries to add openai as a provider
+        config["models"]["providers"]["openai"] = {
+            "baseUrl": "https://api.openai.com",
+            "api": "openai",
+            "models": [{"id": "gpt-4o", "name": "GPT-4o"}],
+        }
+        violations = config_policy.evaluate(config, "starter")
+        fields = [v["field"] for v in violations]
+        assert "models.providers" in fields
+
+    def test_unauthorized_model_in_bedrock_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        # Agent adds qwen to a free-tier provider list
+        config["models"]["providers"]["amazon-bedrock"]["models"].append({
+            "id": "qwen.qwen3-vl-235b-a22b",
+            "name": "Qwen3 VL 235B",
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "reasoning": False,
+            "input": ["text", "image"],
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+        })
+        violations = config_policy.evaluate(config, "free")
+        assert any(v["field"] == "models.providers" for v in violations)
+
+    def test_unknown_tier_falls_back_to_free(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        # Add qwen — illegal for free
+        config["models"]["providers"]["amazon-bedrock"]["models"].append({
+            "id": "qwen.qwen3-vl-235b-a22b", "name": "X", "contextWindow": 1,
+            "maxTokens": 1, "reasoning": False, "input": ["text"],
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+        })
+        violations = config_policy.evaluate(config, "bogus-tier")
+        assert any(v["field"] == "models.providers" for v in violations)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v`
+Expected: Three new tests FAIL (evaluate returns `[]` always).
+
+- [ ] **Step 3: Implement `models.providers` check**
+
+Replace the `evaluate()` function body in `apps/backend/core/services/config_policy.py`:
+
+```python
+from core.config import TIER_CONFIG
+from core.containers.config import (
+    _TIER_ALLOWED_MODEL_IDS,
+    _models_for_tier,
+)
+
+
+def _expected_providers(tier: str) -> dict:
+    """The one provider block this tier is allowed to run: amazon-bedrock
+    with exactly the tier's model list. No other providers permitted."""
+    return {
+        "amazon-bedrock": {
+            "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "api": "bedrock-converse-stream",
+            "auth": "aws-sdk",
+            "models": _models_for_tier(tier),
+        },
+    }
+
+
+def _providers_match(actual: Any, expected: dict) -> bool:
+    """Strict equality check. Providers block must match exactly — any extra
+    provider, any extra/missing model, any changed field is a violation."""
+    return actual == expected
+
+
+def evaluate(config: dict, tier: str) -> list[PolicyViolation]:
+    violations: list[PolicyViolation] = []
+
+    # Tier fallback: unknown tier → free-tier allowlist (default-deny).
+    effective_tier = tier if tier in _TIER_ALLOWED_MODEL_IDS else "free"
+
+    # 1. models.providers — strict match against tier's allowed block
+    actual_providers = config.get("models", {}).get("providers", {})
+    expected_providers = _expected_providers(effective_tier)
+    if not _providers_match(actual_providers, expected_providers):
+        violations.append(
+            {
+                "field": "models.providers",
+                "reason": f"providers block for tier={effective_tier} must match the tier's allowlist",
+                "expected": expected_providers,
+                "actual": actual_providers,
+            }
+        )
+
+    return violations
+```
+
+- [ ] **Step 4: Run all tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v`
+Expected: All tests PASS (clean configs still clean, drift tests catch violations).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/core/services/config_policy.py apps/backend/tests/unit/services/test_config_policy.py
+git commit -m "feat(config-policy): detect models.providers drift with strict allowlist match"
+```
+
+---
+
+## Task 3: Policy — detect `agents.defaults.model.primary` drift
+
+**Files:**
+- Modify: `apps/backend/core/services/config_policy.py`
+- Modify: `apps/backend/tests/unit/services/test_config_policy.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `TestEvaluate`:
+
+```python
+    def test_free_tier_primary_changed_to_qwen_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+        violations = config_policy.evaluate(config, "free")
+        assert any(v["field"] == "agents.defaults.model.primary" for v in violations)
+
+    def test_paid_tier_primary_allowed_model_no_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="pro")
+        config = json.loads(raw)
+        # Pro tier's primary is already Qwen from write_openclaw_config, but
+        # swapping to MiniMax (also allowed on pro) should not be a violation.
+        config["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/minimax.minimax-m2.5"
+        violations = config_policy.evaluate(config, "pro")
+        assert not any(v["field"] == "agents.defaults.model.primary" for v in violations)
+
+    def test_paid_tier_primary_unknown_model_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="pro")
+        config = json.loads(raw)
+        config["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/claude-opus-4"
+        violations = config_policy.evaluate(config, "pro")
+        assert any(v["field"] == "agents.defaults.model.primary" for v in violations)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v -k primary`
+Expected: 2 of 3 new tests FAIL (paid-tier allowed-swap happens to pass coincidentally until we enforce).
+
+- [ ] **Step 3: Add primary-model check to `evaluate()`**
+
+In `apps/backend/core/services/config_policy.py`, after the `models.providers` block inside `evaluate()`, append:
+
+```python
+    # 2. agents.defaults.model.primary — must be in tier allowlist
+    primary = (
+        config.get("agents", {})
+        .get("defaults", {})
+        .get("model", {})
+        .get("primary", "")
+    )
+    bare_primary = primary.removeprefix("amazon-bedrock/")
+    if bare_primary not in _TIER_ALLOWED_MODEL_IDS[effective_tier]:
+        expected_primary = f"amazon-bedrock/{TIER_CONFIG[effective_tier]['primary_model'].removeprefix('amazon-bedrock/')}"
+        violations.append(
+            {
+                "field": "agents.defaults.model.primary",
+                "reason": f"primary model {primary!r} is not allowed for tier={effective_tier}",
+                "expected": expected_primary,
+                "actual": primary,
+            }
+        )
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/core/services/config_policy.py apps/backend/tests/unit/services/test_config_policy.py
+git commit -m "feat(config-policy): detect primary-model drift against tier allowlist"
+```
+
+---
+
+## Task 4: Policy — detect `agents.defaults.models` key drift
+
+**Files:**
+- Modify: `apps/backend/core/services/config_policy.py`
+- Modify: `apps/backend/tests/unit/services/test_config_policy.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `TestEvaluate`:
+
+```python
+    def test_free_tier_agents_models_with_qwen_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["agents"]["defaults"]["models"]["amazon-bedrock/qwen.qwen3-vl-235b-a22b"] = {
+            "alias": "Qwen3 VL 235B",
+        }
+        violations = config_policy.evaluate(config, "free")
+        assert any(v["field"] == "agents.defaults.models" for v in violations)
+
+    def test_paid_tier_agents_models_within_allowlist_no_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="pro")
+        config = json.loads(raw)
+        # Pro tier generator already includes both MiniMax and Qwen — clean.
+        violations = config_policy.evaluate(config, "pro")
+        assert not any(v["field"] == "agents.defaults.models" for v in violations)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v -k "agents_models"`
+Expected: First test FAILS.
+
+- [ ] **Step 3: Add `agents.defaults.models` check**
+
+Append inside `evaluate()` in `apps/backend/core/services/config_policy.py` after the primary-model block:
+
+```python
+    # 3. agents.defaults.models — keys must all be in tier allowlist
+    models_map = (
+        config.get("agents", {}).get("defaults", {}).get("models", {})
+    )
+    if isinstance(models_map, dict):
+        illegal_keys = [
+            k for k in models_map
+            if k.removeprefix("amazon-bedrock/")
+            not in _TIER_ALLOWED_MODEL_IDS[effective_tier]
+        ]
+        if illegal_keys:
+            # Build expected: filter out illegal entries, ensure primary is present.
+            # Reuse write_openclaw_config's helper via a direct import.
+            from core.containers.config import _agent_models_for_tier
+
+            expected_primary = f"amazon-bedrock/{TIER_CONFIG[effective_tier]['primary_model'].removeprefix('amazon-bedrock/')}"
+            expected_models = _agent_models_for_tier(effective_tier, expected_primary)
+            violations.append(
+                {
+                    "field": "agents.defaults.models",
+                    "reason": f"agents.defaults.models contains non-allowlisted keys for tier={effective_tier}: {illegal_keys}",
+                    "expected": expected_models,
+                    "actual": models_map,
+                }
+            )
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/core/services/config_policy.py apps/backend/tests/unit/services/test_config_policy.py
+git commit -m "feat(config-policy): detect agents.defaults.models drift against tier allowlist"
+```
+
+---
+
+## Task 5: Policy — detect free-tier `channels.{p}.accounts` drift
+
+**Files:**
+- Modify: `apps/backend/core/services/config_policy.py`
+- Modify: `apps/backend/tests/unit/services/test_config_policy.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `TestEvaluate`:
+
+```python
+    def test_free_tier_telegram_account_is_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["channels"]["telegram"]["accounts"] = {
+            "my-agent": {"botToken": "1:abc"},
+        }
+        violations = config_policy.evaluate(config, "free")
+        fields = [v["field"] for v in violations]
+        assert "channels.accounts" in fields
+
+    def test_paid_tier_telegram_account_no_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="starter")
+        config = json.loads(raw)
+        config["channels"]["telegram"]["accounts"] = {
+            "my-agent": {"botToken": "1:abc"},
+        }
+        violations = config_policy.evaluate(config, "starter")
+        assert not any(v["field"] == "channels.accounts" for v in violations)
+
+    def test_free_tier_scaffold_channels_no_violation(self):
+        # write_openclaw_config ships enabled/dmPolicy flags for all providers
+        # but no accounts — should be clean on free.
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        violations = config_policy.evaluate(config, "free")
+        assert not any(v["field"] == "channels.accounts" for v in violations)
+
+    def test_free_tier_channels_with_empty_accounts_no_violation(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["channels"]["telegram"]["accounts"] = {}
+        violations = config_policy.evaluate(config, "free")
+        assert not any(v["field"] == "channels.accounts" for v in violations)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v -k channels`
+Expected: First test FAILS.
+
+- [ ] **Step 3: Implement channels check**
+
+Append inside `evaluate()`:
+
+```python
+    # 4. channels.{provider}.accounts — free tier must have no accounts
+    if effective_tier == "free":
+        channels = config.get("channels", {})
+        if isinstance(channels, dict):
+            offending: dict[str, dict] = {}
+            for provider, provider_cfg in channels.items():
+                if not isinstance(provider_cfg, dict):
+                    continue
+                accounts = provider_cfg.get("accounts", {})
+                if isinstance(accounts, dict) and accounts:
+                    offending[provider] = accounts
+            if offending:
+                violations.append(
+                    {
+                        "field": "channels.accounts",
+                        "reason": f"free tier cannot have channel accounts; found: {sorted(offending.keys())}",
+                        "expected": {p: {} for p in offending},
+                        "actual": offending,
+                    }
+                )
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/core/services/config_policy.py apps/backend/tests/unit/services/test_config_policy.py
+git commit -m "feat(config-policy): detect free-tier channel-account drift"
+```
+
+---
+
+## Task 6: Policy — `apply_reverts` implementation
+
+**Files:**
+- Modify: `apps/backend/core/services/config_policy.py`
+- Modify: `apps/backend/tests/unit/services/test_config_policy.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test_config_policy.py`:
+
+```python
+class TestApplyReverts:
+    """Tests for config_policy.apply_reverts()."""
+
+    def test_revert_providers_restores_tier_allowlist(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["models"]["providers"]["openai"] = {"api": "openai", "models": []}
+        violations = config_policy.evaluate(config, "free")
+        reverted = config_policy.apply_reverts(config, violations)
+        assert "openai" not in reverted["models"]["providers"]
+        assert "amazon-bedrock" in reverted["models"]["providers"]
+
+    def test_revert_primary_restores_tier_default(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+        violations = config_policy.evaluate(config, "free")
+        reverted = config_policy.apply_reverts(config, violations)
+        assert reverted["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/minimax.minimax-m2.5"
+
+    def test_revert_channels_empties_accounts_for_violating_providers_only(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["channels"]["telegram"]["accounts"] = {"a": {"botToken": "x"}}
+        config["channels"]["discord"]["accounts"] = {"b": {"botToken": "y"}}
+        violations = config_policy.evaluate(config, "free")
+        reverted = config_policy.apply_reverts(config, violations)
+        assert reverted["channels"]["telegram"]["accounts"] == {}
+        assert reverted["channels"]["discord"]["accounts"] == {}
+        # Scaffold flags preserved
+        assert reverted["channels"]["telegram"]["enabled"] is True
+        assert reverted["channels"]["telegram"]["dmPolicy"] == "pairing"
+
+    def test_apply_reverts_preserves_meta_and_unrelated_keys(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        config["meta"] = {"lastTouchedVersion": "2026.4.5", "lastTouchedAt": "2026-04-12T19:43:24Z"}
+        config["tools"]["deny"].append("some-new-tool")
+        config["models"]["providers"]["openai"] = {"api": "openai"}
+        violations = config_policy.evaluate(config, "free")
+        reverted = config_policy.apply_reverts(config, violations)
+        # Meta preserved
+        assert reverted["meta"] == {"lastTouchedVersion": "2026.4.5", "lastTouchedAt": "2026-04-12T19:43:24Z"}
+        # Agent-mutable tool change preserved
+        assert "some-new-tool" in reverted["tools"]["deny"]
+        # Provider reverted
+        assert "openai" not in reverted["models"]["providers"]
+
+    def test_apply_reverts_empty_violations_is_identity(self):
+        raw = write_openclaw_config(gateway_token="t", tier="free")
+        config = json.loads(raw)
+        reverted = config_policy.apply_reverts(config, [])
+        assert reverted == config
+        assert reverted is not config  # deep-copy
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py::TestApplyReverts -v`
+Expected: All tests in `TestApplyReverts` except the last FAIL (the current impl just deep-copies without applying anything).
+
+- [ ] **Step 3: Implement `apply_reverts`**
+
+Replace the `apply_reverts` function body in `apps/backend/core/services/config_policy.py`:
+
+```python
+def _set_dotted(target: dict, dotted: str, value: Any) -> None:
+    """Set `target[a][b][c] = value` for dotted='a.b.c'. Creates intermediate
+    dicts as needed."""
+    parts = dotted.split(".")
+    cursor = target
+    for segment in parts[:-1]:
+        if segment not in cursor or not isinstance(cursor[segment], dict):
+            cursor[segment] = {}
+        cursor = cursor[segment]
+    cursor[parts[-1]] = value
+
+
+def apply_reverts(config: dict, violations: list[PolicyViolation]) -> dict:
+    """Return a deep copy of config with each violating field replaced by
+    its expected value. Non-violating fields are preserved untouched.
+
+    Special-cases `channels.accounts` since that's a collection of per-provider
+    sub-fields, not a single dotted path.
+    """
+    result = copy.deepcopy(config)
+    for v in violations:
+        field = v["field"]
+        expected = v["expected"]
+        if field == "channels.accounts":
+            # expected is {provider: {} ...}; write into channels.{provider}.accounts
+            channels = result.setdefault("channels", {})
+            for provider in expected:
+                provider_cfg = channels.setdefault(provider, {})
+                if isinstance(provider_cfg, dict):
+                    provider_cfg["accounts"] = {}
+        else:
+            _set_dotted(result, field, copy.deepcopy(expected))
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_policy.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/core/services/config_policy.py apps/backend/tests/unit/services/test_config_policy.py
+git commit -m "feat(config-policy): apply_reverts with dotted-path + channels special case"
+```
+
+---
+
+## Task 7: Container repo — `reconciler_grace_until` helpers
+
+**Files:**
+- Modify: `apps/backend/core/repositories/container_repo.py`
+- Create: `apps/backend/tests/unit/repositories/test_container_repo_grace.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/backend/tests/unit/repositories/test_container_repo_grace.py`:
+
+```python
+"""Tests for container_repo grace-window helpers."""
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_set_reconciler_grace_writes_epoch_seconds():
+    from core.repositories import container_repo
+
+    with (
+        patch.object(container_repo, "get_by_owner_id", AsyncMock(return_value={"owner_id": "u1", "id": "i", "created_at": "x"})),
+        patch.object(container_repo, "update_fields", AsyncMock(return_value={})) as mock_update,
+    ):
+        before = int(time.time())
+        await container_repo.set_reconciler_grace("u1", seconds=5)
+        after = int(time.time())
+
+    mock_update.assert_awaited_once()
+    args, _ = mock_update.call_args
+    owner_id, fields = args
+    assert owner_id == "u1"
+    assert "reconciler_grace_until" in fields
+    assert before + 5 <= fields["reconciler_grace_until"] <= after + 6
+
+
+@pytest.mark.asyncio
+async def test_get_reconciler_grace_returns_zero_when_unset():
+    from core.repositories import container_repo
+
+    with patch.object(container_repo, "get_by_owner_id", AsyncMock(return_value={"owner_id": "u1"})):
+        grace = await container_repo.get_reconciler_grace("u1")
+    assert grace == 0
+
+
+@pytest.mark.asyncio
+async def test_get_reconciler_grace_returns_stored_value():
+    from core.repositories import container_repo
+
+    with patch.object(container_repo, "get_by_owner_id", AsyncMock(return_value={"owner_id": "u1", "reconciler_grace_until": 1234567890})):
+        grace = await container_repo.get_reconciler_grace("u1")
+    assert grace == 1234567890
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/repositories/test_container_repo_grace.py -v`
+Expected: FAIL (`set_reconciler_grace` / `get_reconciler_grace` not defined).
+
+- [ ] **Step 3: Add helpers to container_repo**
+
+Append to `apps/backend/core/repositories/container_repo.py`:
+
+```python
+async def set_reconciler_grace(owner_id: str, seconds: int = 5) -> dict | None:
+    """Write `reconciler_grace_until = now + seconds` to this owner's container
+    row. The reconciler checks this before reverting so admin / backend-initiated
+    writes aren't immediately undone by a concurrent reconciler tick.
+
+    No-op if the row doesn't exist (returns None).
+    """
+    import time
+
+    return await update_fields(owner_id, {"reconciler_grace_until": int(time.time()) + seconds})
+
+
+async def get_reconciler_grace(owner_id: str) -> int:
+    """Return the reconciler_grace_until timestamp (epoch seconds) for this
+    owner, or 0 if unset or the row doesn't exist."""
+    existing = await get_by_owner_id(owner_id)
+    if existing is None:
+        return 0
+    value = existing.get("reconciler_grace_until")
+    if value is None:
+        return 0
+    # DDB returns numbers as Decimal — coerce to int.
+    return int(value)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/repositories/test_container_repo_grace.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/core/repositories/container_repo.py apps/backend/tests/unit/repositories/test_container_repo_grace.py
+git commit -m "feat(container-repo): reconciler_grace_until get/set helpers"
+```
+
+---
+
+## Task 8: Settings — `CONFIG_RECONCILER_MODE`
+
+**Files:**
+- Modify: `apps/backend/core/config.py`
+- Modify: `apps/backend/tests/conftest.py` (if needed for env isolation — check first)
+
+- [ ] **Step 1: Read the current settings module**
+
+Run: `grep -n 'class Settings\|ENVIRONMENT\|pydantic' apps/backend/core/config.py | head -20`
+
+Confirm this is a pydantic `BaseSettings` class. If it is, the new field will be picked up via env var `CONFIG_RECONCILER_MODE`.
+
+- [ ] **Step 2: Add the setting**
+
+In `apps/backend/core/config.py`, inside the `Settings` class (alongside other env-driven fields), add:
+
+```python
+    # Config reconciler mode:
+    #   "off"      -- disabled entirely
+    #   "report"   -- evaluate + log + metric, but do not revert (rollout phase A)
+    #   "enforce"  -- evaluate + revert on drift (rollout phase B, steady-state)
+    CONFIG_RECONCILER_MODE: str = "off"
+```
+
+Place it near other mode-like settings (e.g. near `BEDROCK_ENABLED` or `ENVIRONMENT`). Exact placement is stylistic — just keep it with other top-level flags.
+
+- [ ] **Step 3: Verify settings loads and default is 'off'**
+
+Run: `cd apps/backend && uv run python -c "from core.config import settings; print(settings.CONFIG_RECONCILER_MODE)"`
+Expected: prints `off`.
+
+Also run: `cd apps/backend && CONFIG_RECONCILER_MODE=report uv run python -c "from core.config import settings; print(settings.CONFIG_RECONCILER_MODE)"`
+Expected: prints `report`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/backend/core/config.py
+git commit -m "feat(config): CONFIG_RECONCILER_MODE setting (off/report/enforce)"
+```
+
+---
+
+## Task 9: Reconciler skeleton + shutdown behavior
+
+**Files:**
+- Create: `apps/backend/core/services/config_reconciler.py`
+- Create: `apps/backend/tests/unit/services/test_config_reconciler.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/backend/tests/unit/services/test_config_reconciler.py`:
+
+```python
+"""Tests for ConfigReconciler lifecycle + tick logic."""
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_reconciler_run_forever_exits_when_stop_set():
+    from core.services.config_reconciler import ConfigReconciler
+
+    r = ConfigReconciler(efs_mount="/tmp/does-not-exist-for-test")
+    task = asyncio.create_task(r.run_forever())
+
+    # Give it a moment to enter the loop, then stop it.
+    await asyncio.sleep(0.05)
+    r.stop()
+
+    # It should exit within one tick interval + a small margin.
+    await asyncio.wait_for(task, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_reconciler_swallows_tick_exceptions(monkeypatch, caplog):
+    """A raised exception inside _tick must not kill run_forever."""
+    from core.services.config_reconciler import ConfigReconciler
+
+    r = ConfigReconciler(efs_mount="/tmp")
+
+    call_count = 0
+
+    async def boom():
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("synthetic tick failure")
+
+    monkeypatch.setattr(r, "_tick", boom)
+
+    task = asyncio.create_task(r.run_forever())
+    await asyncio.sleep(2.2)  # enough for multiple tick attempts
+    r.stop()
+    await asyncio.wait_for(task, timeout=2.0)
+    assert call_count >= 2  # loop kept going despite exceptions
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_reconciler.py -v`
+Expected: FAIL (`config_reconciler` module doesn't exist).
+
+- [ ] **Step 3: Write reconciler skeleton**
+
+Create `apps/backend/core/services/config_reconciler.py`:
+
+```python
+"""Backend reconciliation loop for openclaw.json tier policy.
+
+Polls every active user's config on EFS at ~1s cadence, evaluates it
+against the tier policy (core.services.config_policy), and reverts drift
+on locked fields only. Non-locked fields are never touched.
+
+Ships in three modes via CONFIG_RECONCILER_MODE:
+  - off: reconciler never starts
+  - report: reads + evaluates + logs, never writes (rollout phase A)
+  - enforce: reads + evaluates + reverts (rollout phase B, steady state)
+"""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigReconciler:
+    def __init__(
+        self,
+        efs_mount: str,
+        tier_cache_ttl: float = 60.0,
+        tick_interval: float = 1.0,
+    ):
+        self._efs_mount = efs_mount
+        self._tier_cache_ttl = tier_cache_ttl
+        self._tick_interval = tick_interval
+        self._stop = asyncio.Event()
+        self._last_seen_mtime: dict[str, float] = {}
+        self._tier_cache: dict[str, tuple[str, float]] = {}
+
+    def stop(self) -> None:
+        """Signal the loop to exit after its current tick."""
+        self._stop.set()
+
+    async def run_forever(self) -> None:
+        logger.info("config_reconciler started")
+        while not self._stop.is_set():
+            try:
+                await self._tick()
+            except Exception:
+                logger.exception("config_reconciler tick failed")
+            # Sleep until tick_interval elapses OR stop is set (whichever first).
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self._tick_interval)
+            except asyncio.TimeoutError:
+                pass
+        logger.info("config_reconciler stopped")
+
+    async def _tick(self) -> None:
+        """One pass over the active-owner set. No-op in the skeleton."""
+        return
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_reconciler.py -v`
+Expected: Both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/core/services/config_reconciler.py apps/backend/tests/unit/services/test_config_reconciler.py
+git commit -m "feat(config-reconciler): module skeleton with run_forever + graceful shutdown"
+```
+
+---
+
+## Task 10: Reconciler — mtime-gated per-user check (no revert yet)
+
+**Files:**
+- Modify: `apps/backend/core/services/config_reconciler.py`
+- Modify: `apps/backend/tests/unit/services/test_config_reconciler.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test_config_reconciler.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_tick_skips_user_when_mtime_unchanged(tmp_path, monkeypatch):
+    from core.services.config_reconciler import ConfigReconciler
+
+    user_dir = tmp_path / "user_A"
+    user_dir.mkdir()
+    cfg = user_dir / "openclaw.json"
+    cfg.write_text('{"models":{"providers":{}}}')
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+
+    from unittest.mock import AsyncMock
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=["user_A"]),
+    )
+
+    read_count = 0
+    original_open = open
+    def tracked_open(path, *a, **kw):
+        nonlocal read_count
+        if str(path).endswith("openclaw.json"):
+            read_count += 1
+        return original_open(path, *a, **kw)
+    monkeypatch.setattr("builtins.open", tracked_open)
+
+    # First tick — mtime unseen, should read.
+    await r._tick()
+    first_reads = read_count
+
+    # Second tick — mtime unchanged, should skip read.
+    await r._tick()
+    assert read_count == first_reads, "second tick must not re-read unchanged file"
+
+
+@pytest.mark.asyncio
+async def test_tick_handles_missing_config_file(tmp_path, monkeypatch):
+    from core.services.config_reconciler import ConfigReconciler
+    from unittest.mock import AsyncMock
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=["ghost_user"]),
+    )
+
+    # Should not raise.
+    await r._tick()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_reconciler.py -v -k mtime`
+Expected: FAIL (`list_active_owners` does not exist; `_tick` does nothing).
+
+- [ ] **Step 3: Add `list_active_owners` to container_repo**
+
+In `apps/backend/core/repositories/container_repo.py`, append:
+
+```python
+async def list_active_owners() -> list[str]:
+    """Return owner_ids for containers with status='running'. Used by the
+    config reconciler to enumerate targets.
+
+    Deliberately excludes 'provisioning' — during that phase the backend
+    itself is writing openclaw.json, and the reconciler must not race with
+    it. The reconciler starts caring once the container is fully running.
+    """
+    rows = await get_by_status("running")
+    return [r["owner_id"] for r in rows if "owner_id" in r]
+```
+
+- [ ] **Step 4: Add mtime-gated per-user check to reconciler**
+
+Replace the `_tick` method in `apps/backend/core/services/config_reconciler.py`:
+
+```python
+    async def _tick(self) -> None:
+        from core.repositories import container_repo
+
+        owners = await container_repo.list_active_owners()
+        if not owners:
+            return
+
+        sem = asyncio.Semaphore(20)
+
+        async def _one(owner_id: str):
+            async with sem:
+                try:
+                    await self._check_one(owner_id)
+                except Exception:
+                    logger.exception("config_reconciler failed for owner %s", owner_id)
+
+        await asyncio.gather(*[_one(o) for o in owners])
+
+    async def _check_one(self, owner_id: str) -> None:
+        import os
+
+        path = os.path.join(self._efs_mount, owner_id, "openclaw.json")
+        try:
+            mtime = await asyncio.to_thread(os.path.getmtime, path)
+        except FileNotFoundError:
+            # Container row says running but file not yet there; skip.
+            return
+
+        if self._last_seen_mtime.get(owner_id) == mtime:
+            return
+
+        # File changed (or first time seeing it); in this task, only record
+        # the mtime. Actual read + policy + revert lands in Task 11.
+        self._last_seen_mtime[owner_id] = mtime
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_reconciler.py tests/unit/repositories/test_container_repo_grace.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/backend/core/services/config_reconciler.py apps/backend/core/repositories/container_repo.py apps/backend/tests/unit/services/test_config_reconciler.py
+git commit -m "feat(config-reconciler): mtime-gated per-user check + list_active_owners helper"
+```
+
+---
+
+## Task 11: Reconciler — read, evaluate, and revert in enforce mode
+
+**Files:**
+- Modify: `apps/backend/core/services/config_reconciler.py`
+- Modify: `apps/backend/tests/unit/services/test_config_reconciler.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test_config_reconciler.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_tick_reverts_drift_in_enforce_mode(tmp_path, monkeypatch):
+    import json
+    from unittest.mock import AsyncMock
+
+    from core.containers.config import write_openclaw_config
+    from core.services.config_reconciler import ConfigReconciler
+
+    user = "user_drift"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg_path = udir / "openclaw.json"
+    # Start with a clean free-tier config, then mutate it in-file.
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    cfg_path.write_text(json.dumps(base, indent=2))
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr("core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE", "enforce", raising=False)
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    await r._tick()
+
+    on_disk = json.loads(cfg_path.read_text())
+    assert on_disk["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/minimax.minimax-m2.5"
+
+
+@pytest.mark.asyncio
+async def test_tick_report_mode_does_not_write(tmp_path, monkeypatch):
+    import json
+    from unittest.mock import AsyncMock
+
+    from core.containers.config import write_openclaw_config
+    from core.services.config_reconciler import ConfigReconciler
+
+    user = "user_report"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg_path = udir / "openclaw.json"
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    cfg_path.write_text(json.dumps(base, indent=2))
+    drift_mtime = cfg_path.stat().st_mtime
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr("core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE", "report", raising=False)
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    await r._tick()
+
+    # mtime unchanged → no write happened
+    assert cfg_path.stat().st_mtime == drift_mtime
+
+
+@pytest.mark.asyncio
+async def test_tick_honors_grace_window(tmp_path, monkeypatch):
+    import json
+    import time
+    from unittest.mock import AsyncMock
+
+    from core.containers.config import write_openclaw_config
+    from core.services.config_reconciler import ConfigReconciler
+
+    user = "user_grace"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg_path = udir / "openclaw.json"
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    cfg_path.write_text(json.dumps(base, indent=2))
+    pre_mtime = cfg_path.stat().st_mtime
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    monkeypatch.setattr("core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE", "enforce", raising=False)
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    # Grace is in the future → skip revert.
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=int(time.time()) + 30),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    await r._tick()
+    assert cfg_path.stat().st_mtime == pre_mtime
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_reconciler.py -v -k "enforce or report or grace"`
+Expected: FAIL (no tier lookup, no revert path).
+
+- [ ] **Step 3: Replace the reconciler body with the full implementation**
+
+Replace the entire contents of `apps/backend/core/services/config_reconciler.py`:
+
+```python
+"""Backend reconciliation loop for openclaw.json tier policy.
+
+Polls every active user's config on EFS at ~1s cadence, evaluates it
+against the tier policy (core.services.config_policy), and reverts drift
+on locked fields only. Non-locked fields are never touched.
+
+Ships in three modes via CONFIG_RECONCILER_MODE:
+  - off: reconciler never starts
+  - report: reads + evaluates + logs, never writes (rollout phase A)
+  - enforce: reads + evaluates + reverts (rollout phase B, steady state)
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+
+from core.config import settings
+from core.constants import SYSTEM_ACTOR_ID
+from core.observability.metrics import put_metric
+from core.repositories import billing_repo, container_repo
+from core.services import config_policy
+from core.services.config_patcher import _locked_rmw
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigReconciler:
+    def __init__(
+        self,
+        efs_mount: str,
+        tier_cache_ttl: float = 60.0,
+        tick_interval: float = 1.0,
+    ):
+        self._efs_mount = efs_mount
+        self._tier_cache_ttl = tier_cache_ttl
+        self._tick_interval = tick_interval
+        self._stop = asyncio.Event()
+        self._last_seen_mtime: dict[str, float] = {}
+        self._tier_cache: dict[str, tuple[str, float]] = {}
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    async def run_forever(self) -> None:
+        logger.info("config_reconciler started mode=%s", settings.CONFIG_RECONCILER_MODE)
+        while not self._stop.is_set():
+            try:
+                await self._tick()
+            except Exception:
+                logger.exception("config_reconciler tick failed")
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self._tick_interval)
+            except asyncio.TimeoutError:
+                pass
+        logger.info("config_reconciler stopped")
+
+    async def _tick(self) -> None:
+        if settings.CONFIG_RECONCILER_MODE == "off":
+            return
+        owners = await container_repo.list_active_owners()
+        if not owners:
+            return
+
+        sem = asyncio.Semaphore(20)
+
+        async def _one(owner_id: str):
+            async with sem:
+                try:
+                    await self._check_one(owner_id)
+                except Exception:
+                    logger.exception("config_reconciler failed for owner %s", owner_id)
+
+        started = time.monotonic()
+        await asyncio.gather(*[_one(o) for o in owners])
+        put_metric(
+            "config.reconciler.tick.duration",
+            value=(time.monotonic() - started) * 1000.0,
+            dimensions={"mode": settings.CONFIG_RECONCILER_MODE},
+        )
+
+    async def _check_one(self, owner_id: str) -> None:
+        path = os.path.join(self._efs_mount, owner_id, "openclaw.json")
+        try:
+            mtime = await asyncio.to_thread(os.path.getmtime, path)
+        except FileNotFoundError:
+            return
+
+        if self._last_seen_mtime.get(owner_id) == mtime:
+            return
+
+        tier = await self._resolve_tier(owner_id)
+        if tier is None:
+            # Fail-open: don't lock a user out of their own plan due to our DDB error.
+            return
+
+        grace_until = await container_repo.get_reconciler_grace(owner_id)
+        if grace_until > int(time.time()):
+            # Admin just wrote; don't fight them.
+            return
+
+        mode = settings.CONFIG_RECONCILER_MODE
+
+        if mode == "report":
+            # Read without a lock (we're not writing); evaluate; log.
+            try:
+                config = await asyncio.to_thread(_read_json, path)
+            except (OSError, json.JSONDecodeError) as e:
+                logger.warning("reconciler: failed to read %s: %s", path, e)
+                put_metric("config.reconciler.errors", dimensions={"kind": "read"})
+                return
+            violations = config_policy.evaluate(config, tier)
+            if violations:
+                put_metric("config.drift.reported", dimensions={"tier": tier})
+                logger.info(
+                    "reconciler(report) drift for owner=%s tier=%s fields=%s",
+                    owner_id, tier, [v["field"] for v in violations],
+                )
+            self._last_seen_mtime[owner_id] = mtime
+            return
+
+        if mode == "enforce":
+            reverted_fields: list[str] = []
+
+            def _mutate(current: dict) -> bool:
+                violations = config_policy.evaluate(current, tier)
+                if not violations:
+                    return False
+                reverted = config_policy.apply_reverts(current, violations)
+                current.clear()
+                current.update(reverted)
+                reverted_fields.extend(v["field"] for v in violations)
+                return True
+
+            try:
+                await _locked_rmw(owner_id, _mutate, "policy_revert")
+            except Exception as e:
+                logger.exception("reconciler: revert failed for owner=%s: %s", owner_id, e)
+                put_metric("config.reconciler.errors", dimensions={"kind": "revert"})
+                return
+
+            if reverted_fields:
+                put_metric("config.drift.reverted", dimensions={"tier": tier})
+                logger.info(
+                    "reconciler(enforce) reverted owner=%s tier=%s fields=%s",
+                    owner_id, tier, reverted_fields,
+                )
+                await _write_audit(owner_id, tier, reverted_fields)
+            # Mtime moved from our own write; refresh cache from the fresh stat.
+            try:
+                self._last_seen_mtime[owner_id] = await asyncio.to_thread(os.path.getmtime, path)
+            except FileNotFoundError:
+                self._last_seen_mtime.pop(owner_id, None)
+            return
+
+        # Unknown mode — behave as off.
+        logger.warning("unknown CONFIG_RECONCILER_MODE=%r, treating as off", mode)
+
+    async def _resolve_tier(self, owner_id: str) -> str | None:
+        cached = self._tier_cache.get(owner_id)
+        now = time.monotonic()
+        if cached and now - cached[1] < self._tier_cache_ttl:
+            return cached[0]
+        try:
+            account = await billing_repo.get_by_owner_id(owner_id)
+        except Exception:
+            logger.exception("reconciler: billing_repo lookup failed for owner=%s", owner_id)
+            put_metric("config.reconciler.errors", dimensions={"kind": "tier_lookup"})
+            return None
+        tier = (account or {}).get("plan_tier", "free")
+        self._tier_cache[owner_id] = (tier, now)
+        return tier
+
+
+def _read_json(path: str) -> dict:
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+async def _write_audit(owner_id: str, tier: str, fields: list[str]) -> None:
+    """Best-effort audit log; swallow failures (audit should never break the loop)."""
+    try:
+        from core.repositories import audit_log_repo  # type: ignore
+        await audit_log_repo.create(
+            actor_id=SYSTEM_ACTOR_ID,
+            action="config_policy_revert",
+            owner_id=owner_id,
+            metadata={"tier": tier, "fields": fields},
+        )
+    except Exception:
+        logger.debug("audit log write failed", exc_info=True)
+```
+
+- [ ] **Step 4: Confirm audit_log_repo exists (or stub its absence)**
+
+Run: `ls apps/backend/core/repositories/ | grep -i audit`
+
+If there's no `audit_log_repo.py`, the `_write_audit` call is already wrapped in a try/except that only logs at debug level — so nothing breaks. That's fine; a future task can formalize the audit write. Move on.
+
+- [ ] **Step 5: Run all reconciler and policy tests**
+
+Run: `cd apps/backend && uv run pytest tests/unit/services/test_config_reconciler.py tests/unit/services/test_config_policy.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/backend/core/services/config_reconciler.py apps/backend/tests/unit/services/test_config_reconciler.py
+git commit -m "feat(config-reconciler): read/evaluate/revert with enforce+report modes, tier cache, grace window"
+```
+
+---
+
+## Task 12: Integration test — real EFS path, real fcntl lock
+
+**Files:**
+- Create: `apps/backend/tests/integration/test_config_reconciliation.py`
+
+- [ ] **Step 1: Write the integration tests**
+
+Create `apps/backend/tests/integration/test_config_reconciliation.py`:
+
+```python
+"""Integration tests for the config reconciler against a real tmp filesystem
+and real fcntl.lockf locking (no mocks around the lock/IO layer).
+
+These catch bugs that unit mocks miss: lock semantics, atomic rename,
+concurrent writer races.
+"""
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.containers.config import write_openclaw_config
+from core.services.config_reconciler import ConfigReconciler
+
+
+@pytest.mark.asyncio
+async def test_reconciler_reverts_drift_end_to_end(tmp_path, monkeypatch):
+    user = "user_e2e"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg = udir / "openclaw.json"
+    base = json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    base["agents"]["defaults"]["model"]["primary"] = "amazon-bedrock/qwen.qwen3-vl-235b-a22b"
+    base["channels"]["telegram"]["accounts"] = {"bot1": {"botToken": "x"}}
+    cfg.write_text(json.dumps(base, indent=2))
+
+    # Patch the module-level _efs_mount_path used inside _locked_rmw.
+    monkeypatch.setattr("core.services.config_patcher._efs_mount_path", str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "enforce",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    r = ConfigReconciler(efs_mount=str(tmp_path), tick_interval=0.1)
+    await r._tick()
+
+    restored = json.loads(cfg.read_text())
+    assert restored["agents"]["defaults"]["model"]["primary"] == "amazon-bedrock/minimax.minimax-m2.5"
+    assert restored["channels"]["telegram"]["accounts"] == {}
+
+
+@pytest.mark.asyncio
+async def test_reconciler_serializes_with_config_patcher(tmp_path, monkeypatch):
+    """Fire a reconciler tick and a config_patcher patch in parallel.
+    The result must be a single valid JSON file (no interleaved writes)."""
+    import json as _json
+    from core.services import config_patcher
+
+    user = "user_par"
+    udir = tmp_path / user
+    udir.mkdir()
+    cfg = udir / "openclaw.json"
+    base = _json.loads(write_openclaw_config(gateway_token="t", tier="free"))
+    cfg.write_text(_json.dumps(base, indent=2))
+
+    monkeypatch.setattr("core.services.config_patcher._efs_mount_path", str(tmp_path))
+    monkeypatch.setattr(
+        "core.services.config_reconciler.settings.CONFIG_RECONCILER_MODE",
+        "enforce",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.list_active_owners",
+        AsyncMock(return_value=[user]),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.container_repo.get_reconciler_grace",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        "core.services.config_reconciler.billing_repo.get_by_owner_id",
+        AsyncMock(return_value={"plan_tier": "free"}),
+    )
+
+    r = ConfigReconciler(efs_mount=str(tmp_path))
+    await asyncio.gather(
+        r._tick(),
+        config_patcher.patch_openclaw_config(user, {"tools": {"web": {"fetch": {"enabled": False}}}}),
+    )
+
+    # File must still parse and contain both changes' non-conflicting pieces.
+    result = _json.loads(cfg.read_text())
+    assert result["tools"]["web"]["fetch"]["enabled"] is False
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd apps/backend && uv run pytest tests/integration/test_config_reconciliation.py -v`
+Expected: Both tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/backend/tests/integration/test_config_reconciliation.py
+git commit -m "test(config-reconciler): end-to-end + fcntl-lock concurrency integration tests"
+```
+
+---
+
+## Task 13: Router — swap `routers/config.py` to use policy module
+
+**Files:**
+- Modify: `apps/backend/routers/config.py`
+- Modify: `apps/backend/tests/unit/routers/test_config_router.py`
+
+- [ ] **Step 1: Update existing tests for new error shape**
+
+Open `apps/backend/tests/unit/routers/test_config_router.py`.
+
+Replace `test_patch_config_free_tier_channels_rejected` (around line 94-106) with:
+
+```python
+def test_patch_config_free_tier_channels_rejected(client):
+    cleanup = _patch_auth(_personal_auth())
+    try:
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch("routers.config.read_openclaw_config_from_efs", AsyncMock(return_value={
+                "channels": {"telegram": {"enabled": True, "dmPolicy": "pairing"}},
+                "models": {"providers": _free_providers()},
+                "agents": {"defaults": {"model": {"primary": "amazon-bedrock/minimax.minimax-m2.5"}, "models": {"amazon-bedrock/minimax.minimax-m2.5": {"alias": "MiniMax M2.5"}}}},
+            })),
+            _mock_billing("free"),
+        ):
+            resp = client.patch(
+                "/api/v1/config",
+                json={"patch": {"channels": {"telegram": {"accounts": {"a": {"botToken": "x"}}}}}},
+            )
+        assert resp.status_code == 403
+        detail = resp.json().get("detail", {})
+        assert detail.get("code") == "policy_violation"
+        assert "channels.accounts" in detail.get("fields", [])
+        mock_patch.assert_not_called()
+    finally:
+        cleanup()
+```
+
+At the top of the test file, after the imports, add the helper:
+
+```python
+def _free_providers():
+    from core.containers.config import _models_for_tier
+    return {
+        "amazon-bedrock": {
+            "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "api": "bedrock-converse-stream",
+            "auth": "aws-sdk",
+            "models": _models_for_tier("free"),
+        },
+    }
+```
+
+- [ ] **Step 2: Add new tests for model/provider enforcement**
+
+Append to `test_config_router.py`:
+
+```python
+def test_patch_config_rejects_unauthorized_provider_any_tier(client):
+    cleanup = _patch_auth(_personal_auth())
+    try:
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch("routers.config.read_openclaw_config_from_efs", AsyncMock(return_value={
+                "models": {"providers": _free_providers()},
+                "agents": {"defaults": {"model": {"primary": "amazon-bedrock/minimax.minimax-m2.5"}, "models": {"amazon-bedrock/minimax.minimax-m2.5": {"alias": "MiniMax M2.5"}}}},
+            })),
+            _mock_billing("pro"),
+        ):
+            resp = client.patch(
+                "/api/v1/config",
+                json={"patch": {"models": {"providers": {"openai": {"api": "openai", "baseUrl": "x", "models": []}}}}},
+            )
+        assert resp.status_code == 403
+        detail = resp.json().get("detail", {})
+        assert detail.get("code") == "policy_violation"
+        assert "models.providers" in detail.get("fields", [])
+        mock_patch.assert_not_called()
+    finally:
+        cleanup()
+
+
+def test_patch_config_accepts_non_locked_field_change(client):
+    cleanup = _patch_auth(_personal_auth())
+    try:
+        with (
+            patch("routers.config.patch_openclaw_config", AsyncMock()) as mock_patch,
+            patch("routers.config.read_openclaw_config_from_efs", AsyncMock(return_value={
+                "models": {"providers": _free_providers()},
+                "agents": {"defaults": {"model": {"primary": "amazon-bedrock/minimax.minimax-m2.5"}, "models": {"amazon-bedrock/minimax.minimax-m2.5": {"alias": "MiniMax M2.5"}}}},
+            })),
+            _mock_billing("free"),
+        ):
+            resp = client.patch(
+                "/api/v1/config",
+                json={"patch": {"tools": {"web": {"search": {"enabled": False}}}}},
+            )
+        assert resp.status_code == 200
+        mock_patch.assert_awaited_once()
+    finally:
+        cleanup()
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/routers/test_config_router.py -v`
+Expected: New and updated tests FAIL (router still uses the old check).
+
+- [ ] **Step 4: Swap the router implementation**
+
+Replace the `patch_config` endpoint body in `apps/backend/routers/config.py` (currently lines ~102-138) with:
+
+```python
+@router.patch(
+    "",
+    summary="Patch the caller's openclaw.json config",
+    description=(
+        "Deep-merges the patch into the caller's owner_id openclaw.json on EFS. "
+        "Derives owner_id from auth context (org_id if org, else user_id). "
+        "Requires org_admin for org callers. Tier-gates locked fields via config_policy."
+    ),
+)
+async def patch_config(
+    body: ConfigPatchBody,
+    auth: AuthContext = Depends(get_current_user),
+):
+    require_org_admin(auth)
+    owner_id = resolve_owner_id(auth)
+
+    # Resolve tier and simulate the merged config to apply policy to the
+    # final state, not to the isolated patch (which might only toggle a
+    # scaffold flag while keeping the locked field legal).
+    account = await billing_repo.get_by_owner_id(owner_id)
+    tier = account.get("plan_tier", "free") if isinstance(account, dict) else "free"
+
+    current = await read_openclaw_config_from_efs(owner_id) or {}
+    merged = _deep_merge_for_policy(current, body.patch)
+
+    from core.services import config_policy
+
+    violations = config_policy.evaluate(merged, tier)
+    if violations:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "policy_violation",
+                "fields": [v["field"] for v in violations],
+                "reason": violations[0]["reason"],
+            },
+        )
+
+    # Bot-token collision pre-check (channels-specific; runs only if patch touches channels).
+    if _patch_touches_channels(body.patch):
+        await _check_token_collision(owner_id, body.patch)
+
+    try:
+        await patch_openclaw_config(owner_id, body.patch)
+    except ConfigPatchError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    return {"status": "patched", "owner_id": owner_id}
+
+
+def _deep_merge_for_policy(base: dict, patch: dict) -> dict:
+    """Local deep-merge matching config_patcher._deep_merge semantics —
+    dicts merge recursively, non-dict values replace. Kept local to avoid
+    importing a private helper."""
+    import copy
+
+    result = copy.deepcopy(base) if not isinstance(base, dict) else dict(base)
+    if not isinstance(patch, dict):
+        return patch
+    for k, v in patch.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _deep_merge_for_policy(result[k], v)
+        else:
+            import copy as _c
+            result[k] = _c.deepcopy(v)
+    return result
+```
+
+Keep the existing `_patch_touches_channels` and `_check_token_collision` helpers — they still run for the collision check. Do NOT keep the old tier-gate channel block; `config_policy.evaluate` now handles it.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/routers/test_config_router.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/backend/routers/config.py apps/backend/tests/unit/routers/test_config_router.py
+git commit -m "refactor(routers/config): delegate locked-field enforcement to config_policy"
+```
+
+---
+
+## Task 14: Admin patch endpoints set grace window
+
+**Files:**
+- Modify: `apps/backend/routers/updates.py`
+- Create: `apps/backend/tests/unit/routers/test_updates_grace.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/backend/tests/unit/routers/test_updates_grace.py`:
+
+```python
+"""Tests for admin-patch grace window on routers/updates.py."""
+import os
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from main import app
+    return TestClient(app)
+
+
+def _patch_auth():
+    from core.auth import AuthContext, get_current_user
+    from main import app
+    app.dependency_overrides[get_current_user] = lambda: AuthContext(user_id="u_admin")
+    return lambda: app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_admin_single_config_patch_sets_grace(client):
+    cleanup = _patch_auth()
+    try:
+        with (
+            patch("routers.updates.patch_openclaw_config", AsyncMock()),
+            patch("routers.updates.container_repo.set_reconciler_grace", AsyncMock()) as set_grace,
+        ):
+            resp = client.patch("/api/v1/container/config/owner_1", json={"patch": {"tools": {}}})
+        assert resp.status_code == 200
+        set_grace.assert_awaited_once_with("owner_1", seconds=5)
+    finally:
+        cleanup()
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd apps/backend && uv run pytest tests/unit/routers/test_updates_grace.py -v`
+Expected: FAIL (grace isn't set).
+
+- [ ] **Step 3: Update `patch_single_config` in `routers/updates.py`**
+
+In `apps/backend/routers/updates.py`, update the import line near the top:
+
+```python
+from core.repositories import container_repo, update_repo
+```
+
+Then modify `patch_single_config` (around line 148) to set the grace before the patch:
+
+```python
+async def patch_single_config(
+    owner_id: str,
+    body: ConfigPatchRequest,
+    auth: AuthContext = Depends(get_current_user),
+):
+    if auth.is_org_context:
+        require_org_admin(auth)
+
+    # Tell the reconciler to stand down for 5s while we apply an admin override.
+    await container_repo.set_reconciler_grace(owner_id, seconds=5)
+
+    try:
+        await patch_openclaw_config(owner_id, body.patch)
+    except ConfigPatchError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    put_metric("update.config_patch.applied", dimensions={"scope": "single"})
+    return {"status": "patched", "owner_id": owner_id, "keys": list(body.patch.keys())}
+```
+
+Do the same inside the fleet patch loop (`patch_fleet_config`, around line 171 — for each `oid` iterated):
+
+```python
+    for oid in owners:
+        try:
+            await container_repo.set_reconciler_grace(oid, seconds=5)
+            await patch_openclaw_config(oid, body.patch)
+            patched += 1
+        except ConfigPatchError:
+            failed += 1
+            logger.warning("Skipped config patch for owner %s (no config file)", oid)
+        except Exception:
+            failed += 1
+            logger.exception("Failed to patch config for owner %s", oid)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/routers/test_updates_grace.py tests/unit/routers/test_config_router.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/routers/updates.py apps/backend/tests/unit/routers/test_updates_grace.py
+git commit -m "feat(routers/updates): set reconciler grace window on admin config patches"
+```
+
+---
+
+## Task 15: Lifespan — start reconciler in `main.py`
+
+**Files:**
+- Modify: `apps/backend/main.py`
+
+- [ ] **Step 1: Add startup + shutdown hooks**
+
+In `apps/backend/main.py`, modify the `lifespan` async context manager (currently around lines 44-80):
+
+Add this block inside `lifespan` right after the `idle_checker_task = asyncio.create_task(_safe_idle_checker())` line (around line 64):
+
+```python
+    from core.services.config_reconciler import ConfigReconciler
+
+    reconciler = ConfigReconciler(efs_mount=settings.EFS_MOUNT_PATH)
+
+    async def _safe_reconciler():
+        if settings.CONFIG_RECONCILER_MODE == "off":
+            logger.info("config_reconciler disabled (CONFIG_RECONCILER_MODE=off)")
+            return
+        try:
+            await reconciler.run_forever()
+        except Exception:
+            logger.exception("config_reconciler crashed")
+
+    reconciler_task = asyncio.create_task(_safe_reconciler())
+```
+
+And add the shutdown block before `await shutdown_containers()` (around line 80):
+
+```python
+    reconciler.stop()
+    try:
+        await reconciler_task
+    except asyncio.CancelledError:
+        pass
+```
+
+- [ ] **Step 2: Verify startup logs**
+
+Run: `cd apps/backend && uv run python -c "from main import app; print('ok')"`
+Expected: prints `ok` with no exceptions.
+
+- [ ] **Step 3: Quick smoke: import reconciler module**
+
+Run: `cd apps/backend && uv run python -c "from core.services.config_reconciler import ConfigReconciler; r = ConfigReconciler('/tmp'); print(r)"`
+Expected: prints the reconciler object, no import errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/backend/main.py
+git commit -m "feat(main): start config reconciler in lifespan task"
+```
+
+---
+
+## Task 16: Fleet cleanup script
+
+**Files:**
+- Create: `apps/backend/scripts/reconcile_all_configs.py`
+
+- [ ] **Step 1: Write the script**
+
+Create `apps/backend/scripts/reconcile_all_configs.py`:
+
+```python
+"""One-shot fleet cleanup for config policy drift.
+
+Runs synchronously. Walks every active container, evaluates its openclaw.json
+against the tier policy, and reverts drift on locked fields. Prints a
+summary report at the end.
+
+Usage (from apps/backend/):
+    uv run python scripts/reconcile_all_configs.py [--dry-run]
+
+Dry-run prints what WOULD be reverted without writing. Use before flipping
+CONFIG_RECONCILER_MODE to enforce to confirm the blast radius.
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+
+from core.config import settings
+from core.containers.config import read_openclaw_config_from_efs
+from core.repositories import billing_repo, container_repo
+from core.services import config_policy
+from core.services.config_patcher import _locked_rmw
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("reconcile_all")
+
+
+async def reconcile_owner(owner_id: str, dry_run: bool) -> tuple[str, list[str]]:
+    account = await billing_repo.get_by_owner_id(owner_id)
+    tier = account.get("plan_tier", "free") if isinstance(account, dict) else "free"
+
+    config = await read_openclaw_config_from_efs(owner_id)
+    if config is None:
+        return ("no_config", [])
+
+    violations = config_policy.evaluate(config, tier)
+    if not violations:
+        return ("clean", [])
+
+    fields = [v["field"] for v in violations]
+    if dry_run:
+        return ("would_revert", fields)
+
+    def _mutate(current: dict) -> bool:
+        vs = config_policy.evaluate(current, tier)
+        if not vs:
+            return False
+        reverted = config_policy.apply_reverts(current, vs)
+        current.clear()
+        current.update(reverted)
+        return True
+
+    await _locked_rmw(owner_id, _mutate, "fleet_cleanup")
+    return ("reverted", fields)
+
+
+async def main(dry_run: bool) -> None:
+    owners = await container_repo.list_active_owners()
+    logger.info("found %d active containers", len(owners))
+
+    counts = {"clean": 0, "no_config": 0, "would_revert": 0, "reverted": 0, "error": 0}
+    for owner_id in owners:
+        try:
+            status, fields = await reconcile_owner(owner_id, dry_run)
+            counts[status] = counts.get(status, 0) + 1
+            if fields:
+                logger.info("%s owner=%s fields=%s", status, owner_id, fields)
+        except Exception as e:
+            counts["error"] += 1
+            logger.exception("error on owner=%s: %s", owner_id, e)
+
+    logger.info("summary: %s", counts)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="Report what would be reverted, do not write.")
+    args = parser.parse_args()
+    asyncio.run(main(dry_run=args.dry_run))
+```
+
+- [ ] **Step 2: Verify it imports cleanly**
+
+Run: `cd apps/backend && uv run python -c "import scripts.reconcile_all_configs as m; print(m.__doc__[:60])"`
+Expected: prints the first ~60 chars of the docstring, no import error.
+
+- [ ] **Step 3: Run against empty local (expect no-op summary)**
+
+If you have a local backend mount available, run:
+`cd apps/backend && EFS_MOUNT_PATH=/tmp/empty uv run python scripts/reconcile_all_configs.py --dry-run`
+Expected: prints `found 0 active containers` (assuming local DDB has no containers) and `summary: {'clean': 0, ...}`.
+
+If you don't have a local env configured, skip this — the script is tested transitively by the reconciler unit + integration tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/backend/scripts/reconcile_all_configs.py
+git commit -m "feat(scripts): one-shot fleet reconciliation with --dry-run"
+```
+
+---
+
+## Task 17: E2E — Playwright test for agent-driven drift revert
+
+**Files:**
+- Modify: `apps/frontend/tests/e2e/` (exact test file naming follows existing conventions — check `apps/frontend/tests/e2e/` for patterns first)
+
+- [ ] **Step 1: Locate the existing E2E test directory**
+
+Run: `ls apps/frontend/tests/e2e/ 2>/dev/null || ls apps/frontend/e2e/ 2>/dev/null || find apps/frontend -name '*.spec.ts' -type f | head -10`
+
+Note the naming convention and any helpers used (e.g. login fixture, agent-chat page object).
+
+- [ ] **Step 2: Write the failing test**
+
+Create (or append to the appropriate existing file) an e2e test following the existing conventions. Minimum coverage:
+
+```typescript
+// Near existing e2e specs, e.g. apps/frontend/tests/e2e/config-policy.spec.ts
+import { test, expect } from "@playwright/test";
+
+test("agent config edits to non-locked fields persist", async ({ page }) => {
+  // Login + navigate to chat. Use your existing test-login fixture.
+  await loginAsTestUser(page);
+  await page.goto("/chat");
+
+  // Ask agent to add a cron job (non-locked field).
+  await page.getByPlaceholder(/message your agent/i).fill(
+    "Please add a cron job that runs daily at 9am. Just confirm you've done it."
+  );
+  await page.keyboard.press("Enter");
+
+  // Wait for the agent's response confirming the change.
+  await expect(page.getByText(/cron|scheduled|added/i)).toBeVisible({ timeout: 60_000 });
+
+  // Small wait past the reconciler tick so any revert would have fired.
+  await page.waitForTimeout(2500);
+
+  // Re-open the config panel; confirm cron is still there.
+  await page.getByRole("button", { name: /config|settings/i }).click();
+  await expect(page.getByText(/cron/i)).toBeVisible();
+});
+
+test("agent attempt to switch primary model gets reverted", async ({ page }) => {
+  await loginAsTestUser(page);
+  await page.goto("/chat");
+
+  await page.getByPlaceholder(/message your agent/i).fill(
+    "Switch your primary model to amazon-bedrock/qwen.qwen3-vl-235b-a22b and confirm."
+  );
+  await page.keyboard.press("Enter");
+
+  // Wait for the agent's attempt to resolve.
+  await page.waitForTimeout(5_000);
+
+  // Send a follow-up — the reconciler should have reverted the primary by now.
+  // We verify via the gateway RPC snapshot if the UI exposes it, OR by asking
+  // the agent which model it's about to use. (Pick whichever matches your
+  // existing E2E conventions — both are valid.)
+
+  await page.getByPlaceholder(/message your agent/i).fill(
+    "What model are you currently using as your primary?"
+  );
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByText(/minimax/i)).toBeVisible({ timeout: 60_000 });
+});
+```
+
+Replace `loginAsTestUser` with the project's existing login helper.
+
+- [ ] **Step 3: Run the test**
+
+Run: `cd apps/frontend && pnpm run test:e2e`
+Expected: Both tests PASS against a deployment with `CONFIG_RECONCILER_MODE=enforce`.
+
+Note: These E2E tests implicitly depend on the reconciler being in `enforce` mode. In CI, ensure the test env has `CONFIG_RECONCILER_MODE=enforce` set; in other environments they're expected to be skipped or run against a staging deploy with the mode enabled.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/frontend/tests/e2e/config-policy.spec.ts
+git commit -m "test(e2e): config policy enforcement (non-locked persists, locked reverts)"
+```
+
+---
+
+## Task 18: Rollout — phase A deploy, phase B enforce
+
+This is the deploy/ops task, not a code task. Checklist for the operator:
+
+- [ ] **Step 1: Deploy with `CONFIG_RECONCILER_MODE=report`**
+
+Set `CONFIG_RECONCILER_MODE=report` in the backend service env (CDK service-stack or wherever env vars live for the backend ECS service). Deploy.
+
+- [ ] **Step 2: Observe ~24 hours of `report`-mode telemetry**
+
+Check CloudWatch for:
+- `config.drift.reported` metric emission — any owner drifts?
+- `config.reconciler.tick.duration` — loop latency at real fleet size (should be well under the 1s interval)
+- `config.reconciler.errors` by `kind` — should be near-zero
+
+Investigate any spikes. False positives (legal configs flagged as illegal) must be fixed in `config_policy.evaluate` before advancing.
+
+- [ ] **Step 3: Run the fleet cleanup script (dry-run first)**
+
+```bash
+cd apps/backend && uv run python scripts/reconcile_all_configs.py --dry-run
+```
+
+Review the report. If blast radius is acceptable, run for real:
+
+```bash
+cd apps/backend && uv run python scripts/reconcile_all_configs.py
+```
+
+- [ ] **Step 4: Flip `CONFIG_RECONCILER_MODE=enforce` and redeploy**
+
+After the cleanup run, flip the env var and redeploy. Post-flip, monitor:
+- `config.drift.reverted` by `tier` — expected to be near-zero on steady state; spikes indicate agent tampering attempts.
+- Support tickets / user reports of "my agent can't change X" — confirm that X is a non-locked field (should never happen by design).
+
+---
+
+## Spec coverage check
+
+Every requirement from the spec maps to a task:
+
+- `core/services/config_policy.py` → Tasks 1-6
+- `core/services/config_reconciler.py` → Tasks 9-11 (+12 integration)
+- `routers/config.py` shared policy → Task 13
+- `routers/updates.py` admin grace → Task 14
+- `main.py` lifespan → Task 15
+- `core/config.py` `CONFIG_RECONCILER_MODE` → Task 8
+- `scripts/reconcile_all_configs.py` → Task 16
+- `containers.reconciler_grace_until` DDB field → Task 7
+- Unit tests (policy) → Tasks 1-6
+- Unit tests (reconciler) → Tasks 9-11
+- Integration tests → Task 12
+- API tests → Task 13
+- E2E tests → Task 17
+- Rollout phase A / B → Task 18
+
+No spec items left unimplemented.

--- a/docs/superpowers/specs/2026-04-14-config-protection-design.md
+++ b/docs/superpowers/specs/2026-04-14-config-protection-design.md
@@ -1,0 +1,364 @@
+# Config Protection Design
+
+**Date:** 2026-04-14
+**Status:** Design approved, ready for implementation plan
+**Scope:** Prevent agents from bypassing tier-based restrictions on `openclaw.json`, regardless of the write path (gateway RPC, generic file tools, bash)
+
+## Problem
+
+Each user's OpenClaw container writes its own `openclaw.json` on EFS at `/mnt/efs/users/{user_id}/openclaw.json`. The agent inside the container has **two paths** to mutate this file, and both bypass the backend's tier enforcement at `routers/config.py:121-128`:
+
+1. **Gateway RPC.** The LLM-callable `gateway` tool (`src/agents/tools/gateway-tool.ts:159-324`) exposes `config.patch` and `config.apply` actions. These wrap the gateway's `config.patch` RPC (`src/gateway/server-methods/config.ts:464-`), which validates against the config schema but has no per-field tier policy — it will write any schema-valid JSON the agent produces. The RPC is local to the container (loopback to the gateway); our backend does not see it.
+
+2. **Direct file write.** The agent's general-purpose `write`/`edit` tools can write `openclaw.json` directly without going through any RPC. Even if we intercepted the gateway RPC, this path remains.
+
+OpenClaw hot-reloads on file change either way. Both paths terminate in the same place (an on-disk JSON file) — so the enforcement point has to be at the file, not at either specific write path.
+
+Two fields must be policy-enforced regardless of write path:
+
+- **`models.providers`** (and dependent `agents.defaults.model.primary` / `agents.defaults.models`) — locked for everyone. Prevents agents from switching to unauthorized Bedrock models or adding entire new providers.
+- **`channels.{provider}.accounts`** — locked to empty for free tier only. Prevents free-tier users from configuring Telegram/Discord/Slack bots.
+
+Everything else in `openclaw.json` — `tools`, `hooks`, `memory`, `cron`, plugin configs, non-locked channel flags, OpenClaw's runtime `meta` block — remains freely agent-mutable. Agent-as-config-author is a deliberate product value.
+
+## Constraints investigated and ruled out
+
+**POSIX file permissions.** Could make `openclaw.json` root-owned + read-only to the container. Rejected: POSIX operates at whole-file granularity; the agent's legitimate edits (tools, hooks, memory, etc.) would also fail. Breaks the core product value.
+
+**OpenClaw `tools.fs.workspaceOnly: true`.** Confines `read`/`write`/`edit` tools to the agent workspace dir, which *would* make `openclaw.json` unreachable — but it's all-or-nothing: agent also loses access to its own config. Same failure mode as POSIX.
+
+**OpenClaw `exec-approvals` socket.** Real-time JSONL approval gate (`src/infra/exec-approvals.ts:983-1013`). Only covers shell command execution, not file writes via `write`/`edit`. Doesn't solve the primary attack path.
+
+**Intercepting the `config.patch` gateway RPC.** The agent's `gateway` tool routes through a local loopback RPC; our backend's `GatewayConnectionPool` doesn't see that traffic. We could add a proxy inside the container or patch the gateway handler to call out for authorization, but both require OpenClaw modifications or container-side shims. Even with this layer, the direct-file-write path still bypasses it. The file is the only common choke point, so reconciliation is strictly more general.
+
+**OpenClaw layered/overlay config.** Not supported (`src/config/paths.ts:23-24` loads a single file).
+
+**EFS byte-range locks (`fcntl`/`flock`).** Advisory locks only; non-cooperating writer (`echo > openclaw.json`) bypasses. Not an access-control mechanism.
+
+**Forking OpenClaw.** Ruled out as too-heavy maintenance cost for this use case. We consume `alpine/openclaw` from Docker Hub.
+
+## Approach: backend reconciliation
+
+The backend runs a per-user polling loop that re-reads each active user's `openclaw.json`, evaluates it against a tier-aware policy, and reverts drift on locked fields only. Reaction time ~1 second. Non-locked fields are never touched.
+
+Defense-in-depth layers:
+
+| Layer | Mechanism | Closes |
+|-------|-----------|--------|
+| 1 | Backend API policy (`routers/config.py`) | Frontend/admin PATCH path writing forbidden fields |
+| 2 | Backend reconciler loop | Agent bypassing the API by writing the file directly |
+| 3 | Audit logs + metrics | Observability into drift attempts |
+
+Race window: a forbidden config is live for at most ~1 second between agent write and reconciler revert. For model changes, any usage during that window is metered by the existing usage poller and billed accordingly. For free-tier channel attempts, configuring a channel also requires a bot token + pairing flow that free-tier UI doesn't expose, so the 1-second window has no practical attack value.
+
+## Architecture
+
+```
+  OpenClaw container (agent writes openclaw.json)
+        │
+        ▼
+    EFS: /mnt/efs/users/{uid}/openclaw.json   (mtime updated)
+        │
+        ▼ (polled every ~1s)
+  ConfigReconciler
+        │
+        ├─ mtime unchanged?  ─── yes ──▶ skip
+        │                        no
+        │                        ▼
+        │                   fcntl.lockf EX
+        │                        │
+        │                        ▼
+        │                 read + parse JSON
+        │                        │
+        │                        ▼
+        │           config_policy.evaluate(config, tier)
+        │                        │
+        │           ┌────────────┴───────────┐
+        │           │ no violations          │ violations
+        │           ▼                        ▼
+        │       skip write             apply_reverts(config, violations)
+        │                                    │
+        │                                    ▼
+        │                           atomic write + chown 1000:1000
+        │                                    │
+        │                                    ▼
+        │                          audit log + metric
+        │                                    │
+        ▼                                    ▼
+   release lock                       release lock
+```
+
+### Components
+
+Two new files under `apps/backend/core/services/`:
+
+- **`config_policy.py`** — pure, side-effect-free policy module. No IO, no DB. Tier + config dict → list of violations. Reverts compute the authoritative expected value from existing helpers in `core/containers/config.py`.
+- **`config_reconciler.py`** — asyncio task, runs as a FastAPI lifespan background task alongside `usage_poller.py`. Polls, locks, reconciles.
+
+Modifications to existing files:
+
+- **`routers/config.py`** — replace the custom `_patch_touches_channels` check with `config_policy.evaluate` on the merged result. One source of truth for policy.
+- **`routers/updates.py`** — admin `PATCH /container/config/{owner_id}` and fleet patch set a DDB grace field `containers.reconciler_grace_until = now + 5s` so the reconciler doesn't immediately revert admin overrides.
+- **`main.py`** — start the reconciler in the lifespan handler.
+- **`core/config.py`** — add `CONFIG_RECONCILER_MODE` setting with values `off | report | enforce`.
+
+New one-shot script:
+
+- **`scripts/reconcile_all_configs.py`** — walks every active container and synchronously reconciles. Used during initial rollout and as a manual recovery tool.
+
+## Policy module (`config_policy.py`)
+
+### Public interface
+
+```python
+from typing import Any, Literal, TypedDict
+
+LockedField = Literal[
+    "models.providers",
+    "agents.defaults.models",
+    "agents.defaults.model.primary",
+    "channels.accounts",
+]
+
+class PolicyViolation(TypedDict):
+    field: LockedField
+    reason: str          # human-readable, for logs + audit
+    expected: Any        # revert target
+    actual: Any          # what drift produced
+
+def evaluate(config: dict, tier: str) -> list[PolicyViolation]: ...
+
+def apply_reverts(config: dict, violations: list[PolicyViolation]) -> dict: ...
+```
+
+`evaluate()` returns an empty list if the config is legal. `apply_reverts()` deep-copies the input, overwrites only the violating fields with their expected values, and returns the result. All other keys (including OpenClaw's `meta` block) are preserved untouched.
+
+### Expected-config computation
+
+Reuses existing helpers to keep one source of truth for "what's allowed per tier":
+
+- `_models_for_tier(tier)` — `core/containers/config.py:197-204`
+- `_agent_models_for_tier(tier, primary)` — `core/containers/config.py:207-220`
+- `_TIER_ALLOWED_MODEL_IDS` — `core/containers/config.py:178-194`
+- `TIER_CONFIG` — `core/config.py`
+
+### Violation rules
+
+"Paid" means `starter`, `pro`, or `enterprise`. Unknown tier strings fall through to free (matches the default-deny posture in `_models_for_tier`).
+
+| Field | Free | Paid | Revert target |
+|-------|------|------|---------------|
+| `models.providers` | `{"amazon-bedrock": {...free models only}}` | `{"amazon-bedrock": {...tier models}}` | Computed from `_models_for_tier(tier)` |
+| `agents.defaults.models` keys | subset of tier allowlist | subset of tier allowlist | Filter out unauthorized entries, add primary |
+| `agents.defaults.model.primary` | `TIER_CONFIG.free.primary_model` | any ID in tier allowlist | `TIER_CONFIG[tier].primary_model` |
+| `channels.{p}.accounts` | empty `{}` or missing | no check | `{}` |
+
+### Deliberate non-enforcements
+
+Agent may modify these without triggering reverts:
+
+- `channels.{p}.enabled`, `channels.{p}.dmPolicy` — scaffold flags. No accounts = no risk.
+- `plugins.entries.amazon-bedrock.config.discovery` — controls plugin-side auto-discovery; doesn't expand what our IAM role can invoke.
+- `plugins.entries` for non-provider plugins (perplexity, etc.)
+- Top-level: `tools`, `hooks`, `memory`, `cron`, `browser`, `web`, `session`, `update`, `meta`, `skills`, `agents.defaults.workspace`, etc.
+
+## Reconciler loop (`config_reconciler.py`)
+
+### Structure
+
+```python
+class ConfigReconciler:
+    def __init__(self, efs_mount: str, tier_cache_ttl: float = 60.0):
+        self._stop = asyncio.Event()
+        self._last_seen_mtime: dict[str, float] = {}
+        self._tier_cache: dict[str, tuple[str, float]] = {}
+
+    async def run_forever(self) -> None:
+        while not self._stop.is_set():
+            try:
+                await self._tick()
+            except Exception:
+                logger.exception("reconciler tick failed")
+            await asyncio.wait([asyncio.create_task(self._stop.wait())], timeout=1.0)
+```
+
+### Per-user check
+
+Two-phase for efficiency:
+
+**Phase 1 — cheap mtime gate (no parse, no lock):**
+
+```python
+try:
+    mtime = await asyncio.to_thread(os.path.getmtime, config_path)
+except FileNotFoundError:
+    return  # container not yet provisioned
+if mtime == self._last_seen_mtime.get(owner_id):
+    return  # unchanged, skip
+```
+
+**Phase 2 — locked read + policy check + conditional revert:**
+
+```python
+def _mutate(current: dict) -> bool:
+    violations = config_policy.evaluate(current, tier)
+    if not violations:
+        return False  # no write needed
+    reverted = config_policy.apply_reverts(current, violations)
+    current.clear()
+    current.update(reverted)
+    return True
+
+await config_patcher._locked_rmw(owner_id, _mutate, "policy_revert")
+```
+
+### Reused primitives
+
+- `config_patcher._locked_rmw` (`config_patcher.py:35-98`) — handles `fcntl.lockf` EX lock, atomic temp+rename, backup, chown to uid 1000. Zero new locking code.
+- `container_repo.list_active_owners()` (new helper) — scans DDB `containers` table for `status = "running"` only. Owners in `provisioning` are excluded because the backend is actively writing `openclaw.json` during that phase (see Container provisioning race below). Owners with no container don't need reconciliation.
+
+### Tier cache
+
+Per-owner cache with 60s TTL. Billing changes (upgrade/downgrade) propagate within 60s + 1s poll. Cache miss → single DDB read from `billing-accounts` table.
+
+### Admin grace window
+
+Before reverting, reconciler checks `containers.reconciler_grace_until` in DDB. If current time < grace timestamp, skip this cycle. Set by admin patch endpoints to `now + 5s`.
+
+### Concurrency
+
+- At most one tick per second per user.
+- Fleet parallelization via `asyncio.Semaphore(20)`.
+- Admin `PATCH /config` and reconciler serialize through `_locked_rmw`'s `fcntl.lockf` EX lock.
+- Agent writes compete via POSIX; any write during the reconciler's lock is flushed after unlock, picked up on the next tick.
+
+### Failure modes
+
+| Failure | Behavior |
+|---------|----------|
+| Container dir missing | Skip silently (not yet provisioned) |
+| JSON parse error | Log + metric, skip this cycle (agent might be mid-write) |
+| Lock contention | `fcntl.lockf` blocks, wait turn |
+| DDB tier lookup fails | Log + skip (fail-open; never lock a user out of their own plan due to our DDB error) |
+| EFS mount gone | Log + alert; pointless to revert on dead FS |
+
+### Observability
+
+- Metric `config.drift.reverted` with `tier` dimension
+- Metric `config.reconciler.tick.duration`
+- Metric `config.reconciler.errors` with `kind` dimension
+- Audit log entry per revert in DDB `audit_logs`: `{actor: SYSTEM_ACTOR_ID, action: "config_policy_revert", owner_id, violations}`
+
+### Shutdown
+
+Lifespan `on_shutdown` sets `self._stop`. Reconciler finishes current tick (≤1s) and exits.
+
+## Backend API policy (`routers/config.py`)
+
+Replace the current custom channels check with a shared policy evaluation on the merged result. This catches subtle cases (e.g., a patch that sets `channels.telegram.enabled: true` is not a violation on its own because it only touches a scaffold flag — the merged config still has no accounts).
+
+```python
+current = await read_openclaw_config_from_efs(owner_id) or {}
+merged = _deep_merge(current, body.patch)
+
+violations = config_policy.evaluate(merged, tier)
+if violations:
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "code": "policy_violation",
+            "fields": [v["field"] for v in violations],
+            "reason": violations[0]["reason"],
+        },
+    )
+
+await patch_openclaw_config(owner_id, body.patch)
+```
+
+Existing channel-specific tests in `tests/unit/routers/test_config_router.py:94-106` update to assert the new structured error shape.
+
+### Admin endpoints
+
+`routers/updates.py` admin `PATCH /container/config/{owner_id}` and fleet patch stay intentionally un-gated by policy — admins sometimes need emergency overrides. They DO update `containers.reconciler_grace_until = now + 5s` in DDB before patching.
+
+## Rollout
+
+### Phase A — report-only
+
+Deploy reconciler with `CONFIG_RECONCILER_MODE=report`. Reads + evaluates + emits metrics + logs violations, but does NOT write. Gives ~1 day of production telemetry to confirm:
+
+- No false positives (legitimate configs flagged as illegal)
+- Actual drift rate
+- Loop latency at real fleet size
+
+### Phase B — enforce
+
+Flip to `CONFIG_RECONCILER_MODE=enforce`. Before the flip:
+
+- Run `scripts/reconcile_all_configs.py` as a one-shot to clean any pre-existing drift synchronously. This creates a known-clean baseline before the live loop starts enforcing.
+
+### Tier change handling
+
+- Upgrade free → paid: reconciler tier cache TTL (60s) means within a minute the now-permitted channel accounts stop being reverted. No user action needed.
+- Downgrade paid → free: existing channel accounts get reverted (removed) within 60s + 1s. Frontend warns the user at downgrade time via existing billing-page UX.
+
+### Container provisioning race
+
+`ecs_manager.create_user_service` writes `openclaw.json` before the container is `status=running`. Reconciler's `list_active_owners()` filter includes `status=running` only, so provisioning writes never race with reconciler.
+
+## Testing
+
+### Unit — `tests/unit/services/test_config_policy.py`
+
+Table-driven over `(tier, input_config)` → expected violations. Coverage:
+
+- Free tier with agent-added Telegram account → violation on `channels.accounts`
+- Paid tier with agent-added Telegram account → no violation
+- Free tier with agent-changed primary model to Qwen → violation on `agents.defaults.model.primary`
+- Any tier with agent-added `openai` provider → violation on `models.providers`
+- Base config from `write_openclaw_config(tier="free")` → no violations (regression)
+- Base config from `write_openclaw_config(tier="pro")` → no violations (regression)
+
+### Unit — `tests/unit/services/test_config_reconciler.py`
+
+Mock EFS via `tmp_path`, mock DDB tier lookups, call `_tick()` directly. Assertions:
+
+- Unchanged mtime → no file re-read
+- Changed mtime + clean config → no write
+- Changed mtime + dirty config → write happens, reverted-config matches expected
+- Admin grace timestamp in DDB → skip revert
+- Tier cache TTL expires → fresh DDB read
+- `CONFIG_RECONCILER_MODE=report` → never writes
+
+### Integration — `tests/integration/test_config_reconciliation.py`
+
+Wires reconciler + `config_patcher` against a real tmp EFS path with real `fcntl` locking. One happy path (dirty config reverted) and one concurrency test (admin patch and reconciler both firing at once, no corruption). Catches IO/lock bugs that unit mocks miss.
+
+### API — extend `tests/unit/routers/test_config_router.py`
+
+- Existing channel-specific tests updated for new structured error shape
+- Paid user tries to add `openai` provider → 403 `policy_violation` with `fields: ["models.providers"]`
+- Admin PATCH at `/container/config/{owner_id}` with policy-violating payload → 200, with DDB grace timestamp set
+
+### E2E — Playwright
+
+- Agent (via chat) adds a cron job → persists
+- Agent (via chat) tries to switch primary model to unauthorized → reverts within 2s; next chat uses authorized model
+
+## Deliverables
+
+1. `core/services/config_policy.py` — ~150 LOC pure policy
+2. `core/services/config_reconciler.py` — ~200 LOC asyncio loop
+3. `routers/config.py` — swap custom channel check for `config_policy.evaluate` on merged config
+4. `routers/updates.py` — set DDB grace timestamp on admin patches
+5. `main.py` — lifespan-started reconciler alongside `usage_poller`
+6. `core/config.py` — `CONFIG_RECONCILER_MODE` setting
+7. `scripts/reconcile_all_configs.py` — one-shot fleet cleanup
+8. Unit + integration + e2e tests per above
+9. One new DDB field on `containers` table: `reconciler_grace_until` (number, epoch seconds)
+
+## Out of scope for this spec
+
+- UX around surfacing "your plan doesn't allow this" to the agent/user after a revert. Future polish: push a chat banner or system message when drift is reverted.
+- Exec-approvals socket for bash-based bypass (`src/infra/exec-approvals.ts`). Valid defense-in-depth layer, but not blocking — agent doesn't use bash as its primary write path today, and reconciliation covers the residual risk. Future follow-up.
+- Forking OpenClaw to add a path-level tool denylist or layered config. Heavier than justified by this problem.


### PR DESCRIPTION
## Summary

Prevent agents from bypassing tier-based restrictions by writing forbidden fields to `openclaw.json` (via gateway RPC, generic file tools, or shell). Enforcement happens at the file level via a backend reconciliation loop, so it doesn't matter how the agent attempts the write — drift gets reverted within ~1 second.

**What's locked:**
- `models.providers` (and dependent `agents.defaults.model.primary` / `agents.defaults.models`) — for everyone
- `channels.{provider}.accounts` — for free tier only

**What's NOT locked** (agent retains full authoring power): `tools`, `hooks`, `memory`, `cron`, plugin configs, OpenClaw's `meta` block, channel scaffold flags, etc.

## Architecture (defense in depth)

| Layer | Mechanism |
|-------|-----------|
| 1 | Backend API policy (`routers/config.py`) — frontend/admin PATCH gated by `config_policy.evaluate` |
| 2 | Backend reconciler loop — polls EFS at ~1s, reverts drift on locked fields only |
| 3 | Admin grace window — `set_reconciler_grace(owner, seconds=5)` so admin patches don't fight the loop |
| 4 | CloudWatch metrics + logs — observability into drift attempts and reconciler health |

**Rollout staged via `CONFIG_RECONCILER_MODE=off|report|enforce`.** Default is `off`; deploy in `report` mode for ~24h to confirm no false positives, run the one-shot `scripts/reconcile_all_configs.py --dry-run` to preview blast radius, then flip to `enforce`.

## Components

**New (`apps/backend/`):**
- `core/services/config_policy.py` — pure tier-aware policy (evaluate + apply_reverts)
- `core/services/config_reconciler.py` — asyncio polling loop with mtime gate, tier cache, grace window
- `scripts/reconcile_all_configs.py` — one-shot fleet cleanup with `--dry-run`

**Modified:**
- `core/services/config_patcher.py` — promoted `_locked_rmw` → `locked_rmw` (now public, used by reconciler + script). Also fixes two latent concurrency bugs uncovered by the new integration test:
  - **Per-process fcntl gotcha:** `fcntl.lockf` doesn't block sibling threads in the same process — the reconciler and patcher could enter the critical section simultaneously via `asyncio.to_thread`. Fixed with a per-owner `threading.Lock` acquired before the fcntl lock.
  - **Rename/orphan race:** Cross-process waiters held fds pointing to the orphaned inode after another writer's atomic rename. Fixed with a re-open loop comparing `fstat.st_ino` to `stat(path).st_ino` after lock acquisition.
- `routers/config.py` — delegates to `config_policy.evaluate` on merged config; fail-closed on billing/EFS lookup errors
- `routers/updates.py` — admin patch endpoints set 5s reconciler grace
- `main.py` — reconciler started in FastAPI lifespan
- `core/repositories/container_repo.py` — `set_reconciler_grace`, `get_reconciler_grace`, `list_active_owners`
- `core/config.py` — `CONFIG_RECONCILER_MODE` setting

## Test Plan

- [x] All 652 backend tests pass (unit + integration + contract)
- [x] Policy module: 20 unit tests (drift detection per locked field + clean-config regressions)
- [x] Reconciler: 9 unit tests (mtime gate, tier cache, grace window, off/report/enforce modes)
- [x] Integration: 2 tests against real `tmp_path` with real `fcntl.lockf` — including a true two-writer concurrency test that uncovered (and now verifies fixes for) the locking bugs above
- [x] Router: 11 tests covering policy enforcement, structured 403 errors, fail-closed paths
- [x] E2E specs written, env-gated behind `E2E_CONFIG_POLICY=1` (require deployed enforce mode + working WS chat)
- [ ] Deploy to dev with `CONFIG_RECONCILER_MODE=report`, observe `config.drift.reported` metric for ~24h to confirm no false positives
- [ ] Run `scripts/reconcile_all_configs.py --dry-run` to preview blast radius
- [ ] Flip to `enforce` mode

## Spec + Plan

- Design: [`docs/superpowers/specs/2026-04-14-config-protection-design.md`](docs/superpowers/specs/2026-04-14-config-protection-design.md)
- Implementation plan: [`docs/superpowers/plans/2026-04-14-config-protection.md`](docs/superpowers/plans/2026-04-14-config-protection.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)