### PR TITLE
fix(infra): build openhue with 'go build' (avoids GoReleaser dep)

### DIFF
--- a/apps/infra/openclaw/Dockerfile
+++ b/apps/infra/openclaw/Dockerfile
@@ -74,9 +74,11 @@ RUN git clone --depth=1 https://github.com/Yakitrak/notesmd-cli.git /tmp/notesmd
     rm -rf /tmp/notesmd /root/.cache/go-build
 
 # ---- Layer 8b: openhue ----
+# `make build` requires GoReleaser, which is overkill (it builds release
+# artifacts for multiple platforms). For a single linux/amd64 binary,
+# `go build` from the repo root works directly.
 RUN git clone --depth=1 https://github.com/openhue/openhue-cli.git /tmp/openhue && \
-    cd /tmp/openhue && make build && \
-    install -m 755 /tmp/openhue/openhue /usr/local/bin/openhue && \
+    cd /tmp/openhue && go build -o /usr/local/bin/openhue . && \
     rm -rf /tmp/openhue /root/.cache/go-build
 
 # ---- Layer 9: himalaya (pre-built binary via install.sh) ----


### PR DESCRIPTION
## Summary

Continuing to unblock the build-openclaw-image workflow:

- Previous build failures: 1Password ARM mismatch (PR #280 docs fix), `uv tool install --bin-dir` invalid flag (PR #282), Debian's apt golang-go is 1.19 (PR #283)
- This build's failure: openhue-cli's `make build` target requires GoReleaser, which is overkill for producing a single linux/amd64 binary

## Fix

Replace `make build` with `go build .` from the repo root.

## Test plan

- [ ] After merge: workflow auto-triggers (Dockerfile changed) → build progresses past openhue layer
- [ ] If more layers fail, fix in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)