### PR TITLE
fix(containers): make provisioning state machine durable

### DIFF
--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -495,22 +495,58 @@ class EcsManager:
                 },
             )
 
-            # Update DB record
-            await self._update_container(user_id, task_definition_arn=new_task_def_arn, status="provisioning")
-
-            logger.info(
-                "Resized container for user %s: cpu=%s memory=%s image=%s",
-                user_id,
-                new_cpu,
-                new_memory,
-                new_image,
+            # Decide whether to flip status=provisioning + fire the poller.
+            # resize never touches desiredCount -- if the service is currently
+            # scaled to zero (e.g. a free-tier container stopped by the reaper),
+            # update_service just registers the new task definition for later
+            # use. No tasks will start as a result of resize alone, so flipping
+            # status=provisioning would leave an orphan poller spinning forever
+            # (rolloutState won't go to FAILED; the deployment "completes" with
+            # zero tasks). The new task def will take effect on the next
+            # start_user_service call, which has its own poller firing.
+            desc_resp = await asyncio.to_thread(
+                self._ecs.describe_services,
+                cluster=self._cluster,
+                services=[service_name],
             )
+            services = desc_resp.get("services", [])
+            current_desired = services[0].get("desiredCount", 0) if services else 0
 
-            # Fire the durable transition poller. resize sets status=provisioning
-            # via update_fields above and forces a new ECS deployment; without
-            # the poller, the row stays stuck at provisioning until the next
-            # backend restart's startup reconciler catches it.
-            asyncio.create_task(self._await_running_transition(user_id))
+            if current_desired > 0:
+                # Update DB record
+                await self._update_container(
+                    user_id,
+                    task_definition_arn=new_task_def_arn,
+                    status="provisioning",
+                )
+                logger.info(
+                    "Resized running container for user %s: cpu=%s memory=%s image=%s",
+                    user_id,
+                    new_cpu,
+                    new_memory,
+                    new_image,
+                )
+                # Fire the durable transition poller. resize sets
+                # status=provisioning via update_fields above and forces a new
+                # ECS deployment; without the poller, the row stays stuck at
+                # provisioning until the next backend restart's startup
+                # reconciler catches it.
+                asyncio.create_task(self._await_running_transition(user_id))
+            else:
+                # Scaled to zero: only update task_definition_arn so the new
+                # def takes effect on next start. Do NOT flip status or fire
+                # the poller -- there are no tasks to become healthy.
+                await self._update_container(
+                    user_id,
+                    task_definition_arn=new_task_def_arn,
+                )
+                logger.info(
+                    "Resized stopped container for user %s: cpu=%s memory=%s image=%s (new task def applies on next start)",
+                    user_id,
+                    new_cpu,
+                    new_memory,
+                    new_image,
+                )
 
             return new_task_def_arn
 

--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -284,6 +284,12 @@ class EcsManager:
                     }
                 },
                 serviceRegistries=[{"registryArn": self._cloud_map_service_arn}],
+                deploymentConfiguration={
+                    "deploymentCircuitBreaker": {
+                        "enable": True,
+                        "rollback": False,
+                    }
+                },
             )
             # Enable ECS Exec for all environments so we can debug per-user
             # OpenClaw containers (skill installs, workspace state, gateway

--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -903,15 +903,9 @@ class EcsManager:
         put_metric("container.provision", dimensions={"status": "ok"})
         logger.info("Provisioned container %s for user %s", service_name, user_id)
 
-        # Step 5: Eagerly drive the provisioning → running transition. The
-        # previous design relied on the next call to `resolve_running_container`
-        # to flip the status when the task became reachable, which left rows
-        # stuck at `provisioning` forever if the user's first chat hit an
-        # upstream error (e.g. a bad model id) before the poll path fired.
-        # Now we fire-and-forget a background poller immediately so the row
-        # transitions as soon as the ECS task reports healthy, independent of
-        # user activity.
-        asyncio.create_task(self._await_running_transition(user_id))
+        # No poller fired here: start_user_service above already fired one.
+        # Firing again would double list_tasks/describe_services traffic and
+        # race two tasks to write the provisioning -> running transition.
 
         return service_name
 

--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -939,17 +939,22 @@ class EcsManager:
 
         Exits on one of four conditions:
 
-        1. Container is reachable (ECS task RUNNING + gateway port open):
-           write status=running, substatus=gateway_healthy, store task_arn,
-           return.
+        1. Container is reachable (ECS task from the PRIMARY deployment is
+           RUNNING + gateway port open): write status=running, substatus=
+           gateway_healthy, store task_arn, return.
         2. DDB status is no longer "provisioning" (external state change --
            admin stop, re-provision, reaper, etc.): return silently.
-        3. ECS deployment rolloutState=FAILED (circuit breaker tripped -- the
-           provision will never succeed): write status=error, return.
+        3. PRIMARY deployment rolloutState=FAILED (circuit breaker tripped --
+           the provision will never succeed): write status=error, return.
         4. asyncio.CancelledError (backend shutdown): propagate.
 
         No fixed timeout. The container can take 10s or 10 minutes to become
         healthy -- the poller keeps going until one of the above happens.
+
+        Forced-redeploy paths (resize, forceNewDeployment) have an OLD healthy
+        task while the NEW deployment rolls out. The poller filters tasks to
+        only those from the PRIMARY deployment so an old task can't cause a
+        premature status=running write that masks a failing new rollout.
         """
         while True:
             try:
@@ -960,8 +965,32 @@ class EcsManager:
 
                 service_name = container["service_name"]
 
-                # Try to find a healthy running task.
-                task_arn, ip = await self._poll_running_task(service_name)
+                # One describe_services per iteration covers both concerns:
+                # 1. primary deployment id -> startedBy filter for list_tasks
+                # 2. primary deployment rolloutState -> failure detection
+                primary = await self._get_primary_deployment(service_name)
+                if primary is None:
+                    # Transient state -- no PRIMARY deployment visible. Retry.
+                    await asyncio.sleep(interval_s)
+                    continue
+
+                if primary.get("rolloutState") == "FAILED":
+                    await container_repo.update_fields(
+                        user_id,
+                        {
+                            "status": "error",
+                            "substatus": "deployment_failed",
+                        },
+                    )
+                    logger.error(
+                        "Deployment circuit breaker tripped for container %s (user=%s); marking error",
+                        service_name,
+                        user_id,
+                    )
+                    return
+
+                deployment_id = primary.get("id")
+                task_arn, ip = await self._poll_running_task(service_name, deployment_id)
                 if task_arn and ip and self.is_healthy(ip):
                     await container_repo.update_fields(
                         user_id,
@@ -979,24 +1008,6 @@ class EcsManager:
                     )
                     return
 
-                # No healthy task yet -- check whether the circuit breaker tripped.
-                # We only issue this describe_services call on the slow path so
-                # the happy path stays cheap (ECS DescribeServices is 20 req/s).
-                if await self._deployment_failed(service_name):
-                    await container_repo.update_fields(
-                        user_id,
-                        {
-                            "status": "error",
-                            "substatus": "deployment_failed",
-                        },
-                    )
-                    logger.error(
-                        "Deployment circuit breaker tripped for container %s (user=%s); marking error",
-                        service_name,
-                        user_id,
-                    )
-                    return
-
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -1007,16 +1018,50 @@ class EcsManager:
 
             await asyncio.sleep(interval_s)
 
-    async def _poll_running_task(self, service_name: str) -> tuple[str | None, str | None]:
-        """Find a RUNNING task for the service and return (task_arn, ip).
+    async def _get_primary_deployment(self, service_name: str) -> dict | None:
+        """Return the PRIMARY deployment dict for the service, or None if
+        unavailable. Primary is the deployment currently being rolled out or
+        most-recently-succeeded; there is at most one at any time.
 
-        Returns (None, None) when no RUNNING task has an IP yet. Caller uses
-        this to decide whether to check for circuit-breaker failure.
+        Returns None on transient ECS errors so the caller retries on the
+        next poll tick rather than flipping to error on a describe_services
+        hiccup.
         """
+        try:
+            resp = self._ecs.describe_services(
+                cluster=self._cluster,
+                services=[service_name],
+            )
+        except Exception:
+            logger.warning("describe_services failed for %s; will retry next tick", service_name)
+            return None
+
+        services = resp.get("services", [])
+        if not services:
+            return None
+        for deployment in services[0].get("deployments", []):
+            if deployment.get("status") == "PRIMARY":
+                return deployment
+        return None
+
+    async def _poll_running_task(self, service_name: str, deployment_id: str | None) -> tuple[str | None, str | None]:
+        """Find a RUNNING task from the given deployment and return (task_arn, ip).
+
+        Filters list_tasks by startedBy=<deployment-id> so old drain-phase
+        tasks from a previous deployment are excluded. If deployment_id is
+        None (defensive: no PRIMARY visible), returns (None, None).
+
+        Returns (None, None) when no RUNNING task has an IP yet. Caller
+        uses this as "not ready yet" and sleeps another tick.
+        """
+        if not deployment_id:
+            return None, None
+
         list_resp = self._ecs.list_tasks(
             cluster=self._cluster,
             serviceName=service_name,
             desiredStatus="RUNNING",
+            startedBy=deployment_id,
         )
         task_arns = list_resp.get("taskArns", [])
         if not task_arns:
@@ -1037,25 +1082,6 @@ class EcsManager:
                 if detail.get("name") == "privateIPv4Address":
                     return task_arns[0], detail.get("value")
         return None, None
-
-    async def _deployment_failed(self, service_name: str) -> bool:
-        """True when ECS has marked the service's latest deployment FAILED."""
-        try:
-            resp = self._ecs.describe_services(
-                cluster=self._cluster,
-                services=[service_name],
-            )
-            services = resp.get("services", [])
-            if not services:
-                return False
-            deployments = services[0].get("deployments", [])
-            if not deployments:
-                return False
-            return deployments[0].get("rolloutState") == "FAILED"
-        except Exception:
-            # If describe_services fails, don't flip to error -- retry next cycle.
-            logger.warning("describe_services failed for %s; assuming not-failed", service_name)
-            return False
 
     async def write_user_configs(self, user_id: str, gateway_token: str, tier: str = "free") -> None:
         """Write OpenClaw config files + pre-paired device trust store to EFS.

--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -894,87 +894,129 @@ class EcsManager:
         self,
         user_id: str,
         *,
-        max_attempts: int = 30,
-        interval_s: float = 4.0,
+        interval_s: float = 10.0,
     ) -> None:
-        """Background poller that drives provisioning → running eagerly.
+        """Durable background poller that drives provisioning -> running.
 
-        Polls ECS for the task's private IP, then TCP-connects to the gateway
-        port, then writes status=running once both succeed. Also stores the
-        task ARN on the row (previously never written because the old code
-        path only updated status, not task_arn).
+        Exits on one of four conditions:
 
-        Exits quietly on timeout — the next user request will still retry
-        via `resolve_running_container`, so this is strictly an optimization
-        for the happy path.
+        1. Container is reachable (ECS task RUNNING + gateway port open):
+           write status=running, substatus=gateway_healthy, store task_arn,
+           return.
+        2. DDB status is no longer "provisioning" (external state change --
+           admin stop, re-provision, reaper, etc.): return silently.
+        3. ECS deployment rolloutState=FAILED (circuit breaker tripped -- the
+           provision will never succeed): write status=error, return.
+        4. asyncio.CancelledError (backend shutdown): propagate.
+
+        No fixed timeout. The container can take 10s or 10 minutes to become
+        healthy -- the poller keeps going until one of the above happens.
         """
-        for attempt in range(max_attempts):
+        while True:
             try:
                 container = await container_repo.get_by_owner_id(user_id)
                 if not container or container.get("status") != "provisioning":
-                    # Already transitioned (or the row is gone) — nothing to do.
+                    # External state change or row gone -- nothing to do.
                     return
 
                 service_name = container["service_name"]
-                list_resp = self._ecs.list_tasks(
-                    cluster=self._cluster,
-                    serviceName=service_name,
-                    desiredStatus="RUNNING",
-                )
-                task_arns = list_resp.get("taskArns", [])
-                if not task_arns:
-                    await asyncio.sleep(interval_s)
-                    continue
 
-                task_arn = task_arns[0]
-                desc_resp = self._ecs.describe_tasks(
-                    cluster=self._cluster,
-                    tasks=[task_arn],
-                )
-                tasks = desc_resp.get("tasks", [])
-                if not tasks or tasks[0].get("lastStatus") != "RUNNING":
-                    await asyncio.sleep(interval_s)
-                    continue
+                # Try to find a healthy running task.
+                task_arn, ip = await self._poll_running_task(service_name)
+                if task_arn and ip and self.is_healthy(ip):
+                    await container_repo.update_fields(
+                        user_id,
+                        {
+                            "status": "running",
+                            "substatus": "gateway_healthy",
+                            "task_arn": task_arn,
+                        },
+                    )
+                    logger.info(
+                        "Transitioned container %s to running (user=%s, task=%s)",
+                        service_name,
+                        user_id,
+                        task_arn.split("/")[-1],
+                    )
+                    return
 
-                ip = None
-                for attachment in tasks[0].get("attachments", []):
-                    if attachment.get("type") == "ElasticNetworkInterface":
-                        for detail in attachment.get("details", []):
-                            if detail.get("name") == "privateIPv4Address":
-                                ip = detail.get("value")
-                                break
-                if not ip or not self.is_healthy(ip):
-                    await asyncio.sleep(interval_s)
-                    continue
+                # No healthy task yet -- check whether the circuit breaker tripped.
+                # We only issue this describe_services call on the slow path so
+                # the happy path stays cheap (ECS DescribeServices is 20 req/s).
+                if await self._deployment_failed(service_name):
+                    await container_repo.update_fields(
+                        user_id,
+                        {
+                            "status": "error",
+                            "substatus": "deployment_failed",
+                        },
+                    )
+                    logger.error(
+                        "Deployment circuit breaker tripped for container %s (user=%s); marking error",
+                        service_name,
+                        user_id,
+                    )
+                    return
 
-                await container_repo.update_fields(
-                    user_id,
-                    {
-                        "status": "running",
-                        "substatus": "gateway_healthy",
-                        "task_arn": task_arn,
-                    },
-                )
-                logger.info(
-                    "Eagerly transitioned container %s to running (user=%s, task=%s)",
-                    service_name,
-                    user_id,
-                    task_arn.split("/")[-1],
-                )
-                return
+            except asyncio.CancelledError:
+                raise
             except Exception:
                 logger.exception(
-                    "Unexpected error in eager running transition for %s (attempt %d)",
+                    "Unexpected error in _await_running_transition for %s; will retry",
                     user_id,
-                    attempt,
                 )
-                await asyncio.sleep(interval_s)
 
-        logger.warning(
-            "Eager provisioning -> running transition timed out for user %s after %d attempts",
-            user_id,
-            max_attempts,
+            await asyncio.sleep(interval_s)
+
+    async def _poll_running_task(self, service_name: str) -> tuple[str | None, str | None]:
+        """Find a RUNNING task for the service and return (task_arn, ip).
+
+        Returns (None, None) when no RUNNING task has an IP yet. Caller uses
+        this to decide whether to check for circuit-breaker failure.
+        """
+        list_resp = self._ecs.list_tasks(
+            cluster=self._cluster,
+            serviceName=service_name,
+            desiredStatus="RUNNING",
         )
+        task_arns = list_resp.get("taskArns", [])
+        if not task_arns:
+            return None, None
+
+        desc_resp = self._ecs.describe_tasks(
+            cluster=self._cluster,
+            tasks=[task_arns[0]],
+        )
+        tasks = desc_resp.get("tasks", [])
+        if not tasks or tasks[0].get("lastStatus") != "RUNNING":
+            return None, None
+
+        for attachment in tasks[0].get("attachments", []):
+            if attachment.get("type") != "ElasticNetworkInterface":
+                continue
+            for detail in attachment.get("details", []):
+                if detail.get("name") == "privateIPv4Address":
+                    return task_arns[0], detail.get("value")
+        return None, None
+
+    async def _deployment_failed(self, service_name: str) -> bool:
+        """True when ECS has marked the service's latest deployment FAILED."""
+        try:
+            resp = self._ecs.describe_services(
+                cluster=self._cluster,
+                services=[service_name],
+            )
+            services = resp.get("services", [])
+            if not services:
+                return False
+            deployments = services[0].get("deployments", [])
+            if not deployments:
+                return False
+            return deployments[0].get("rolloutState") == "FAILED"
+        except Exception:
+            # If describe_services fails, don't flip to error -- retry next cycle.
+            logger.warning("describe_services failed for %s; assuming not-failed", service_name)
+            return False
 
     async def write_user_configs(self, user_id: str, gateway_token: str, tier: str = "free") -> None:
         """Write OpenClaw config files + pre-paired device trust store to EFS.

--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -371,6 +371,11 @@ class EcsManager:
     async def start_user_service(self, user_id: str) -> None:
         """Scale a user's ECS service to 1 (running) with forced new deployment.
 
+        Fires _await_running_transition afterwards so the provisioning -> running
+        transition happens eventually even if the user disconnects before the
+        ECS task finishes warming up. Without this, cold-start restart rows
+        get stuck at status=provisioning forever.
+
         Args:
             user_id: Clerk user ID.
 
@@ -402,6 +407,11 @@ class EcsManager:
             await container_repo.update_status(user_id, "provisioning")
 
         logger.info("Started ECS service %s for user %s", service_name, user_id)
+
+        # Fire the durable poller. Any code path that sets status=provisioning
+        # MUST ensure a transition poller is running, otherwise a slow ECS
+        # cold-start leaves the row stuck.
+        asyncio.create_task(self._await_running_transition(user_id))
 
     async def resize_user_container(
         self,

--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -1083,12 +1083,13 @@ class EcsManager:
     async def _poll_running_task(self, service_name: str, deployment_id: str | None) -> tuple[str | None, str | None]:
         """Find a RUNNING task from the given deployment and return (task_arn, ip).
 
-        Filters list_tasks by startedBy=<deployment-id> so old drain-phase
-        tasks from a previous deployment are excluded. If deployment_id is
-        None (defensive: no PRIMARY visible), returns (None, None).
+        Lists ALL running tasks for the service, then filters in-code to
+        tasks whose `startedBy` matches the primary deployment's id. ECS
+        tags service-launched tasks with startedBy=ecs-svc/<deployment-id>.
+        We can't filter via the ListTasks API because ECS rejects startedBy
+        combined with serviceName (InvalidParameterException).
 
-        Returns (None, None) when no RUNNING task has an IP yet. Caller
-        uses this as "not ready yet" and sleeps another tick.
+        Returns (None, None) when no qualifying task has an IP yet.
         """
         if not deployment_id:
             return None, None
@@ -1097,7 +1098,6 @@ class EcsManager:
             cluster=self._cluster,
             serviceName=service_name,
             desiredStatus="RUNNING",
-            startedBy=deployment_id,
         )
         task_arns = list_resp.get("taskArns", [])
         if not task_arns:
@@ -1105,18 +1105,20 @@ class EcsManager:
 
         desc_resp = self._ecs.describe_tasks(
             cluster=self._cluster,
-            tasks=[task_arns[0]],
+            tasks=task_arns,
         )
-        tasks = desc_resp.get("tasks", [])
-        if not tasks or tasks[0].get("lastStatus") != "RUNNING":
-            return None, None
-
-        for attachment in tasks[0].get("attachments", []):
-            if attachment.get("type") != "ElasticNetworkInterface":
+        for task in desc_resp.get("tasks", []):
+            if task.get("startedBy") != deployment_id:
                 continue
-            for detail in attachment.get("details", []):
-                if detail.get("name") == "privateIPv4Address":
-                    return task_arns[0], detail.get("value")
+            if task.get("lastStatus") != "RUNNING":
+                continue
+            for attachment in task.get("attachments", []):
+                if attachment.get("type") != "ElasticNetworkInterface":
+                    continue
+                for detail in attachment.get("details", []):
+                    if detail.get("name") == "privateIPv4Address":
+                        task_arn = task.get("taskArn") or task_arns[0]
+                        return task_arn, detail.get("value")
         return None, None
 
     async def write_user_configs(self, user_id: str, gateway_token: str, tier: str = "free") -> None:

--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -493,6 +493,13 @@ class EcsManager:
                 new_memory,
                 new_image,
             )
+
+            # Fire the durable transition poller. resize sets status=provisioning
+            # via update_fields above and forces a new ECS deployment; without
+            # the poller, the row stays stuck at provisioning until the next
+            # backend restart's startup reconciler catches it.
+            asyncio.create_task(self._await_running_transition(user_id))
+
             return new_task_def_arn
 
         except EcsManagerError:
@@ -821,6 +828,10 @@ class EcsManager:
                     raise EcsManagerError(f"Failed to force redeploy: {e}", user_id)
 
                 put_metric("container.provision", dimensions={"status": "ok"})
+                # New deployment forces a fresh task; fire the poller so the
+                # row transitions back to status=running once the new task is
+                # healthy.
+                asyncio.create_task(self._await_running_transition(user_id))
                 return service_name
 
             else:
@@ -839,6 +850,10 @@ class EcsManager:
                             "substatus": "starting",
                         },
                     )
+                # ECS is mid-launch for this service; fire the poller so the
+                # row transitions to status=running once the task becomes
+                # healthy.
+                asyncio.create_task(self._await_running_transition(user_id))
                 return service_name
 
         # --- Scenario: No service exists -- full provisioning ---

--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -392,6 +392,12 @@ class EcsManager:
                     service=service_name,
                     desiredCount=1,
                     forceNewDeployment=True,
+                    deploymentConfiguration={
+                        "deploymentCircuitBreaker": {
+                            "enable": True,
+                            "rollback": False,
+                        }
+                    },
                 )
         except Exception as e:
             logger.error(
@@ -481,6 +487,12 @@ class EcsManager:
                 service=service_name,
                 taskDefinition=new_task_def_arn,
                 forceNewDeployment=True,
+                deploymentConfiguration={
+                    "deploymentCircuitBreaker": {
+                        "enable": True,
+                        "rollback": False,
+                    }
+                },
             )
 
             # Update DB record
@@ -820,6 +832,12 @@ class EcsManager:
                         cluster=self._cluster,
                         service=service_name,
                         forceNewDeployment=True,
+                        deploymentConfiguration={
+                            "deploymentCircuitBreaker": {
+                                "enable": True,
+                                "rollback": False,
+                            }
+                        },
                     )
                 except Exception as e:
                     put_metric("container.provision", dimensions={"status": "error"})
@@ -850,10 +868,12 @@ class EcsManager:
                             "substatus": "starting",
                         },
                     )
-                # ECS is mid-launch for this service; fire the poller so the
-                # row transitions to status=running once the task becomes
-                # healthy.
-                asyncio.create_task(self._await_running_transition(user_id))
+                    # We just flipped status to provisioning -- fire the poller.
+                    # If status was already provisioning, an earlier poller is
+                    # already running (or the startup reconciler will pick it up
+                    # on next deploy), so firing another would just double the
+                    # ECS API traffic for no gain.
+                    asyncio.create_task(self._await_running_transition(user_id))
                 return service_name
 
         # --- Scenario: No service exists -- full provisioning ---

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -19,8 +19,14 @@ from fastapi.responses import JSONResponse
 
 from core.auth import get_current_user
 from core.config import settings
-from core.containers import get_gateway_pool, startup_containers, shutdown_containers
+from core.containers import (
+    get_ecs_manager,
+    get_gateway_pool,
+    startup_containers,
+    shutdown_containers,
+)
 from core.observability.metrics import put_metric
+from core.repositories import container_repo
 from core.services.update_service import run_scheduled_worker
 from routers import (
     billing,
@@ -64,12 +70,37 @@ async def _safe_idle_checker():
         logger.warning("idle checker exited with exception", exc_info=True)
 
 
+async def _resume_provisioning_transitions() -> None:
+    """Resume the provisioning -> running poller for any containers that were
+    mid-transition when the backend last shut down.
+
+    ``_await_running_transition`` is an in-process asyncio task — a deploy or
+    crash kills it mid-poll. DDB ``status="provisioning"`` is the durable
+    marker that the transition hasn't completed; on startup we find those
+    rows and re-kick the poller. The poller itself is idempotent (if the
+    container is already healthy, the first iteration transitions it to
+    running and exits).
+    """
+    try:
+        rows = await container_repo.get_by_status("provisioning")
+    except Exception:
+        logger.warning("Could not resume provisioning transitions on startup", exc_info=True)
+        return
+
+    ecs = get_ecs_manager()
+    for row in rows:
+        owner_id = row["owner_id"]
+        asyncio.create_task(ecs._await_running_transition(owner_id))
+        logger.info("Resumed provisioning -> running poller for %s", owner_id)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan handler."""
     # Startup
     logger.info("Starting application...")
     await startup_containers()
+    await _resume_provisioning_transitions()
     worker_task = asyncio.create_task(run_scheduled_worker())
 
     idle_checker_task = asyncio.create_task(_safe_idle_checker())

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -506,7 +506,10 @@ class TestStartUserService:
     @pytest.mark.asyncio
     async def test_start_scales_to_one(self, manager, mock_ecs_client):
         """start_user_service calls update_service with desiredCount=1 and force."""
-        with patch("core.containers.ecs_manager.container_repo") as mock_repo:
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+        ):
             mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="stopped"))
             mock_repo.update_status = AsyncMock(return_value=_make_container_dict(status="provisioning"))
 
@@ -546,7 +549,10 @@ class TestStartUserService:
     @pytest.mark.asyncio
     async def test_start_no_db_record(self, manager, mock_ecs_client):
         """start_user_service with no repo record still calls ECS."""
-        with patch("core.containers.ecs_manager.container_repo") as mock_repo:
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+        ):
             mock_repo.get_by_owner_id = AsyncMock(return_value=None)
 
             await manager.start_user_service("user_test_123")
@@ -562,8 +568,9 @@ class TestStartUserService:
             "UpdateService",
         )
 
-        with pytest.raises(EcsManagerError, match="Failed to start ECS service"):
-            await manager.start_user_service("user_test_123")
+        with patch.object(manager, "_await_running_transition", new_callable=AsyncMock):
+            with pytest.raises(EcsManagerError, match="Failed to start ECS service"):
+                await manager.start_user_service("user_test_123")
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -521,6 +521,29 @@ class TestStartUserService:
             mock_repo.update_status.assert_called_once_with("user_test_123", "provisioning")
 
     @pytest.mark.asyncio
+    async def test_start_fires_running_transition_poller(self, manager, mock_ecs_client):
+        """Cold-start restart MUST fire _await_running_transition, or the cold-
+        started container will get stuck at status=provisioning forever when
+        its ECS task takes >10s to become healthy and the user leaves before
+        making another request."""
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock) as mock_await,
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="stopped"))
+            mock_repo.update_status = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+
+            await manager.start_user_service("user_test_123")
+
+            # Give the fire-and-forget task a chance to be scheduled.
+            # asyncio.create_task schedules it immediately; a yield is enough.
+            import asyncio as _asyncio
+
+            await _asyncio.sleep(0)
+
+            mock_await.assert_called_once_with("user_test_123")
+
+    @pytest.mark.asyncio
     async def test_start_no_db_record(self, manager, mock_ecs_client):
         """start_user_service with no repo record still calls ECS."""
         with patch("core.containers.ecs_manager.container_repo") as mock_repo:

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -1299,6 +1299,20 @@ class TestResizeUserContainer:
 
     @pytest.mark.asyncio
     async def test_resize_fires_running_transition_poller(self, manager, mock_ecs_client):
+        # Service is currently running with tasks -- resize should fire the
+        # poller to drive tasks through the rolling replacement.
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                    "status": "ACTIVE",
+                    "desiredCount": 1,
+                    "runningCount": 1,
+                    "deployments": [{"id": "ecs-svc/primary", "status": "PRIMARY", "rolloutState": "IN_PROGRESS"}],
+                }
+            ]
+        }
+
         with (
             patch("core.containers.ecs_manager.container_repo") as mock_repo,
             patch.object(manager, "_await_running_transition", new_callable=AsyncMock) as mock_await,
@@ -1323,6 +1337,19 @@ class TestResizeUserContainer:
     async def test_resize_enables_circuit_breaker_on_update_service(self, manager, mock_ecs_client):
         """resize path's update_service must also carry the circuit breaker
         so pre-existing services get upgraded on resize."""
+        # Service running with tasks so we exercise the full flip+poller path.
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                    "status": "ACTIVE",
+                    "desiredCount": 1,
+                    "runningCount": 1,
+                    "deployments": [{"id": "ecs-svc/primary", "status": "PRIMARY", "rolloutState": "IN_PROGRESS"}],
+                }
+            ]
+        }
+
         with (
             patch("core.containers.ecs_manager.container_repo") as mock_repo,
             patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
@@ -1359,6 +1386,109 @@ class TestResizeUserContainer:
             cb = dc.get("deploymentCircuitBreaker") or {}
             assert cb.get("enable") is True
             assert cb.get("rollback") is False
+
+    @pytest.mark.asyncio
+    async def test_resize_skips_status_flip_and_poller_when_service_stopped(self, manager, mock_ecs_client):
+        """If the service is at desiredCount=0 when resize runs, there are no
+        tasks to become healthy. Flipping status=provisioning and firing the
+        poller in that state leaves an orphan poller that polls forever.
+
+        Instead: record the new task_definition_arn but leave status alone;
+        the new task def takes effect on next start_user_service call."""
+        # Service currently stopped.
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                    "status": "ACTIVE",
+                    "desiredCount": 0,
+                    "runningCount": 0,
+                    "deployments": [{"id": "ecs-svc/primary", "status": "PRIMARY", "rolloutState": "COMPLETED"}],
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock) as mock_await,
+            patch("core.containers.ecs_manager.asyncio.to_thread") as mock_to_thread,
+        ):
+
+            async def passthrough(fn, *args, **kwargs):
+                return fn(*args, **kwargs)
+
+            mock_to_thread.side_effect = passthrough
+
+            mock_repo.get_by_owner_id = AsyncMock(
+                return_value=_make_container_dict(
+                    status="stopped",
+                    task_definition_arn="arn:aws:ecs:us-east-1:123:task-definition/base:1",
+                )
+            )
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="stopped"))
+
+            await manager.resize_user_container("user_test_123", new_cpu="1024", new_memory="2048")
+
+            import asyncio as _asyncio
+
+            await _asyncio.sleep(0)
+
+            # No poller should have been fired -- there would be nothing to poll.
+            mock_await.assert_not_called()
+
+            # task_definition_arn should be updated, but status must NOT flip
+            # to provisioning for a stopped service.
+            update_calls = mock_repo.update_fields.call_args_list
+            for call in update_calls:
+                fields = call.args[1] if len(call.args) > 1 else call.kwargs.get("fields", {})
+                assert fields.get("status") != "provisioning", (
+                    f"Must not flip status to provisioning on a stopped service; got fields={fields}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_resize_fires_poller_when_service_running(self, manager, mock_ecs_client):
+        """When the service has desiredCount>0, resize forces a new deployment
+        AND there are running tasks to be replaced, so we do need the poller
+        to drive the provisioning -> running transition. Confirm the old
+        behavior still holds for running services."""
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                    "status": "ACTIVE",
+                    "desiredCount": 1,
+                    "runningCount": 1,
+                    "deployments": [{"id": "ecs-svc/primary", "status": "PRIMARY", "rolloutState": "IN_PROGRESS"}],
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock) as mock_await,
+            patch("core.containers.ecs_manager.asyncio.to_thread") as mock_to_thread,
+        ):
+
+            async def passthrough(fn, *args, **kwargs):
+                return fn(*args, **kwargs)
+
+            mock_to_thread.side_effect = passthrough
+
+            mock_repo.get_by_owner_id = AsyncMock(
+                return_value=_make_container_dict(
+                    status="running",
+                    task_definition_arn="arn:aws:ecs:us-east-1:123:task-definition/base:1",
+                )
+            )
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+
+            await manager.resize_user_container("user_test_123", new_cpu="1024", new_memory="2048")
+
+            import asyncio as _asyncio
+
+            await _asyncio.sleep(0)
+
+            mock_await.assert_called_once_with("user_test_123")
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -57,7 +57,7 @@ def mock_ecs_client():
         "services": [
             {
                 "serviceName": "openclaw-user_test_123-f4ae64abb2db",
-                "deployments": [{"rolloutState": "IN_PROGRESS"}],
+                "deployments": [{"id": "ecs-svc/primary", "status": "PRIMARY", "rolloutState": "IN_PROGRESS"}],
             }
         ]
     }
@@ -980,7 +980,9 @@ class TestAwaitRunningTransition:
         after N failed task placements, so we know the provision will never
         succeed on its own (bad image, crash loop, etc.)."""
         mock_ecs_client.list_tasks.return_value = {"taskArns": []}
-        mock_ecs_client.describe_services.return_value = {"services": [{"deployments": [{"rolloutState": "FAILED"}]}]}
+        mock_ecs_client.describe_services.return_value = {
+            "services": [{"deployments": [{"id": "ecs-svc/primary", "status": "PRIMARY", "rolloutState": "FAILED"}]}]
+        }
 
         with (
             patch("core.containers.ecs_manager.container_repo") as mock_repo,
@@ -1064,11 +1066,10 @@ class TestAwaitRunningTransition:
             assert fields["status"] == "running"
 
     @pytest.mark.asyncio
-    async def test_skips_describe_services_on_happy_path(self, manager, mock_ecs_client):
-        """When a healthy task is found immediately, we should NOT call
-        describe_services -- that call is only needed when we're waiting and
-        need to check for failure. Avoids hitting the 20 req/s limit on
-        describe_services when many containers are provisioning concurrently."""
+    async def test_one_describe_services_per_iteration_on_happy_path(self, manager, mock_ecs_client):
+        """describe_services consolidates two concerns (primary-deployment
+        filter + rolloutState failure detection) so a happy-path transition
+        costs one describe_services + one list_tasks + one describe_tasks."""
         mock_ecs_client.list_tasks.return_value = {"taskArns": ["arn:aws:ecs:us-east-1:123:task/cluster/abc"]}
         mock_ecs_client.describe_tasks.return_value = {
             "tasks": [
@@ -1094,7 +1095,162 @@ class TestAwaitRunningTransition:
 
             await manager._await_running_transition("user_test_123")
 
-            mock_ecs_client.describe_services.assert_not_called()
+            assert mock_ecs_client.describe_services.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_filters_running_tasks_by_primary_deployment(self, manager, mock_ecs_client):
+        """During a forced redeploy, the OLD task is still RUNNING while the
+        NEW deployment rolls out. _poll_running_task MUST only consider tasks
+        from the current PRIMARY deployment -- picking the old task would
+        flip status=running using the pre-deploy task_arn and mask a failing
+        rollout.
+
+        Filter mechanism: pass startedBy=<primary-deployment-id> to list_tasks.
+        ECS tags service-launched tasks with startedBy=ecs-svc/<deployment-id>.
+        """
+        # describe_services returns one PRIMARY and one ACTIVE (draining) deployment.
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "deployments": [
+                        {
+                            "id": "ecs-svc/new",
+                            "status": "PRIMARY",
+                            "rolloutState": "IN_PROGRESS",
+                        },
+                        {
+                            "id": "ecs-svc/old",
+                            "status": "ACTIVE",
+                            "rolloutState": "COMPLETED",
+                        },
+                    ]
+                }
+            ]
+        }
+
+        # list_tasks should be called with startedBy pointing at the PRIMARY.
+        mock_ecs_client.list_tasks.return_value = {"taskArns": ["arn:aws:ecs:us-east-1:123:task/cluster/new-task"]}
+        mock_ecs_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "lastStatus": "RUNNING",
+                    "attachments": [
+                        {
+                            "type": "ElasticNetworkInterface",
+                            "details": [{"name": "privateIPv4Address", "value": "10.0.1.99"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "is_healthy", return_value=True),
+            patch("core.containers.ecs_manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager._await_running_transition("user_test_123")
+
+            # list_tasks must have been called with startedBy=<primary-id>.
+            list_kwargs = mock_ecs_client.list_tasks.call_args.kwargs
+            assert list_kwargs.get("startedBy") == "ecs-svc/new", (
+                f"Expected startedBy='ecs-svc/new', got {list_kwargs.get('startedBy')!r}. "
+                "Must filter to the PRIMARY deployment's tasks so an old "
+                "drain-phase task doesn't trigger a premature status=running."
+            )
+
+            # With the filter correctly applied, the new task's ARN is recorded.
+            fields = mock_repo.update_fields.call_args.args[1]
+            assert fields["task_arn"] == "arn:aws:ecs:us-east-1:123:task/cluster/new-task"
+
+    @pytest.mark.asyncio
+    async def test_no_primary_deployment_keeps_polling(self, manager, mock_ecs_client):
+        """If describe_services returns no PRIMARY deployment (transient ECS
+        state during deployment churn), the poller should just sleep and
+        retry next iteration -- not write status=running or status=error."""
+        mock_ecs_client.describe_services.return_value = {"services": [{"deployments": []}]}
+        mock_ecs_client.list_tasks.return_value = {"taskArns": []}
+
+        # Cancel after one sleep so the loop exits.
+        import asyncio as _asyncio
+
+        sleep_calls = [0]
+
+        async def count_and_cancel(*args, **kwargs):
+            sleep_calls[0] += 1
+            if sleep_calls[0] >= 1:
+                raise _asyncio.CancelledError()
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.asyncio.sleep", side_effect=count_and_cancel),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            with pytest.raises(_asyncio.CancelledError):
+                await manager._await_running_transition("user_test_123")
+
+            # No status transition written either direction.
+            mock_repo.update_fields.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_detects_circuit_breaker_via_primary_deployment_rollout_state(self, manager, mock_ecs_client):
+        """rolloutState='FAILED' must be read from the PRIMARY deployment
+        specifically, not from deployments[0] blindly. During a rollout,
+        the ACTIVE (old) deployment can coexist with the new PRIMARY and
+        the list order is not guaranteed."""
+        import asyncio as _asyncio
+
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "deployments": [
+                        # Draining old deployment listed first.
+                        {
+                            "id": "ecs-svc/old",
+                            "status": "ACTIVE",
+                            "rolloutState": "COMPLETED",
+                        },
+                        # New PRIMARY failed.
+                        {
+                            "id": "ecs-svc/new",
+                            "status": "PRIMARY",
+                            "rolloutState": "FAILED",
+                        },
+                    ]
+                }
+            ]
+        }
+        mock_ecs_client.list_tasks.return_value = {"taskArns": []}
+
+        # If the implementation incorrectly reads deployments[0] and misses
+        # the FAILED PRIMARY, the loop would spin forever -- cancel after a
+        # few sleeps so the test fails loudly instead of hanging.
+        sleep_count = [0]
+
+        async def cancel_after_a_few(*args, **kwargs):
+            sleep_count[0] += 1
+            if sleep_count[0] > 3:
+                raise _asyncio.CancelledError()
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.asyncio.sleep", side_effect=cancel_after_a_few),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            # Expected: implementation finds FAILED PRIMARY -> writes error -> returns
+            # without ever reaching the cancellation guard.
+            await manager._await_running_transition("user_test_123")
+
+            mock_repo.update_fields.assert_called_once()
+            fields = mock_repo.update_fields.call_args.args[1]
+            assert fields["status"] == "error"
 
     @pytest.mark.asyncio
     async def test_respects_cancellation(self, manager, mock_ecs_client):
@@ -1105,7 +1261,9 @@ class TestAwaitRunningTransition:
 
         mock_ecs_client.list_tasks.return_value = {"taskArns": []}
         mock_ecs_client.describe_services.return_value = {
-            "services": [{"deployments": [{"rolloutState": "IN_PROGRESS"}]}]
+            "services": [
+                {"deployments": [{"id": "ecs-svc/primary", "status": "PRIMARY", "rolloutState": "IN_PROGRESS"}]}
+            ]
         }
 
         # asyncio.sleep raises CancelledError inside the poller loop.

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -520,6 +520,12 @@ class TestStartUserService:
                 service="openclaw-user_test_123-f4ae64abb2db",
                 desiredCount=1,
                 forceNewDeployment=True,
+                deploymentConfiguration={
+                    "deploymentCircuitBreaker": {
+                        "enable": True,
+                        "rollback": False,
+                    }
+                },
             )
             mock_repo.update_status.assert_called_once_with("user_test_123", "provisioning")
 
@@ -571,6 +577,28 @@ class TestStartUserService:
         with patch.object(manager, "_await_running_transition", new_callable=AsyncMock):
             with pytest.raises(EcsManagerError, match="Failed to start ECS service"):
                 await manager.start_user_service("user_test_123")
+
+    @pytest.mark.asyncio
+    async def test_start_service_enables_circuit_breaker_on_existing_services(self, manager, mock_ecs_client):
+        """start_user_service's update_service call must include the circuit
+        breaker so pre-existing services (created before Task 1) get upgraded
+        the first time we touch them. Otherwise _await_running_transition
+        can never receive rolloutState=FAILED and polls forever on a broken
+        pre-existing service."""
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="stopped"))
+            mock_repo.update_status = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+
+            await manager.start_user_service("user_test_123")
+
+            call_kwargs = mock_ecs_client.update_service.call_args.kwargs
+            dc = call_kwargs.get("deploymentConfiguration") or {}
+            cb = dc.get("deploymentCircuitBreaker") or {}
+            assert cb.get("enable") is True
+            assert cb.get("rollback") is False
 
 
 # ---------------------------------------------------------------------------
@@ -1133,6 +1161,47 @@ class TestResizeUserContainer:
 
             mock_await.assert_called_once_with("user_test_123")
 
+    @pytest.mark.asyncio
+    async def test_resize_enables_circuit_breaker_on_update_service(self, manager, mock_ecs_client):
+        """resize path's update_service must also carry the circuit breaker
+        so pre-existing services get upgraded on resize."""
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+            patch("core.containers.ecs_manager.asyncio.to_thread") as mock_to_thread,
+        ):
+            # asyncio.to_thread runs the sync boto3 call in a thread;
+            # intercept it so we can inspect kwargs.
+            async def passthrough(fn, *args, **kwargs):
+                return fn(*args, **kwargs)
+
+            mock_to_thread.side_effect = passthrough
+
+            mock_repo.get_by_owner_id = AsyncMock(
+                return_value=_make_container_dict(
+                    status="running",
+                    task_definition_arn="arn:aws:ecs:us-east-1:123:task-definition/base:1",
+                )
+            )
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+
+            await manager.resize_user_container("user_test_123", new_cpu="1024", new_memory="2048")
+
+            # resize issues two to_thread calls -- register_task_definition
+            # and update_service. Find the update_service call.
+            update_calls = [
+                call
+                for call in mock_to_thread.call_args_list
+                if getattr(call.args[0], "__name__", "") == "update_service"
+                or (call.args and call.args[0] == mock_ecs_client.update_service)
+            ]
+            assert update_calls, "Expected update_service to be called via asyncio.to_thread"
+            call_kwargs = update_calls[0].kwargs
+            dc = call_kwargs.get("deploymentConfiguration") or {}
+            cb = dc.get("deploymentCircuitBreaker") or {}
+            assert cb.get("enable") is True
+            assert cb.get("rollback") is False
+
 
 # ---------------------------------------------------------------------------
 # provision_user_container (full provisioning flow + recovery branches)
@@ -1248,3 +1317,74 @@ class TestProvisionUserContainer:
                 "at the end of provision_user_container is redundant."
             )
             mock_await.assert_called_with("user_test_123")
+
+    @pytest.mark.asyncio
+    async def test_redeploying_branch_enables_circuit_breaker(self, manager, mock_ecs_client):
+        """The redeploying branch (desired=1, running>0) issues an
+        update_service(forceNewDeployment=True). That call must carry the
+        circuit breaker so pre-existing services get upgraded mid-flight."""
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                    "status": "ACTIVE",
+                    "desiredCount": 1,
+                    "runningCount": 1,
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="running"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager.provision_user_container("user_test_123")
+
+            # update_service is called directly (not via asyncio.to_thread)
+            # in the redeploying branch.
+            call_kwargs = mock_ecs_client.update_service.call_args.kwargs
+            dc = call_kwargs.get("deploymentConfiguration") or {}
+            cb = dc.get("deploymentCircuitBreaker") or {}
+            assert cb.get("enable") is True
+            assert cb.get("rollback") is False
+
+    @pytest.mark.asyncio
+    async def test_provision_ecs_starting_no_poller_when_status_already_provisioning(self, manager, mock_ecs_client):
+        """If the DDB status is already 'provisioning' when we hit the
+        ECS-is-starting branch, we should NOT spawn another poller. An
+        earlier one is already running (or the startup reconciler will
+        pick up the row on next deploy). Spawning multiple pollers per
+        owner wastes ECS API quota under a slow cold start with repeated
+        /container/provision calls."""
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                    "status": "ACTIVE",
+                    "desiredCount": 1,
+                    "runningCount": 0,
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock) as mock_await,
+        ):
+            # Row already at status=provisioning.
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager.provision_user_container("user_test_123")
+
+            import asyncio as _asyncio
+
+            await _asyncio.sleep(0)
+
+            # No poller fired -- one's already running (or reconciler will catch it).
+            mock_await.assert_not_called()
+            # Also no DDB update (status already correct).
+            mock_repo.update_fields.assert_not_called()

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -946,6 +946,7 @@ class TestAwaitRunningTransition:
             "tasks": [
                 {
                     "lastStatus": "RUNNING",
+                    "startedBy": "ecs-svc/primary",
                     "attachments": [
                         {
                             "type": "ElasticNetworkInterface",
@@ -1041,6 +1042,7 @@ class TestAwaitRunningTransition:
             "tasks": [
                 {
                     "lastStatus": "RUNNING",
+                    "startedBy": "ecs-svc/primary",
                     "attachments": [
                         {
                             "type": "ElasticNetworkInterface",
@@ -1075,6 +1077,7 @@ class TestAwaitRunningTransition:
             "tasks": [
                 {
                     "lastStatus": "RUNNING",
+                    "startedBy": "ecs-svc/primary",
                     "attachments": [
                         {
                             "type": "ElasticNetworkInterface",
@@ -1134,6 +1137,7 @@ class TestAwaitRunningTransition:
             "tasks": [
                 {
                     "lastStatus": "RUNNING",
+                    "startedBy": "ecs-svc/new",
                     "attachments": [
                         {
                             "type": "ElasticNetworkInterface",
@@ -1154,15 +1158,132 @@ class TestAwaitRunningTransition:
 
             await manager._await_running_transition("user_test_123")
 
-            # list_tasks must have been called with startedBy=<primary-id>.
+            # list_tasks must NOT pass startedBy; AWS rejects it combined with
+            # serviceName. Filtering is done in-code using describe_tasks.
             list_kwargs = mock_ecs_client.list_tasks.call_args.kwargs
-            assert list_kwargs.get("startedBy") == "ecs-svc/new", (
-                f"Expected startedBy='ecs-svc/new', got {list_kwargs.get('startedBy')!r}. "
-                "Must filter to the PRIMARY deployment's tasks so an old "
-                "drain-phase task doesn't trigger a premature status=running."
+            assert "startedBy" not in list_kwargs, (
+                "list_tasks must not pass startedBy; AWS rejects it combined with serviceName."
             )
 
-            # With the filter correctly applied, the new task's ARN is recorded.
+            # With the in-code filter correctly applied, the new task's ARN is recorded.
+            fields = mock_repo.update_fields.call_args.args[1]
+            assert fields["task_arn"] == "arn:aws:ecs:us-east-1:123:task/cluster/new-task"
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_does_not_pass_startedby(self, manager, mock_ecs_client):
+        """ECS ListTasks rejects startedBy combined with serviceName:
+        `InvalidParameterException: cannot specify startedBy with other
+        arguments`. We must filter by deployment-id in-code (from
+        describe_tasks' startedBy field), not via the API filter."""
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "deployments": [
+                        {
+                            "id": "ecs-svc/new",
+                            "status": "PRIMARY",
+                            "rolloutState": "IN_PROGRESS",
+                        },
+                    ]
+                }
+            ]
+        }
+        mock_ecs_client.list_tasks.return_value = {"taskArns": ["arn:aws:ecs:us-east-1:123:task/cluster/new-task"]}
+        mock_ecs_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "lastStatus": "RUNNING",
+                    "startedBy": "ecs-svc/new",
+                    "attachments": [
+                        {
+                            "type": "ElasticNetworkInterface",
+                            "details": [{"name": "privateIPv4Address", "value": "10.0.1.99"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "is_healthy", return_value=True),
+            patch("core.containers.ecs_manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager._await_running_transition("user_test_123")
+
+            # list_tasks must NOT pass startedBy (AWS rejects it).
+            list_kwargs = mock_ecs_client.list_tasks.call_args.kwargs
+            assert "startedBy" not in list_kwargs, (
+                f"list_tasks must not pass startedBy; AWS rejects it combined "
+                f"with serviceName. Got kwargs: {list_kwargs}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_ignores_old_deployment_tasks_via_in_code_filter(self, manager, mock_ecs_client):
+        """During a rollout overlap, list_tasks returns both the OLD
+        drain-phase task and the NEW task. Filter in-code using each task's
+        startedBy from describe_tasks so we ignore the old task."""
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "deployments": [
+                        {
+                            "id": "ecs-svc/new",
+                            "status": "PRIMARY",
+                            "rolloutState": "IN_PROGRESS",
+                        },
+                    ]
+                }
+            ]
+        }
+        # Two running tasks come back; old one listed first.
+        mock_ecs_client.list_tasks.return_value = {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:123:task/cluster/old-task",
+                "arn:aws:ecs:us-east-1:123:task/cluster/new-task",
+            ]
+        }
+        mock_ecs_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-east-1:123:task/cluster/old-task",
+                    "lastStatus": "RUNNING",
+                    "startedBy": "ecs-svc/old",
+                    "attachments": [
+                        {
+                            "type": "ElasticNetworkInterface",
+                            "details": [{"name": "privateIPv4Address", "value": "10.0.1.1"}],
+                        }
+                    ],
+                },
+                {
+                    "taskArn": "arn:aws:ecs:us-east-1:123:task/cluster/new-task",
+                    "lastStatus": "RUNNING",
+                    "startedBy": "ecs-svc/new",
+                    "attachments": [
+                        {
+                            "type": "ElasticNetworkInterface",
+                            "details": [{"name": "privateIPv4Address", "value": "10.0.1.2"}],
+                        }
+                    ],
+                },
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "is_healthy", return_value=True),
+            patch("core.containers.ecs_manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager._await_running_transition("user_test_123")
+
+            # We must have transitioned using the NEW task, not the OLD one.
             fields = mock_repo.update_fields.call_args.args[1]
             assert fields["task_arn"] == "arn:aws:ecs:us-east-1:123:task/cluster/new-task"
 

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -1097,3 +1097,115 @@ class TestAwaitRunningTransition:
                 await manager._await_running_transition("user_test_123")
 
             mock_repo.update_fields.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# resize_user_container (per-user CPU/memory/image update path)
+# ---------------------------------------------------------------------------
+
+
+class TestResizeUserContainer:
+    """Tests resize path fires the transition poller.
+
+    resize writes status=provisioning via update_fields + ECS forceNewDeployment.
+    Without firing the poller, the row stays stuck at provisioning until the
+    next backend restart catches it via the startup reconciler."""
+
+    @pytest.mark.asyncio
+    async def test_resize_fires_running_transition_poller(self, manager, mock_ecs_client):
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock) as mock_await,
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(
+                return_value=_make_container_dict(
+                    status="running",
+                    task_definition_arn="arn:aws:ecs:us-east-1:123:task-definition/base:1",
+                )
+            )
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+
+            await manager.resize_user_container("user_test_123", new_cpu="1024", new_memory="2048")
+
+            import asyncio as _asyncio
+
+            await _asyncio.sleep(0)
+
+            mock_await.assert_called_once_with("user_test_123")
+
+
+# ---------------------------------------------------------------------------
+# provision_user_container (full provisioning flow + recovery branches)
+# ---------------------------------------------------------------------------
+
+
+class TestProvisionUserContainer:
+    """Tests for the recovery branches of provision_user_container that set
+    status=provisioning on an existing service row. Both branches must fire
+    the transition poller so the row drains back to status=running without
+    relying on the startup reconciler."""
+
+    @pytest.mark.asyncio
+    async def test_provision_redeploying_branch_fires_poller(self, manager, mock_ecs_client):
+        """When provision is called and the ECS service is already running,
+        the redeploying branch forces a new deployment and writes
+        status=provisioning. It MUST fire the poller so the row transitions
+        back to status=running once the new task is healthy."""
+        # Service exists with desired=1, running=1 -> redeploying branch.
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                    "status": "ACTIVE",
+                    "desiredCount": 1,
+                    "runningCount": 1,
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock) as mock_await,
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="running"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager.provision_user_container("user_test_123")
+
+            import asyncio as _asyncio
+
+            await _asyncio.sleep(0)
+
+            mock_await.assert_called_once_with("user_test_123")
+
+    @pytest.mark.asyncio
+    async def test_provision_ecs_starting_branch_fires_poller(self, manager, mock_ecs_client):
+        """When provision is called and ECS is mid-launch (desired=1, running=0),
+        the 'ECS is starting' branch writes status=provisioning and returns
+        without taking ECS action. It MUST fire the poller to drive the
+        transition once the task becomes healthy."""
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                    "status": "ACTIVE",
+                    "desiredCount": 1,
+                    "runningCount": 0,
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock) as mock_await,
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="stopped"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager.provision_user_container("user_test_123")
+
+            import asyncio as _asyncio
+
+            await _asyncio.sleep(0)
+
+            mock_await.assert_called_once_with("user_test_123")

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -323,6 +323,28 @@ class TestCreateUserService:
             assert mock_repo.update_fields.call_count == 3
 
     @pytest.mark.asyncio
+    async def test_create_service_enables_deployment_circuit_breaker(self, manager, mock_ecs_client, mock_efs_client):
+        """create_service MUST pass deploymentCircuitBreaker so ECS surfaces a
+        rolloutState=FAILED signal when a per-user provision fails (bad image,
+        crash loop). Without this, _await_running_transition has no way to
+        distinguish a slow start from a permanent failure."""
+        with patch("core.containers.ecs_manager.container_repo") as mock_repo:
+            mock_repo.upsert = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict())
+
+            await manager.create_user_service("user_test_123", "token-abc")
+
+            call_kwargs = mock_ecs_client.create_service.call_args.kwargs
+            dc = call_kwargs.get("deploymentConfiguration") or {}
+            cb = dc.get("deploymentCircuitBreaker") or {}
+            assert cb.get("enable") is True, (
+                "Deployment circuit breaker must be enabled so rolloutState=FAILED "
+                "can be used as the failure signal by _await_running_transition."
+            )
+            # rollback=False: no previous deployment to roll back to on first deploy.
+            assert cb.get("rollback") is False
+
+    @pytest.mark.asyncio
     async def test_ecs_failure_raises_and_rolls_back(self, manager, mock_ecs_client, mock_efs_client):
         """ECS API failure raises EcsManagerError, sets error status, and rolls back AWS resources."""
         with patch("core.containers.ecs_manager.container_repo") as mock_repo:

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -53,6 +53,16 @@ def mock_ecs_client():
     client.register_task_definition.return_value = {
         "taskDefinition": {"taskDefinitionArn": "arn:aws:ecs:us-east-1:123456789:task-definition/isol8-dev-openclaw:42"}
     }
+    client.describe_services.return_value = {
+        "services": [
+            {
+                "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                "deployments": [{"rolloutState": "IN_PROGRESS"}],
+            }
+        ]
+    }
+    client.list_tasks.return_value = {"taskArns": []}
+    client.describe_tasks.return_value = {"tasks": []}
     client.deregister_task_definition.return_value = {}
     return client
 
@@ -855,3 +865,205 @@ class TestEcsManagerError:
         """EcsManagerError defaults user_id to empty string."""
         err = EcsManagerError("generic failure")
         assert err.user_id == ""
+
+
+# ---------------------------------------------------------------------------
+# _await_running_transition (durable provisioning -> running poller)
+# ---------------------------------------------------------------------------
+
+
+class TestAwaitRunningTransition:
+    """The poller that drives provisioning -> running in the background.
+
+    Must be durable (no fixed timeout) and have proper exit conditions so a
+    container can never be left stuck at status=provisioning forever while
+    actually running in ECS.
+    """
+
+    @pytest.mark.asyncio
+    async def test_transitions_to_running_when_task_healthy(self, manager, mock_ecs_client):
+        """Container becomes reachable -> write status=running and exit."""
+        mock_ecs_client.list_tasks.return_value = {"taskArns": ["arn:aws:ecs:us-east-1:123:task/cluster/abc"]}
+        mock_ecs_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "lastStatus": "RUNNING",
+                    "attachments": [
+                        {
+                            "type": "ElasticNetworkInterface",
+                            "details": [{"name": "privateIPv4Address", "value": "10.0.1.42"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "is_healthy", return_value=True),
+            patch("core.containers.ecs_manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager._await_running_transition("user_test_123")
+
+            mock_repo.update_fields.assert_called_once()
+            fields = mock_repo.update_fields.call_args.args[1]
+            assert fields["status"] == "running"
+            assert fields["substatus"] == "gateway_healthy"
+            assert fields["task_arn"] == "arn:aws:ecs:us-east-1:123:task/cluster/abc"
+
+    @pytest.mark.asyncio
+    async def test_transitions_to_error_when_circuit_breaker_trips(self, manager, mock_ecs_client):
+        """ECS deployment rolloutState=FAILED -> write status=error and exit.
+
+        This is the definitive failure signal: the circuit breaker only trips
+        after N failed task placements, so we know the provision will never
+        succeed on its own (bad image, crash loop, etc.)."""
+        mock_ecs_client.list_tasks.return_value = {"taskArns": []}
+        mock_ecs_client.describe_services.return_value = {"services": [{"deployments": [{"rolloutState": "FAILED"}]}]}
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager._await_running_transition("user_test_123")
+
+            mock_repo.update_fields.assert_called_once()
+            fields = mock_repo.update_fields.call_args.args[1]
+            assert fields["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_exits_silently_when_ddb_status_changed_externally(self, manager, mock_ecs_client):
+        """If another actor (admin, reaper, re-provision) changed the DDB status
+        under us, exit without writing anything -- our job is done or obsolete."""
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="stopped"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager._await_running_transition("user_test_123")
+
+            mock_repo.update_fields.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_exits_silently_when_row_missing(self, manager, mock_ecs_client):
+        """Container row deleted -> exit. No row to transition."""
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=None)
+            mock_repo.update_fields = AsyncMock()
+
+            await manager._await_running_transition("user_test_123")
+
+            mock_repo.update_fields.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_keeps_polling_when_task_not_yet_healthy(self, manager, mock_ecs_client):
+        """On iteration N no running task, on iteration N+1 it's healthy -> transition.
+
+        Regression for the 120s timeout bug: a container that takes >2 minutes
+        to become reachable MUST still get transitioned when it eventually is."""
+        # First poll: no tasks. Second poll: a healthy task.
+        mock_ecs_client.list_tasks.side_effect = [
+            {"taskArns": []},
+            {"taskArns": ["arn:aws:ecs:us-east-1:123:task/cluster/abc"]},
+        ]
+        mock_ecs_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "lastStatus": "RUNNING",
+                    "attachments": [
+                        {
+                            "type": "ElasticNetworkInterface",
+                            "details": [{"name": "privateIPv4Address", "value": "10.0.1.42"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "is_healthy", return_value=True),
+            patch("core.containers.ecs_manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager._await_running_transition("user_test_123")
+
+            mock_repo.update_fields.assert_called_once()
+            fields = mock_repo.update_fields.call_args.args[1]
+            assert fields["status"] == "running"
+
+    @pytest.mark.asyncio
+    async def test_skips_describe_services_on_happy_path(self, manager, mock_ecs_client):
+        """When a healthy task is found immediately, we should NOT call
+        describe_services -- that call is only needed when we're waiting and
+        need to check for failure. Avoids hitting the 20 req/s limit on
+        describe_services when many containers are provisioning concurrently."""
+        mock_ecs_client.list_tasks.return_value = {"taskArns": ["arn:aws:ecs:us-east-1:123:task/cluster/abc"]}
+        mock_ecs_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "lastStatus": "RUNNING",
+                    "attachments": [
+                        {
+                            "type": "ElasticNetworkInterface",
+                            "details": [{"name": "privateIPv4Address", "value": "10.0.1.42"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "is_healthy", return_value=True),
+            patch("core.containers.ecs_manager.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            await manager._await_running_transition("user_test_123")
+
+            mock_ecs_client.describe_services.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_respects_cancellation(self, manager, mock_ecs_client):
+        """Clean shutdown: if the event loop cancels the task (backend restart),
+        the poller exits without raising into the caller and without writing
+        a status transition."""
+        import asyncio as _asyncio
+
+        mock_ecs_client.list_tasks.return_value = {"taskArns": []}
+        mock_ecs_client.describe_services.return_value = {
+            "services": [{"deployments": [{"rolloutState": "IN_PROGRESS"}]}]
+        }
+
+        # asyncio.sleep raises CancelledError inside the poller loop.
+        async def cancel_on_sleep(*args, **kwargs):
+            raise _asyncio.CancelledError()
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.asyncio.sleep", side_effect=cancel_on_sleep),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock()
+
+            # Must not swallow CancelledError -- asyncio task cancellation
+            # semantics require it to propagate out.
+            with pytest.raises(_asyncio.CancelledError):
+                await manager._await_running_transition("user_test_123")
+
+            mock_repo.update_fields.assert_not_called()

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -1209,3 +1209,42 @@ class TestProvisionUserContainer:
             await _asyncio.sleep(0)
 
             mock_await.assert_called_once_with("user_test_123")
+
+    @pytest.mark.asyncio
+    async def test_provision_full_flow_fires_poller_exactly_once(self, manager, mock_ecs_client, mock_efs_client):
+        """Full-provision path (no existing service) must fire
+        _await_running_transition EXACTLY ONCE, not twice.
+
+        start_user_service fires one poller (Task 3). Historically
+        provision_user_container fired another at the very end. That's
+        duplicate work -- two identical long-lived tasks doing the same
+        list_tasks/describe_services polling and racing to write the DDB
+        transition. Keep only one."""
+
+        # Make _service_exists return None so we go through the full-provisioning path.
+        mock_ecs_client.describe_services.return_value = {"services": []}
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock) as mock_await,
+            patch.object(manager, "write_user_configs", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=None)
+            mock_repo.upsert = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_status = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+
+            await manager.provision_user_container("user_test_123")
+
+            # Let any fire-and-forget tasks be scheduled.
+            import asyncio as _asyncio
+
+            await _asyncio.sleep(0)
+
+            # Exactly one poller, not two.
+            assert mock_await.await_count == 1, (
+                f"Expected exactly 1 poller, got {mock_await.await_count}. "
+                "start_user_service fires the poller; the outer create_task "
+                "at the end of provision_user_container is redundant."
+            )
+            mock_await.assert_called_with("user_test_123")

--- a/apps/backend/tests/unit/test_main_lifespan.py
+++ b/apps/backend/tests/unit/test_main_lifespan.py
@@ -24,3 +24,81 @@ async def test_safe_idle_checker_emits_crash_metric_on_exception():
         await _safe_idle_checker()
 
     mock_put_metric.assert_any_call("gateway.idle_checker.crash")
+
+
+@pytest.mark.asyncio
+async def test_resume_provisioning_transitions_kicks_off_poller_per_row():
+    """After a backend restart any container still in status=provisioning in
+    DDB MUST have its transition poller resumed. Without this, a deploy that
+    lands mid-provision permanently strands the container at status=provisioning
+    because the original asyncio task was killed on shutdown."""
+    from main import _resume_provisioning_transitions
+
+    provisioning_rows = [
+        {"owner_id": "user_a", "status": "provisioning"},
+        {"owner_id": "user_b", "status": "provisioning"},
+    ]
+
+    mock_ecs = MagicMock()
+    mock_ecs._await_running_transition = AsyncMock()
+
+    with (
+        patch(
+            "main.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=provisioning_rows,
+        ) as mock_get,
+        patch("main.get_ecs_manager", return_value=mock_ecs),
+    ):
+        await _resume_provisioning_transitions()
+
+        # Give fire-and-forget tasks a chance to be scheduled and awaited.
+        import asyncio as _asyncio
+
+        await _asyncio.sleep(0)
+
+        mock_get.assert_awaited_once_with("provisioning")
+        assert mock_ecs._await_running_transition.await_count == 2
+        awaited_users = {call.args[0] for call in mock_ecs._await_running_transition.await_args_list}
+        assert awaited_users == {"user_a", "user_b"}
+
+
+@pytest.mark.asyncio
+async def test_resume_provisioning_transitions_tolerates_empty():
+    """Zero provisioning rows -> no-op, no error."""
+    from main import _resume_provisioning_transitions
+
+    mock_ecs = MagicMock()
+    mock_ecs._await_running_transition = AsyncMock()
+
+    with (
+        patch(
+            "main.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("main.get_ecs_manager", return_value=mock_ecs),
+    ):
+        await _resume_provisioning_transitions()
+
+        mock_ecs._await_running_transition.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resume_provisioning_transitions_tolerates_ddb_failure():
+    """get_by_status raising MUST NOT crash backend startup -- reconciliation
+    is best-effort; a transient DDB error should be logged and shrug off."""
+    from main import _resume_provisioning_transitions
+
+    with (
+        patch(
+            "main.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("ddb transient"),
+        ),
+        patch("main.get_ecs_manager") as mock_get_ecs,
+    ):
+        # Must not raise.
+        await _resume_provisioning_transitions()
+
+        mock_get_ecs.assert_not_called()


### PR DESCRIPTION
## Summary

Root-cause fix for containers stuck at `status="provisioning"` in DynamoDB while actually running in ECS Fargate. The free-tier reaper (PR #265) queries `get_by_status("running")` so these zombie rows were invisible to it — a free container that hit this bug ran for 24h+ in prod.

## The bug

`_await_running_transition` was a fire-and-forget `asyncio.create_task` with a fixed 120s budget (30 × 4s). Containers whose ECS task took longer than 2 minutes to become reachable were abandoned; the DDB row stayed at `status="provisioning"` forever while the ECS service kept running.

Compounding issues:
- Per-user ECS services lacked the deployment circuit breaker — no definitive failure signal to distinguish "slow start" from "permanent failure".
- A backend deploy killed the in-process poller, stranding any in-flight provision.
- Multiple code paths set `status="provisioning"` without firing the poller.

## Fix

1. **Enable deployment circuit breaker** on per-user services (`8f6a81fb`). ECS now surfaces `rolloutState="FAILED"` after 2 failed task placements.
2. **Durable poller** (`fb02b4bf`): rewrite `_await_running_transition` as a `while True` loop with four real exit conditions — healthy → `running`, `rolloutState="FAILED"` → `error`, external DDB state change → silent return, `CancelledError` → propagate. No fixed timeout.
3. **Invariant: every path that sets `status="provisioning"` fires the poller** (`3acd221d`, `c24f4f2a`) — covers `start_user_service`, `resize_user_container`, and both `provision_user_container` "existing service" branches.
4. **Startup reconciler** (`afbb6fa3`) in `main.py` lifespan scans for any rows still at `status="provisioning"` and re-fires the poller. Closes the backend-restart race.

## Test plan

- [x] 57 unit tests in `test_ecs_manager.py` (new `TestAwaitRunningTransition`, `TestResizeUserContainer`, `TestProvisionUserContainer` classes + extensions to existing ones) cover every exit path and every code path that fires the poller
- [x] 4 unit tests in `test_main_lifespan.py` cover the reconciler's three branches (multi-row, empty, DDB failure) plus the existing idle-checker crash test
- [x] Full backend suite: 702 passing
- [ ] Post-deploy: verify the two currently-stuck production containers (`user_3CNDd8aX7xssuRvFFLz5ufXzsZl` in prod, `user_3CGfQjbn8P3n6ZzGxz1txeqEFzC` in dev) transition to `status="running"` on first backend restart (startup reconciler)
- [ ] Post-deploy: verify the free-tier reaper begins seeing those containers and scales them to zero per the 5-min idle SLA
- [ ] Post-deploy: monitor for new `"Deployment circuit breaker tripped"` log lines as the mechanism that previously silently left stuck rows now surfaces real failures

## Docs

- Spec: `docs/superpowers/specs/2026-04-15-resilient-provisioning-state-machine-design.md`
- Plan: `docs/superpowers/plans/2026-04-16-resilient-provisioning-state-machine.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)