### PR TITLE
feat(infra): switch container provisioning to extended OpenClaw image

### DIFF
--- a/apps/infra/lib/stacks/container-stack.ts
+++ b/apps/infra/lib/stacks/container-stack.ts
@@ -12,7 +12,17 @@ import { Construct } from "constructs";
 
 // Single source of truth for the pinned OpenClaw container image.
 // Bump openclaw-version.json at the repo root to upgrade.
-const OPENCLAW_VERSION: { full: string; image: string; tag: string } = JSON.parse(
+type OpenClawVersionConfig = {
+  upstream: string;
+  image: string;
+  tag: string;
+  full: string;
+  extendedImage: string;
+  dev: { tag: string };
+  prod: { tag: string };
+  notes?: string;
+};
+const OPENCLAW_VERSION: OpenClawVersionConfig = JSON.parse(
   fs.readFileSync(path.join(__dirname, "..", "..", "..", "..", "openclaw-version.json"), "utf8"),
 );
 
@@ -211,30 +221,30 @@ export class ContainerStack extends cdk.Stack {
       executionRole: this.taskExecutionRole,
     });
 
-    // Startup command installs runtime dependencies before launching the
-    // OpenClaw gateway.  Mirrors the Terraform task definition in
-    // apps/terraform/modules/ecs/main.tf so both infra paths stay in sync.
+    // Startup command — almost everything (apt packages, pip, npm globals,
+    // gh, uv) is now baked into the extended OpenClaw image. We only:
+    //   1. Install markdown-converter via clawhub (lives at clawhub.com,
+    //      not bundled in the image — landing dir comes from
+    //      CLAWHUB_WORKDIR=/home/node/.openclaw, set as a container env var).
+    //   2. Launch the gateway.
+    // Cold-start drops from ~30s to ~5s.
     const startupCommand = [
-      // System packages
-      "apt-get update -qq && apt-get install -y -qq socat python3-pip sqlite3 build-essential python3 > /dev/null 2>&1",
-      "pip install --break-system-packages websockets > /dev/null 2>&1",
-      // npm global prefix + PATH for the node user
-      "export NPM_CONFIG_PREFIX=/home/node/.npm-global && export PATH=$NPM_CONFIG_PREFIX/bin:$PATH",
-      // npm packages: MCP bridge, skill hub, OpenAI compat, QMD memory backend
-      "npm i -g --ignore-scripts mcporter clawhub openai 2>/dev/null",
-      "npm i -g @tobilu/qmd 2>/dev/null",
-      // GitHub CLI
-      'GH_VER=2.65.0 && wget -qO- https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_amd64.tar.gz | tar xz -C /tmp && cp /tmp/gh_${GH_VER}_linux_amd64/bin/gh $NPM_CONFIG_PREFIX/bin/gh 2>/dev/null',
-      // uv (Python package manager)
-      "wget -qO- https://astral.sh/uv/install.sh | HOME=/home/node sh 2>/dev/null && export PATH=/home/node/.local/bin:$PATH",
-      // Bundled skills
       "clawhub install markdown-converter --no-input 2>/dev/null",
-      // Launch gateway
       "exec node /app/openclaw.mjs gateway --port 18789 --bind lan",
     ].join("; ");
 
+    // Image selection: use the extended ECR image once the per-env tag has been
+    // promoted past the "bootstrap" placeholder. Until then, fall back to the
+    // legacy upstream image so the env keeps deploying. This lets us flip dev
+    // and prod independently via openclaw-version.json bumps without coupling.
+    const envTag = OPENCLAW_VERSION[props.environment as "dev" | "prod"].tag;
+    const containerImage =
+      envTag === "bootstrap"
+        ? ecs.ContainerImage.fromRegistry(OPENCLAW_VERSION.full)
+        : ecs.ContainerImage.fromEcrRepository(this.openclawExtendedRepo, envTag);
+
     const openclawContainer = openclawTaskDef.addContainer("openclaw", {
-      image: ecs.ContainerImage.fromRegistry(OPENCLAW_VERSION.full),
+      image: containerImage,
       essential: true,
       command: ["sh", "-c", startupCommand],
       user: "0:0",

--- a/apps/infra/lib/stacks/container-stack.ts
+++ b/apps/infra/lib/stacks/container-stack.ts
@@ -204,84 +204,6 @@ export class ContainerStack extends cdk.Stack {
       }),
     );
 
-    // Base OpenClaw task definition — the backend clones this per user,
-    // replacing the EFS access point for data isolation.
-    const env = props.environment;
-    const openclawLogGroup = new cdk.aws_logs.LogGroup(this, "OpenClawLogGroup", {
-      logGroupName: `/isol8/${env}/openclaw`,
-      retention: cdk.aws_logs.RetentionDays.TWO_WEEKS,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    });
-
-    const openclawTaskDef = new ecs.FargateTaskDefinition(this, "OpenClawTaskDef", {
-      family: `isol8-${env}-openclaw`,
-      cpu: 1024,
-      memoryLimitMiB: 2048,
-      taskRole: this.taskRole,
-      executionRole: this.taskExecutionRole,
-    });
-
-    // Startup command — almost everything (apt packages, pip, npm globals,
-    // gh, uv) is now baked into the extended OpenClaw image. We only:
-    //   1. Install markdown-converter via clawhub (lives at clawhub.com,
-    //      not bundled in the image — landing dir comes from
-    //      CLAWHUB_WORKDIR=/home/node/.openclaw, set as a container env var).
-    //   2. Launch the gateway.
-    // Cold-start drops from ~30s to ~5s.
-    const startupCommand = [
-      "clawhub install markdown-converter --no-input 2>/dev/null",
-      "exec node /app/openclaw.mjs gateway --port 18789 --bind lan",
-    ].join("; ");
-
-    // Image selection: use the extended ECR image once the per-env tag has been
-    // promoted past the "bootstrap" placeholder. Until then, fall back to the
-    // legacy upstream image so the env keeps deploying. This lets us flip dev
-    // and prod independently via openclaw-version.json bumps without coupling.
-    const envTag = OPENCLAW_VERSION[props.environment as "dev" | "prod"].tag;
-    const containerImage =
-      envTag === "bootstrap"
-        ? ecs.ContainerImage.fromRegistry(OPENCLAW_VERSION.full)
-        : ecs.ContainerImage.fromEcrRepository(this.openclawExtendedRepo, envTag);
-
-    const openclawContainer = openclawTaskDef.addContainer("openclaw", {
-      image: containerImage,
-      essential: true,
-      command: ["sh", "-c", startupCommand],
-      user: "0:0",
-      workingDirectory: "/home/node",
-      environment: {
-        HOME: "/home/node",
-        CHOKIDAR_USEPOLLING: "true",
-        // Redirect clawhub installs to the OpenClaw managed-skills directory
-        // (~/.openclaw/skills) so they're scanned by every agent. Without
-        // this, clawhub falls through to agents.defaults.workspace and lands
-        // at /home/node/.openclaw/workspaces/skills — a path no scanner checks.
-        CLAWHUB_WORKDIR: "/home/node/.openclaw",
-      },
-      portMappings: [{ containerPort: 18789, protocol: ecs.Protocol.TCP }],
-      logging: ecs.LogDrivers.awsLogs({
-        logGroup: openclawLogGroup,
-        streamPrefix: "openclaw",
-      }),
-    });
-
-    // Mount EFS workspace — OpenClaw reads openclaw.json and agent files from here
-    openclawContainer.addMountPoints({
-      containerPath: "/home/node/.openclaw",
-      sourceVolume: "openclaw-workspace",
-      readOnly: false,
-    });
-
-    // Add EFS volume — the backend replaces the access point per user
-    openclawTaskDef.addVolume({
-      name: "openclaw-workspace",
-      efsVolumeConfiguration: {
-        fileSystemId: this.efsFileSystem.fileSystemId,
-        transitEncryption: "ENABLED",
-        authorizationConfig: { iam: "ENABLED" },
-      },
-    });
-
     // Extended OpenClaw image — built and pushed by
     // .github/workflows/build-openclaw-image.yml. Per-env tags live in
     // openclaw-version.json (extendedImage + dev.tag/prod.tag). After the
@@ -291,6 +213,9 @@ export class ContainerStack extends cdk.Stack {
     // The repository is account-scoped, so we create it only in the dev stack
     // and reference it by name in prod. This keeps a single source of truth
     // for image tags (one ECR repo, two env-tagged image references).
+    //
+    // Initialized BEFORE the container task def so the image-selection
+    // expression below can dereference it.
     if (props.environment === "dev") {
       const repo = new ecr.Repository(this, "OpenclawExtendedRepo", {
         repositoryName: "isol8/openclaw-extended",
@@ -346,5 +271,89 @@ export class ContainerStack extends cdk.Stack {
         "isol8/openclaw-extended",
       );
     }
+
+    // Base OpenClaw task definition — the backend clones this per user,
+    // replacing the EFS access point for data isolation.
+    const env = props.environment;
+    const openclawLogGroup = new cdk.aws_logs.LogGroup(this, "OpenClawLogGroup", {
+      logGroupName: `/isol8/${env}/openclaw`,
+      retention: cdk.aws_logs.RetentionDays.TWO_WEEKS,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const openclawTaskDef = new ecs.FargateTaskDefinition(this, "OpenClawTaskDef", {
+      family: `isol8-${env}-openclaw`,
+      cpu: 1024,
+      memoryLimitMiB: 2048,
+      taskRole: this.taskRole,
+      executionRole: this.taskExecutionRole,
+    });
+
+    // Startup command — almost everything (apt packages, pip, npm globals,
+    // gh, uv) is now baked into the extended OpenClaw image. We only:
+    //   1. Install markdown-converter via clawhub (lives at clawhub.com,
+    //      not bundled in the image — landing dir comes from
+    //      CLAWHUB_WORKDIR=/home/node/.openclaw, set as a container env var).
+    //   2. Launch the gateway.
+    // Cold-start drops from ~30s to ~5s.
+    const startupCommand = [
+      "clawhub install markdown-converter --no-input 2>/dev/null",
+      "exec node /app/openclaw.mjs gateway --port 18789 --bind lan",
+    ].join("; ");
+
+    // Image selection: use the extended ECR image once the per-env tag has been
+    // promoted past the "bootstrap" placeholder. Until then, fall back to the
+    // legacy upstream image so the env keeps deploying. This lets us flip dev
+    // and prod independently via openclaw-version.json bumps without coupling.
+    // Unknown envs (e.g. "local") default to legacy via the optional chain.
+    const envCfg =
+      props.environment === "dev" || props.environment === "prod"
+        ? OPENCLAW_VERSION[props.environment]
+        : undefined;
+    const envTag = envCfg?.tag ?? "bootstrap";
+    const containerImage =
+      envTag === "bootstrap"
+        ? ecs.ContainerImage.fromRegistry(OPENCLAW_VERSION.full)
+        : ecs.ContainerImage.fromEcrRepository(this.openclawExtendedRepo, envTag);
+
+    const openclawContainer = openclawTaskDef.addContainer("openclaw", {
+      image: containerImage,
+      essential: true,
+      command: ["sh", "-c", startupCommand],
+      user: "0:0",
+      workingDirectory: "/home/node",
+      environment: {
+        HOME: "/home/node",
+        CHOKIDAR_USEPOLLING: "true",
+        // Redirect clawhub installs to the OpenClaw managed-skills directory
+        // (~/.openclaw/skills) so they're scanned by every agent. Without
+        // this, clawhub falls through to agents.defaults.workspace and lands
+        // at /home/node/.openclaw/workspaces/skills — a path no scanner checks.
+        CLAWHUB_WORKDIR: "/home/node/.openclaw",
+      },
+      portMappings: [{ containerPort: 18789, protocol: ecs.Protocol.TCP }],
+      logging: ecs.LogDrivers.awsLogs({
+        logGroup: openclawLogGroup,
+        streamPrefix: "openclaw",
+      }),
+    });
+
+    // Mount EFS workspace — OpenClaw reads openclaw.json and agent files from here
+    openclawContainer.addMountPoints({
+      containerPath: "/home/node/.openclaw",
+      sourceVolume: "openclaw-workspace",
+      readOnly: false,
+    });
+
+    // Add EFS volume — the backend replaces the access point per user
+    openclawTaskDef.addVolume({
+      name: "openclaw-workspace",
+      efsVolumeConfiguration: {
+        fileSystemId: this.efsFileSystem.fileSystemId,
+        transitEncryption: "ENABLED",
+        authorizationConfig: { iam: "ENABLED" },
+      },
+    });
+
   }
 }

--- a/apps/infra/openclaw/Dockerfile
+++ b/apps/infra/openclaw/Dockerfile
@@ -35,10 +35,10 @@ RUN curl -sSL https://astral.sh/uv/install.sh | HOME=/tmp sh && \
     install -m 755 /tmp/.local/bin/uv /usr/local/bin/uv
 
 # ---- Layer 5: pip packages ----
-RUN pip install --break-system-packages openai-whisper websockets
-
-# ---- Layer 6: uv-installed skills ----
-RUN uv tool install --bin-dir /usr/local/bin nano-pdf
+# nano-pdf moved here from a uv-tool layer — uv tool install doesn't accept
+# --bin-dir, and pip puts entry points on PATH (/usr/local/bin via system
+# Python). One less flag, one less layer.
+RUN pip install --break-system-packages openai-whisper websockets nano-pdf
 
 # ---- Layer 7: Go-installed skills ----
 ENV GOPATH=/opt/go GOBIN=/usr/local/bin


### PR DESCRIPTION
## Summary

Wires container-stack.ts to use the extended OpenClaw image once each env's tag is bumped past the "bootstrap" placeholder. Also fixes a Dockerfile bug caught by the first build (uv tool install doesn't accept --bin-dir).

**This PR by itself does NOT switch images** — both dev and prod still resolve to the legacy upstream image because both tags are "bootstrap". The actual switch happens in tiny follow-up PRs that bump the per-env tag in `openclaw-version.json` (one for dev, one for prod after dev verification).

## Changes

### container-stack.ts
- New `OpenClawVersionConfig` type matching the post-migration JSON shape
- Image source is now conditional on the env's tag:
  - `tag === "bootstrap"` → fall back to legacy `alpine/openclaw` (current behavior)
  - `tag !== "bootstrap"` → use extended ECR image with that tag
- Startup command stripped of all runtime installs (apt/pip/npm/wget). Those are now baked into the extended image. Cold start drops from ~30s to ~5s once an env flips to the extended image.

### Dockerfile fix
- `nano-pdf` moved from `uv tool install` to `pip install`. `uv tool install` doesn't accept `--bin-dir` — caught by the first build attempt failing on this layer.

## Sequence after merge

1. Deploy applies new container-stack.ts (no image change yet — both envs still on legacy)
2. Dockerfile change auto-triggers `build-openclaw-image` workflow
3. Workflow builds + pushes image to ECR
4. Tiny follow-up PR bumps `openclaw-version.json#dev.tag` to the new tag → dev deploy flips dev to the extended image
5. Verify dev (existing dev users see Track 2 update banner)
6. Tiny PR bumps `prod.tag` → prod flips
7. Run per-user task-def migration script for existing prod containers

## Test plan

- [x] `npx jest` in apps/infra: 20/20 pass
- [x] `npx cdk synth` clean for both `dev/*` and `prod/*` (both still produce legacy image source since tag is "bootstrap")
- [ ] After merge: deploy completes (no image change for either env)
- [ ] After merge: build workflow auto-triggers + first image lands in ECR

Spec: \`docs/superpowers/specs/2026-04-16-extended-openclaw-image-design.md\`
Plan: \`docs/superpowers/plans/2026-04-16-extended-openclaw-image.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)