### PR TITLE
fix(skills): redirect clawhub installs + always enable ECS Exec

### DIFF
--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -285,9 +285,11 @@ class EcsManager:
                 },
                 serviceRegistries=[{"registryArn": self._cloud_map_service_arn}],
             )
-            # Only enable ECS Exec for non-production environments
-            if settings.ENVIRONMENT != "prod":
-                create_kwargs["enableExecuteCommand"] = True
+            # Enable ECS Exec for all environments so we can debug per-user
+            # OpenClaw containers (skill installs, workspace state, gateway
+            # health) without redeploying. Requires the task role to grant
+            # ssmmessages:CreateControlChannel/CreateDataChannel/OpenControlChannel/OpenDataChannel.
+            create_kwargs["enableExecuteCommand"] = True
             self._ecs.create_service(**create_kwargs)
             await self._update_container(user_id, substatus="service_created")
         except EcsManagerError:

--- a/apps/infra/lib/stacks/container-stack.ts
+++ b/apps/infra/lib/stacks/container-stack.ts
@@ -176,6 +176,22 @@ export class ContainerStack extends cdk.Stack {
       }),
     );
 
+    // ECS Exec — lets us aws ecs execute-command into per-user OpenClaw
+    // containers for live debugging (skill installs, workspace state, etc.).
+    // Paired with enableExecuteCommand=true on each per-user service in
+    // ecs_manager.py.
+    this.taskRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel",
+        ],
+        resources: ["*"],
+      }),
+    );
+
     // Base OpenClaw task definition — the backend clones this per user,
     // replacing the EFS access point for data isolation.
     const env = props.environment;
@@ -224,6 +240,11 @@ export class ContainerStack extends cdk.Stack {
       environment: {
         HOME: "/home/node",
         CHOKIDAR_USEPOLLING: "true",
+        // Redirect clawhub installs to the OpenClaw managed-skills directory
+        // (~/.openclaw/skills) so they're scanned by every agent. Without
+        // this, clawhub falls through to agents.defaults.workspace and lands
+        // at /home/node/.openclaw/workspaces/skills — a path no scanner checks.
+        CLAWHUB_WORKDIR: "/home/node/.openclaw",
       },
       portMappings: [{ containerPort: 18789, protocol: ecs.Protocol.TCP }],
       logging: ecs.LogDrivers.awsLogs({


### PR DESCRIPTION
## Summary

- Set `CLAWHUB_WORKDIR=/home/node/.openclaw` in the OpenClaw container env so `clawhub install` lands at `/home/node/.openclaw/skills/{slug}` (the canonical managed-skills directory OpenClaw scans for all agents)
- Always enable ECS Exec on per-user OpenClaw services + grant the task role `ssmmessages:*` so we can `aws ecs execute-command` into them in any env

## The bug

`clawhub install` resolves the active workspace via openclaw.json's `agents.defaults.workspace` BEFORE checking `agents.list[default].workspace` ([clawhub@0.9.0 dist/cli/clawdbotConfig.js:44-46](https://www.npmjs.com/package/clawhub)). Result: skills land at `/home/node/.openclaw/workspaces/skills/{slug}` — a path no OpenClaw skill scanner checks ([source: src/agents/skills/workspace.ts:409-452](https://docs.openclaw.ai/tools/skills)).

**Confirmed across prod EFS:** 2 of 4 users had `markdown-converter` in this limbo directory, invisible to every agent. The other 2 happened to land at `workspaces/main/skills/` because their workspace dir already existed when `clawhub install` ran at startup. So the bug is non-deterministic depending on EFS state at startup.

With `CLAWHUB_WORKDIR` set, clawhub's resolution short-circuits before reaching the buggy fallback — installs always land at `~/.openclaw/skills/`, the managed-skills directory. Visible to all agents via `skills.status` and the Skills control panel.

## Test plan
- [x] `pytest tests/unit/containers/` — 123 passing
- [ ] After deploy: provision a fresh container, verify `clawhub install <slug>` lands at `/home/node/.openclaw/skills/{slug}`
- [ ] Verify `aws ecs execute-command` works against a per-user OpenClaw container (e.g. `aws ecs execute-command --cluster isol8-prod-container-* --task <task-id> --container openclaw --interactive --command "/bin/sh"`)
- [ ] Verify newly-installed skills show up in the control panel Skills tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)