### PR TITLE
fix(config): use absolute workspace paths to prevent nested skill installs

### DIFF
--- a/apps/backend/core/containers/config.py
+++ b/apps/backend/core/containers/config.py
@@ -332,7 +332,7 @@ def write_openclaw_config(
                     "primary": primary_model,
                 },
                 "models": agent_models,
-                "workspace": ".openclaw/workspaces",
+                "workspace": "/home/node/.openclaw/workspaces",
                 "memorySearch": {
                     "enabled": True,
                 },
@@ -356,16 +356,10 @@ def write_openclaw_config(
                     "id": "main",
                     "default": True,
                     "reasoningDefault": "stream",
-                    # Explicit override so main lands at .openclaw/workspaces/main/
-                    # — inside the EFS mount — matching the
-                    # {defaults.workspace}/{agentId} path custom agents get
-                    # automatically. The ".openclaw/" prefix is REQUIRED: OpenClaw
-                    # resolves per-agent workspace values via path.resolve() against
-                    # the process cwd (/home/node). A bare "workspaces/main" would
-                    # land at /home/node/workspaces/main/ — outside the EFS mount
-                    # at /home/node/.openclaw/ — and be ephemeral (lost on restart).
-                    # See docs/superpowers/specs/2026-04-14-agent-workspace-normalization-design.md
-                    "workspace": ".openclaw/workspaces/main",
+                    # Absolute path so path.resolve() returns it unchanged
+                    # regardless of process cwd (agent exec tools run with
+                    # cwd=workspaceDir, which breaks relative resolution).
+                    "workspace": "/home/node/.openclaw/workspaces/main",
                 },
             ],
         },

--- a/apps/backend/tests/unit/containers/test_config.py
+++ b/apps/backend/tests/unit/containers/test_config.py
@@ -152,22 +152,17 @@ class TestWriteOpenclawConfig:
     def test_agents_defaults_workspace_routes_to_efs(self):
         """New agent workspaces must land under `.openclaw/` so they live on EFS."""
         config = json.loads(write_openclaw_config())
-        assert config["agents"]["defaults"]["workspace"] == ".openclaw/workspaces"
+        assert config["agents"]["defaults"]["workspace"] == "/home/node/.openclaw/workspaces"
 
-    def test_main_agent_has_explicit_workspace(self):
-        """Main agent's workspace is .openclaw/workspaces/main so it joins
-        the {id}/ scheme AND stays on EFS.
-
-        The .openclaw/ prefix is REQUIRED: OpenClaw resolves per-agent
-        workspace values via path.resolve() against the process cwd
-        (/home/node). A bare "workspaces/main" would land at
-        /home/node/workspaces/main/ — OUTSIDE the EFS mount at
-        /home/node/.openclaw/ — so every write would be lost on container
-        restart.
+    def test_main_agent_has_absolute_workspace(self):
+        """Main agent workspace must be absolute so path.resolve() returns it
+        unchanged regardless of process cwd. Agent exec tools run with
+        cwd=workspaceDir, which breaks relative resolution (skills install
+        to a nested path instead of {workspace}/skills/).
         """
         config = json.loads(write_openclaw_config())
         main_entry = next(a for a in config["agents"]["list"] if a.get("id") == "main")
-        assert main_entry.get("workspace") == ".openclaw/workspaces/main"
+        assert main_entry.get("workspace") == "/home/node/.openclaw/workspaces/main"
 
     def test_browser_disabled(self):
         """Browser automation is disabled by default."""


### PR DESCRIPTION
## Summary
- Changed `agents.defaults.workspace` and main agent `workspace` from relative paths (`.openclaw/workspaces`) to absolute (`/home/node/.openclaw/workspaces`) in the provisioned `openclaw.json`
- OpenClaw resolves workspace paths via `path.resolve()`, which depends on `process.cwd()`. Agent exec tools run with `cwd=workspaceDir`, causing relative paths to double-nest (e.g. skills landing at `/home/node/.openclaw/workspaces/main/.openclaw/workspaces/skills/` instead of `/home/node/.openclaw/workspaces/main/skills/`)
- Absolute paths make `path.resolve()` return them unchanged regardless of cwd

## Test plan
- [x] Unit tests updated and passing (`test_config.py`)
- [ ] Reprovision a container and verify `clawhub install` puts skills at `{workspace}/skills/{slug}` (not nested)
- [ ] Verify new agent creation still works (frontend sends relative paths, OpenClaw gateway resolves to absolute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)