### PR TITLE
build(openclaw): multi-stage build to slim image from 8.6 GB to ~2-3 GB

### DIFF
--- a/apps/infra/openclaw/Dockerfile
+++ b/apps/infra/openclaw/Dockerfile
@@ -1,36 +1,84 @@
 # Extended OpenClaw image — bundles Linux skill binaries so they're available
 # at runtime without paying install cost on every container cold-start.
 #
-# Bump UPSTREAM = `openclaw-version.json#upstream` field. Keep this FROM line in
-# sync with that field manually until automation lands.
+# Multi-stage build:
+#   builder -> compiles all Go binaries (Go toolchain + build-essential live here)
+#   final   -> upstream openclaw + runtime-only apt packages + copied binaries
+#
+# Splitting the stages keeps the ~600 MB Go toolchain and ~500 MB build-essential
+# out of the final image. Targets ~2-3 GB instead of ~8.6 GB so the image fits
+# within Fargate's default 20 GiB ephemeral storage with room to spare.
+#
+# Bump UPSTREAM = `openclaw-version.json#upstream` field. Keep the FROM lines
+# below in sync with that field manually until automation lands.
+
+# =============================================================================
+# Stage 1: builder — compiles every Go binary, produces /out/bin
+# =============================================================================
+FROM debian:bookworm-slim AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+      build-essential ca-certificates curl git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pin Go from go.dev — Debian 12's apt golang-go is 1.19, but several
+# steipete/* tools have go.mod directives requiring Go ≥1.24.
+RUN GO_VER=1.24.2 && \
+    curl -sL https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz \
+      | tar -xz -C /usr/local
+
+ENV PATH=/usr/local/go/bin:$PATH \
+    GOPATH=/opt/go \
+    GOBIN=/out/bin \
+    CGO_ENABLED=0
+
+RUN mkdir -p /out/bin
+
+# Steipete + community Go tools — `go install` writes binaries into GOBIN (=/out/bin).
+RUN go install github.com/steipete/eightctl/cmd/eightctl@latest && \
+    go install github.com/Hyaxia/blogwatcher/cmd/blogwatcher@latest && \
+    go install github.com/steipete/ordercli/cmd/ordercli@latest && \
+    go install github.com/steipete/sonoscli/cmd/sonos@latest && \
+    go install github.com/steipete/wacli/cmd/wacli@latest && \
+    go install github.com/steipete/gifgrep/cmd/gifgrep@latest && \
+    go install github.com/steipete/blucli/cmd/blu@latest && \
+    go install github.com/steipete/songsee/cmd/songsee@latest && \
+    go install github.com/steipete/gogcli/cmd/gog@latest && \
+    go install github.com/steipete/goplaces/cmd/goplaces@latest && \
+    go install github.com/steipete/spogo/cmd/spogo@latest
+
+# notesmd-cli (formerly obsidian-cli) — `go build` from a cloned repo.
+RUN git clone --depth=1 https://github.com/Yakitrak/notesmd-cli.git /tmp/notesmd && \
+    cd /tmp/notesmd && go build -o /out/bin/notesmd-cli .
+
+# openhue — `go build` from repo root (skipping `make build`/GoReleaser).
+RUN git clone --depth=1 https://github.com/openhue/openhue-cli.git /tmp/openhue && \
+    cd /tmp/openhue && go build -o /out/bin/openhue .
+
+# =============================================================================
+# Stage 2: final — runtime-only image
+# =============================================================================
 FROM alpine/openclaw:2026.4.5
 
 USER root
 
-# ---- Layer 1: apt packages (rarely change) ----
-# Note: Debian 12's golang-go is 1.19 but modern Steipete tools require
-# Go ≥1.24. Go is installed separately below from go.dev in Layer 1b.
-RUN apt-get update -qq && apt-get install -y -qq \
+# ---- Layer 1: runtime apt packages ----
+# Dropped from upstream extended image: build-essential, make (build-only).
+# Keeps git/curl/wget/gnupg — runtime tools (skills shell out, clawhub uses git).
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
       ffmpeg jq ripgrep tmux poppler-utils \
-      socat python3-pip sqlite3 build-essential python3 \
-      curl wget ca-certificates gnupg make git \
+      socat python3-pip sqlite3 python3 \
+      curl wget ca-certificates gnupg git \
     && rm -rf /var/lib/apt/lists/*
-
-# ---- Layer 1b: Go toolchain (from go.dev, not apt) ----
-# Some steipete/* tools have go.mod directives requiring Go ≥1.24, which
-# Debian's apt golang-go doesn't satisfy. Pin the latest stable tarball here.
-RUN GO_VER=1.24.2 && \
-    curl -sL https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz \
-      | tar -xz -C /usr/local && \
-    ln -s /usr/local/go/bin/go /usr/local/bin/go && \
-    ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # ---- Layer 2: 1Password CLI (apt repo) ----
 RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc \
       | gpg --dearmor -o /usr/share/keyrings/1password-archive-keyring.gpg && \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main" \
       > /etc/apt/sources.list.d/1password.list && \
-    apt-get update -qq && apt-get install -y 1password-cli && \
+    apt-get update -qq && apt-get install -y --no-install-recommends 1password-cli && \
     rm -rf /var/lib/apt/lists/*
 
 # ---- Layer 3: GitHub CLI ----
@@ -44,47 +92,24 @@ RUN GH_VER=2.65.0 && \
 RUN curl -sSL https://astral.sh/uv/install.sh | HOME=/tmp sh && \
     install -m 755 /tmp/.local/bin/uv /usr/local/bin/uv
 
-# ---- Layer 5: pip packages ----
-# nano-pdf moved here from a uv-tool layer — uv tool install doesn't accept
-# --bin-dir, and pip puts entry points on PATH (/usr/local/bin via system
-# Python). One less flag, one less layer.
-RUN pip install --break-system-packages openai-whisper websockets nano-pdf
+# ---- Layer 5: pip packages (no cache, pre-built wheels only) ----
+# nano-pdf entry points land on PATH via system python (/usr/local/bin).
+RUN pip install --no-cache-dir --break-system-packages \
+      openai-whisper websockets nano-pdf
 
-# ---- Layer 7: Go-installed skills ----
-ENV GOPATH=/opt/go GOBIN=/usr/local/bin
-RUN go install github.com/steipete/eightctl/cmd/eightctl@latest && \
-    go install github.com/Hyaxia/blogwatcher/cmd/blogwatcher@latest && \
-    go install github.com/steipete/ordercli/cmd/ordercli@latest && \
-    go install github.com/steipete/sonoscli/cmd/sonos@latest && \
-    go install github.com/steipete/wacli/cmd/wacli@latest && \
-    go install github.com/steipete/gifgrep/cmd/gifgrep@latest && \
-    go install github.com/steipete/blucli/cmd/blu@latest && \
-    go install github.com/steipete/songsee/cmd/songsee@latest && \
-    go install github.com/steipete/gogcli/cmd/gog@latest && \
-    go install github.com/steipete/goplaces/cmd/goplaces@latest && \
-    go install github.com/steipete/spogo/cmd/spogo@latest && \
-    rm -rf /opt/go/pkg /opt/go/src /root/.cache/go-build
+# ---- Layer 6: Go-built skills (copied from builder) ----
+# 13 binaries built in the builder stage — Go toolchain itself stays out
+# of the final image, saving ~600 MB.
+COPY --from=builder /out/bin/ /usr/local/bin/
 
-# ---- Layer 8a: notesmd-cli (formerly obsidian-cli) ----
-# Upstream renamed; OpenClaw's `obsidian` SKILL.md still requires bin "obsidian-cli".
-# Build under the new name, symlink to the old name to satisfy eligibility.
-RUN git clone --depth=1 https://github.com/Yakitrak/notesmd-cli.git /tmp/notesmd && \
-    cd /tmp/notesmd && go build -o /usr/local/bin/notesmd-cli . && \
-    ln -s /usr/local/bin/notesmd-cli /usr/local/bin/obsidian-cli && \
-    rm -rf /tmp/notesmd /root/.cache/go-build
+# OpenClaw's `obsidian` SKILL.md still requires bin "obsidian-cli", so
+# alias to the renamed `notesmd-cli` to keep eligibility.
+RUN ln -s /usr/local/bin/notesmd-cli /usr/local/bin/obsidian-cli
 
-# ---- Layer 8b: openhue ----
-# `make build` requires GoReleaser, which is overkill (it builds release
-# artifacts for multiple platforms). For a single linux/amd64 binary,
-# `go build` from the repo root works directly.
-RUN git clone --depth=1 https://github.com/openhue/openhue-cli.git /tmp/openhue && \
-    cd /tmp/openhue && go build -o /usr/local/bin/openhue . && \
-    rm -rf /tmp/openhue /root/.cache/go-build
-
-# ---- Layer 9: himalaya (pre-built binary via install.sh) ----
+# ---- Layer 7: himalaya (pre-built binary via install.sh) ----
 RUN curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | sh
 
-# ---- Layer 10: Node packages ----
+# ---- Layer 8: Node packages ----
 ENV NPM_CONFIG_PREFIX=/usr/local
 RUN npm i -g --ignore-scripts \
       mcporter clawhub openai @tobilu/qmd \

--- a/openclaw-version.json
+++ b/openclaw-version.json
@@ -5,7 +5,7 @@
   "tag": "2026.4.5",
   "full": "alpine/openclaw:2026.4.5",
   "extendedImage": "877352799272.dkr.ecr.us-east-1.amazonaws.com/isol8/openclaw-extended",
-  "dev":  { "tag": "2026.4.5-5656b8a" },
+  "dev":  { "tag": "2026.4.5-bf9f699" },
   "prod": { "tag": "bootstrap" },
   "notes": "Two image references coexist during the migration to the extended image. The legacy `image`/`tag`/`full` fields point at the upstream alpine/openclaw image used by current container-stack.ts (Task 1-8 of the plan). The new `extendedImage` + per-env `dev.tag`/`prod.tag` fields point at our custom ECR image used after Task 9 lands. The 'bootstrap' tag is a placeholder until the first CI build completes — it intentionally won't resolve, so any deploy referencing it before the first build will fail loudly."
 }


### PR DESCRIPTION
## Summary
- Rewrite `apps/infra/openclaw/Dockerfile` as a 2-stage build: builder compiles all Go binaries with the toolchain, final stage copies just the binaries.
- Drops Go toolchain (~600 MB) + `build-essential` (~500 MB) from the final image.
- Static Go binaries via `CGO_ENABLED=0` so the cross-stage copy is clean.
- Adds `--no-install-recommends` (apt) and `--no-cache-dir` (pip) in the final stage.

## Why
Live rollover of the extended image to a real Fargate task failed today with:
```
CannotPullContainerError: ... write /var/lib/containerd/.../usr/local/bin/wacli: no space left on device
```
The extended image is **8.64 GB compressed** in ECR — expanded onto a Fargate task it exceeds the 20 GiB default ephemeral storage. This blocks per-user task-def migration (Task 12 of the extended-image plan).

Cheaper to slim the image than to bump every paying user's `ephemeralStorageGiB` (the latter would cost ~$2.43/user/mo for a 50 GiB cap).

## Test plan
- [x] CI build-openclaw-image workflow runs and pushes a new `{upstream}-{sha}` tag
- [ ] Verify new image size in ECR is meaningfully smaller (target: <3 GB compressed, currently 8.6 GB)
- [ ] Smoke a sample skill binary out of the image (e.g. `docker run --rm <new-tag> /usr/local/bin/wacli --help`)
- [ ] Bump `openclaw-version.json#dev.tag` to the new tag in a follow-up PR
- [ ] Re-run the per-user migration on prasiddha@gmail.com's container in dev — confirm rollover reaches RUNNING this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)