### PR TITLE
fix(gateway): kill the post-login cascade that stops freshly-active containers

### DIFF
--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -369,12 +369,22 @@ class EcsManager:
         logger.info("Stopped ECS service %s for user %s", service_name, user_id)
 
     async def start_user_service(self, user_id: str) -> None:
-        """Scale a user's ECS service to 1 (running) with forced new deployment.
+        """Scale a user's ECS service to 1 (running).
 
         Fires _await_running_transition afterwards so the provisioning -> running
         transition happens eventually even if the user disconnects before the
         ECS task finishes warming up. Without this, cold-start restart rows
         get stuck at status=provisioning forever.
+
+        Does NOT pass forceNewDeployment=True. The historical use case here was
+        a stopped service (desiredCount=0) — `desiredCount=1` alone is enough
+        to launch a new task. Forcing a new deployment was unintentionally
+        destructive when called in racy contexts: if `stop_user_service` had
+        just set `desiredCount=0` but ECS hadn't yet stopped the old task,
+        a follow-up `start_user_service` with forceNewDeployment would
+        terminate that still-running task and replace it with a fresh one,
+        producing a ~30s outage right after a user logged in (the cascade
+        traced in the post-incident review of the 47h-uptime container).
 
         Args:
             user_id: Clerk user ID.
@@ -391,7 +401,6 @@ class EcsManager:
                     cluster=self._cluster,
                     service=service_name,
                     desiredCount=1,
-                    forceNewDeployment=True,
                     deploymentConfiguration={
                         "deploymentCircuitBreaker": {
                             "enable": True,

--- a/apps/backend/routers/websocket_chat.py
+++ b/apps/backend/routers/websocket_chat.py
@@ -139,6 +139,25 @@ async def ws_connect(
     except Exception as e:
         logger.warning("Failed to register frontend connection with pool: %s", e)
 
+    # Record activity on connect so the scale-to-zero idle reaper sees a
+    # fresh `last_active_at` immediately after a user logs in. Without this,
+    # there is a 0-65 second window before the frontend's first user_active
+    # heartbeat arrives where the reaper can fire on a stale timestamp from
+    # a prior session and stop the user's container right after they
+    # connect (paired with the `start_user_service` change that no longer
+    # passes `forceNewDeployment=True`, this kills the cascade that caused
+    # the post-login outage in the post-incident review of the 47h-uptime
+    # container). `record_activity` itself is throttled to 1 DDB write per
+    # 30s per owner, so multiple WS connects in a short window don't hammer
+    # DDB.
+    try:
+        owner_id_for_activity = x_org_id or x_user_id
+        asyncio.create_task(get_gateway_pool().record_activity(owner_id_for_activity))
+    except Exception:
+        # Pool may not be initialized in tests / extreme edge cases. Don't
+        # fail connect for a best-effort activity ping.
+        pass
+
     # Send OpenClaw connect.challenge so the control UI SPA can complete
     # its handshake.  The chat frontend silently ignores this message.
     background_tasks.add_task(_send_connect_challenge, x_connection_id)

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -504,8 +504,15 @@ class TestStartUserService:
     """Test scaling service to 1."""
 
     @pytest.mark.asyncio
-    async def test_start_scales_to_one(self, manager, mock_ecs_client):
-        """start_user_service calls update_service with desiredCount=1 and force."""
+    async def test_start_scales_to_one_without_force_new_deployment(self, manager, mock_ecs_client):
+        """start_user_service calls update_service with desiredCount=1 ONLY.
+
+        forceNewDeployment is NOT passed: when stop_user_service has just run
+        but ECS hasn't yet stopped the old task, a follow-up start_user_service
+        with forceNewDeployment=True would terminate the still-running task
+        and produce a ~30s post-login outage. Plain desiredCount=1 lets ECS
+        keep the existing healthy task if there is one.
+        """
         with (
             patch("core.containers.ecs_manager.container_repo") as mock_repo,
             patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
@@ -519,13 +526,18 @@ class TestStartUserService:
                 cluster=manager._cluster,
                 service="openclaw-user_test_123-f4ae64abb2db",
                 desiredCount=1,
-                forceNewDeployment=True,
                 deploymentConfiguration={
                     "deploymentCircuitBreaker": {
                         "enable": True,
                         "rollback": False,
                     }
                 },
+            )
+            # Belt + suspenders: forceNewDeployment must NOT be in kwargs.
+            call_kwargs = mock_ecs_client.update_service.call_args.kwargs
+            assert "forceNewDeployment" not in call_kwargs, (
+                "start_user_service must not force a new deployment — kills "
+                "still-running tasks during the stop -> start race"
             )
             mock_repo.update_status.assert_called_once_with("user_test_123", "provisioning")
 

--- a/apps/backend/tests/unit/routers/test_websocket_chat.py
+++ b/apps/backend/tests/unit/routers/test_websocket_chat.py
@@ -99,6 +99,55 @@ class TestConnectEndpoint:
         )
 
     @pytest.mark.asyncio
+    async def test_connect_records_activity_for_personal_owner(self, test_app, mock_connection_service, mock_gateway_pool):
+        """Connect must call record_activity(owner_id) so the scale-to-zero
+        idle reaper sees a fresh last_active_at immediately after login.
+
+        Without this, there is a 0-65 second window before the frontend's
+        first user_active heartbeat lands where the reaper can fire on a
+        stale timestamp from a prior session and stop the user's container
+        right after they connect.
+
+        For personal users, owner_id == user_id (no org).
+        """
+        mock_gateway_pool.record_activity = MagicMock(return_value=asyncio.sleep(0))
+
+        async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+            response = await client.post(
+                "/ws/connect",
+                headers={
+                    "x-connection-id": "test-conn-123",
+                    "x-user-id": "test-user-456",
+                },
+            )
+        # Yield once so the asyncio.create_task fires inside the event loop.
+        await asyncio.sleep(0)
+
+        assert response.status_code == 200
+        mock_gateway_pool.record_activity.assert_called_once_with("test-user-456")
+
+    @pytest.mark.asyncio
+    async def test_connect_records_activity_for_org_owner(self, test_app, mock_connection_service, mock_gateway_pool):
+        """Same activity recording for org-context connects, but routed by
+        org_id (which is the owner_id) rather than user_id.
+        """
+        mock_gateway_pool.record_activity = MagicMock(return_value=asyncio.sleep(0))
+
+        async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+            response = await client.post(
+                "/ws/connect",
+                headers={
+                    "x-connection-id": "test-conn-123",
+                    "x-user-id": "test-user-456",
+                    "x-org-id": "test-org-789",
+                },
+            )
+        await asyncio.sleep(0)
+
+        assert response.status_code == 200
+        mock_gateway_pool.record_activity.assert_called_once_with("test-org-789")
+
+    @pytest.mark.asyncio
     async def test_connect_without_connection_id_fails(self, test_app, mock_connection_service):
         """Connect without x-connection-id header should return 400."""
         async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:

--- a/apps/backend/tests/unit/routers/test_websocket_chat.py
+++ b/apps/backend/tests/unit/routers/test_websocket_chat.py
@@ -99,7 +99,9 @@ class TestConnectEndpoint:
         )
 
     @pytest.mark.asyncio
-    async def test_connect_records_activity_for_personal_owner(self, test_app, mock_connection_service, mock_gateway_pool):
+    async def test_connect_records_activity_for_personal_owner(
+        self, test_app, mock_connection_service, mock_gateway_pool
+    ):
         """Connect must call record_activity(owner_id) so the scale-to-zero
         idle reaper sees a fresh last_active_at immediately after login.
 


### PR DESCRIPTION
## Summary

Two surgical fixes for the cascade observed in the 47h-uptime container incident — when a free-tier user logged back in, the system was stopping their container within seconds and restarting it via forced redeploy, producing a ~30s perceived outage.

## The cascade

1. User connects via WebSocket → `record_activity` is NOT called for WS connect (only for explicit `user_active` heartbeats and `agent_chat` messages)
2. Idle reaper polls within 60s, sees stale `last_active_at` from prior session, calls `stop_user_service` → `desiredCount=0` + DDB `status=stopped`
3. ECS hasn't actually stopped the task yet (10-30s lag)
4. Frontend polls `/container/status`, sees `status=stopped`, auto-POSTs `/container/provision`
5. `start_user_service` runs with `forceNewDeployment=True` → ECS **terminates the still-alive task** and replaces it with a new one

## Fixes

### Fix A — `routers/websocket_chat.py:ws_connect`

Fire-and-forget `record_activity` on WS connect so the reaper sees a fresh `last_active_at` immediately after login. Stops the cascade at step 2. The existing 30s DDB write cooldown in `record_activity` prevents thundering-herd writes from rapid reconnects.

### Fix D — `core/containers/ecs_manager.py:start_user_service`

Drop `forceNewDeployment=True`. `desiredCount=1` alone scales up correctly when the service is at zero, and avoids killing a still-running task in the racy `stop → start` window. Defense in depth — even if Fix A misses some edge case, the wake-up call no longer destroys the alive task.

The `deploymentCircuitBreaker` config from PR #281 stays.

## Tests

- Existing `test_start_scales_to_one` renamed to `test_start_scales_to_one_without_force_new_deployment` and updated to assert `forceNewDeployment` is NOT in the call kwargs (with a comment explaining why)
- Two new `ws_connect` tests verify `record_activity` fires with the right owner_id (personal vs org)
- 716 backend tests pass; 91 in the directly-impacted suites

## Not in scope

- **Bug B** (DDB `status=stopped` written before ECS confirms): mitigated by Fix D — the inconsistency window becomes harmless
- **Bug C** (frontend auto-POSTs `/provision` when `status=stopped`): intentional cold-start UX; changing it would worsen real cold-start latency

## Related

- PR #281: durable provisioning state machine — fixed the upstream cause (zombie `provisioning` rows that hid free-tier containers from the reaper)
- This PR: fixes the cascade that fires once a container does become visible to the reaper but the user is actively present

🤖 Generated with [Claude Code](https://claude.com/claude-code)