### PR TITLE
feat(infra): bump dev.tag to 2026.4.5-5656b8a — flips dev to extended image

### DIFF
--- a/openclaw-version.json
+++ b/openclaw-version.json
@@ -5,7 +5,7 @@
   "tag": "2026.4.5",
   "full": "alpine/openclaw:2026.4.5",
   "extendedImage": "877352799272.dkr.ecr.us-east-1.amazonaws.com/isol8/openclaw-extended",
-  "dev":  { "tag": "bootstrap" },
+  "dev":  { "tag": "2026.4.5-5656b8a" },
   "prod": { "tag": "bootstrap" },
   "notes": "Two image references coexist during the migration to the extended image. The legacy `image`/`tag`/`full` fields point at the upstream alpine/openclaw image used by current container-stack.ts (Task 1-8 of the plan). The new `extendedImage` + per-env `dev.tag`/`prod.tag` fields point at our custom ECR image used after Task 9 lands. The 'bootstrap' tag is a placeholder until the first CI build completes — it intentionally won't resolve, so any deploy referencing it before the first build will fail loudly."
 }


### PR DESCRIPTION
## Summary

First successful build of `isol8/openclaw-extended` is in ECR. This 1-line PR flips dev's per-user OpenClaw containers to use it on next provision (or scale-to-zero restart for free tier). Existing dev containers see the Track 2 update banner and opt in when ready.

## Image

- Tag: \`2026.4.5-5656b8a\`
- Pushed: 2026-04-16T22:21:47-04:00
- Manifest size: 8.64 GB (compressed layers ~1.5-2 GB on disk)

## Test plan

- [ ] After merge: dev deploy completes (no resource changes — just new task def with new image source)
- [ ] Bring up a fresh dev container — verify image is the ECR extended one
- [ ] Verify a few skills are callable (ffmpeg, jq, op, gh, eightctl, gemini, etc.)
- [ ] Existing dev users see Track 2 update banner; opt-in works
- [ ] Cold-start drops from ~30s to ~5s

After dev verification, follow-up tiny PR copies dev.tag → prod.tag, then run per-user task-def migration script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)