### PR TITLE
fix(e2e): re-enable E2E gate and stabilize onboarding helpers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1050,6 +1050,53 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  prod-E2EGate:
+    name: E2EGate
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - Build-Synth
+      - dev-isol8-dev-auth-Deploy
+      - dev-isol8-dev-dns-Deploy
+      - dev-isol8-dev-database-Deploy
+      - dev-isol8-dev-network-Deploy
+      - dev-isol8-dev-api-Deploy
+      - dev-isol8-dev-container-Deploy
+      - dev-isol8-dev-service-Deploy
+      - dev-isol8-dev-observability-Deploy
+      - dev-DeployVercelDev
+    env: {}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: cd apps/frontend && npx playwright install chromium --with-deps
+      - name: Run E2E gate tests
+        run: cd apps/frontend && npx playwright test --project=chromium
+        env:
+          BASE_URL: https://dev.isol8.co
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL_DEV }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_DEV }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_DEV }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: apps/frontend/playwright-report/
+          retention-days: 7
   prod-isol8-prod-auth-Deploy:
     name: Deploy prodisol8prodauthA33C6000
     permissions:
@@ -1058,6 +1105,7 @@ jobs:
     needs:
       - Build-Synth
       - Assets-FileAsset15
+      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1104,6 +1152,7 @@ jobs:
     needs:
       - Build-Synth
       - Assets-FileAsset16
+      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1151,6 +1200,7 @@ jobs:
       - Build-Synth
       - Assets-FileAsset17
       - prod-isol8-prod-auth-Deploy
+      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1199,6 +1249,7 @@ jobs:
       - Assets-FileAsset18
       - Assets-FileAsset5
       - prod-isol8-prod-dns-Deploy
+      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1252,6 +1303,7 @@ jobs:
       - Assets-FileAsset11
       - prod-isol8-prod-network-Deploy
       - prod-isol8-prod-dns-Deploy
+      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1300,6 +1352,7 @@ jobs:
       - Assets-FileAsset20
       - prod-isol8-prod-network-Deploy
       - prod-isol8-prod-auth-Deploy
+      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1352,6 +1405,7 @@ jobs:
       - prod-isol8-prod-auth-Deploy
       - prod-isol8-prod-database-Deploy
       - prod-isol8-prod-api-Deploy
+      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1403,6 +1457,7 @@ jobs:
       - prod-isol8-prod-container-Deploy
       - prod-isol8-prod-service-Deploy
       - prod-isol8-prod-database-Deploy
+      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy

--- a/apps/frontend/tests/e2e/helpers/stripe.ts
+++ b/apps/frontend/tests/e2e/helpers/stripe.ts
@@ -40,44 +40,52 @@ export async function cancelSubscriptionIfExists(email: string): Promise<void> {
 }
 
 /**
- * Retrieve the backend's Stripe customer ID.
+ * Ensure a billing account + Stripe customer exist for this user by calling
+ * POST /billing/checkout on the backend. This creates the DynamoDB billing
+ * account row AND Stripe customer (same as clicking "Subscribe" in the UI).
+ * We then look up the Stripe customer ID from the backend-created customer.
  *
- * The backend creates Stripe customers with metadata.owner_id but NO email,
- * so we can't find them via customers.list({ email }). Instead, we use
- * Stripe's Search API to find customers by owner_id metadata.
- *
- * Calls GET /billing/account first to ensure the billing account + Stripe
- * customer exist.
+ * Returns the Stripe customer ID.
  */
-export async function getBackendStripeCustomerId(
-  clerkUserId: string,
+export async function ensureBillingCustomer(
   apiUrl: string,
   getToken: () => Promise<string>,
+  clerkUserId: string,
 ): Promise<string> {
-  // Ensure the billing account exists (creates Stripe customer if needed)
+  // Call POST /billing/checkout to trigger customer creation on the backend.
+  // We don't need to follow the returned checkout_url — we just want the
+  // side effect of creating the Stripe customer + DynamoDB billing row.
   const token = await getToken();
-  const res = await fetch(`${apiUrl}/billing/account`, {
-    headers: { Authorization: `Bearer ${token}` },
+  const res = await fetch(`${apiUrl}/billing/checkout`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tier: 'starter' }),
   });
-  if (!res.ok) throw new Error(`GET /billing/account failed: ${res.status}`);
-
-  // Search for the backend-created customer by owner_id metadata.
-  // Stripe Search has an indexing delay (up to ~60s for newly created objects),
-  // so retry a few times before giving up.
-  const maxAttempts = 8;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const result = await stripe().customers.search({
-      query: `metadata["owner_id"]:"${clerkUserId}"`,
-    });
-    if (result.data.length > 0) {
-      return result.data[0].id;
-    }
-    if (attempt < maxAttempts) {
-      console.log(`[e2e] Stripe search: no customer yet (attempt ${attempt}/${maxAttempts}), retrying in 5s...`);
-      await new Promise((r) => setTimeout(r, 5_000));
-    }
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`POST /billing/checkout failed: ${res.status} — ${body}`);
   }
-  throw new Error(`No Stripe customer found with owner_id=${clerkUserId} after ${maxAttempts} attempts`);
+  console.log('[e2e] POST /billing/checkout succeeded (customer + billing row created)');
+
+  // The backend just created a Stripe customer with metadata.owner_id.
+  // Stripe List API (not Search) returns it immediately — no indexing delay.
+  const customers = await stripe().customers.list({ limit: 100 });
+  const match = customers.data.find((c) => c.metadata?.owner_id === clerkUserId);
+  if (match) {
+    console.log(`[e2e] Found Stripe customer via list: ${match.id}`);
+    return match.id;
+  }
+
+  // Fallback: search (may have indexing delay but customer was just created)
+  const result = await stripe().customers.search({
+    query: `metadata["owner_id"]:"${clerkUserId}"`,
+  });
+  if (result.data.length > 0) {
+    console.log(`[e2e] Found Stripe customer via search: ${result.data[0].id}`);
+    return result.data[0].id;
+  }
+
+  throw new Error(`No Stripe customer found for owner_id=${clerkUserId} after checkout`);
 }
 
 /**

--- a/apps/frontend/tests/e2e/helpers/stripe.ts
+++ b/apps/frontend/tests/e2e/helpers/stripe.ts
@@ -61,15 +61,23 @@ export async function getBackendStripeCustomerId(
   });
   if (!res.ok) throw new Error(`GET /billing/account failed: ${res.status}`);
 
-  // Search for the backend-created customer by owner_id metadata
-  const result = await stripe().customers.search({
-    query: `metadata["owner_id"]:"${clerkUserId}"`,
-  });
-  if (result.data.length === 0) {
-    throw new Error(`No Stripe customer found with owner_id=${clerkUserId}`);
+  // Search for the backend-created customer by owner_id metadata.
+  // Stripe Search has an indexing delay (up to ~60s for newly created objects),
+  // so retry a few times before giving up.
+  const maxAttempts = 8;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await stripe().customers.search({
+      query: `metadata["owner_id"]:"${clerkUserId}"`,
+    });
+    if (result.data.length > 0) {
+      return result.data[0].id;
+    }
+    if (attempt < maxAttempts) {
+      console.log(`[e2e] Stripe search: no customer yet (attempt ${attempt}/${maxAttempts}), retrying in 5s...`);
+      await new Promise((r) => setTimeout(r, 5_000));
+    }
   }
-  // Use the most recently created one
-  return result.data[0].id;
+  throw new Error(`No Stripe customer found with owner_id=${clerkUserId} after ${maxAttempts} attempts`);
 }
 
 /**

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -164,11 +164,25 @@ test.describe('E2E Gate: Full User Journey', () => {
     test.setTimeout(4 * 60_000);
     await test.step('Sync user with backend', async () => {
       const token = await getToken();
+
+      // Diagnostic: decode JWT claims (no verification) to debug 401
+      try {
+        const [, payloadB64] = token.split('.');
+        const claims = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+        console.log('[e2e] JWT claims: iss=%s sub=%s aud=%s azp=%s exp=%s nbf=%s',
+          claims.iss, claims.sub, claims.aud, claims.azp, claims.exp, claims.nbf);
+        console.log('[e2e] JWT full claims:', JSON.stringify(claims));
+      } catch (e) { console.log('[e2e] JWT decode error:', e); }
+
       const res = await fetch(`${API_URL}/users/sync`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
       });
       console.log('[e2e] User sync:', res.status);
+      if (!res.ok) {
+        const body = await res.text();
+        console.log('[e2e] User sync error body:', body);
+      }
     }, { timeout: 30_000 });
     await test.step('Create Stripe subscription via backend customer', async () => {
       // Get the Stripe customer ID the backend uses (searches by owner_id metadata)

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -171,16 +171,6 @@ test.describe('E2E Gate: Full User Journey', () => {
     test.setTimeout(4 * 60_000);
     await test.step('Sync user with backend', async () => {
       const token = await getToken();
-
-      // Diagnostic: decode JWT claims (no verification) to debug 401
-      try {
-        const [, payloadB64] = token.split('.');
-        const claims = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
-        console.log('[e2e] JWT claims: iss=%s sub=%s aud=%s azp=%s exp=%s nbf=%s',
-          claims.iss, claims.sub, claims.aud, claims.azp, claims.exp, claims.nbf);
-        console.log('[e2e] JWT full claims:', JSON.stringify(claims));
-      } catch (e) { console.log('[e2e] JWT decode error:', e); }
-
       const res = await fetch(`${API_URL}/users/sync`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
@@ -188,7 +178,7 @@ test.describe('E2E Gate: Full User Journey', () => {
       console.log('[e2e] User sync:', res.status);
       if (!res.ok) {
         const body = await res.text();
-        console.log('[e2e] User sync error body:', body);
+        throw new Error(`User sync failed: ${res.status} — ${body}`);
       }
     }, { timeout: 30_000 });
     await test.step('Create Stripe subscription via backend customer', async () => {

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -211,9 +211,34 @@ test.describe('E2E Gate: Full User Journey', () => {
     }, { timeout: 12 * 60_000 });
   });
 
-  // Step 5 (Chat) is skipped for now — the WebSocket API Gateway returns 500
-  // during the handshake in CI (works locally). The Lambda authorizer or
-  // VPC Link path needs investigation via CloudWatch logs.
-  // TODO: Re-enable once WebSocket 500 is resolved.
-  // See: WebSocket error: "Unexpected response code: 500" from wss://ws-dev.isol8.co
+  test('Step 5: Chat', async () => {
+    test.setTimeout(3 * 60_000);
+
+    await test.step('Navigate to /chat and wait for WebSocket connection', async () => {
+      // Ensure we're on the chat page
+      if (!sharedPage.url().includes('/chat')) {
+        await sharedPage.goto(`${BASE_URL}/chat`, { waitUntil: 'domcontentloaded' });
+      }
+
+      // Wait for "Connected" indicator — means the WebSocket handshake succeeded
+      // and the gateway pool is healthy.
+      await sharedPage.getByText('Connected').waitFor({ state: 'visible', timeout: 60_000 });
+    }, { timeout: 90_000 });
+
+    await test.step('Send a message and receive a response', async () => {
+      // Type a simple message into the chat input
+      const input = sharedPage.getByPlaceholder('Ask anything');
+      await input.waitFor({ state: 'visible', timeout: 10_000 });
+      await input.fill('Say "hello" and nothing else.');
+
+      // Click send
+      await sharedPage.getByTestId('send-button').click();
+
+      // Wait for an assistant response. Messages have data-role="assistant".
+      const assistantMsg = sharedPage.locator('[data-role="assistant"]').last();
+      await assistantMsg.waitFor({ state: 'visible', timeout: 90_000 });
+      // Verify it has some text content (not an empty/error state)
+      await expect(assistantMsg).not.toBeEmpty();
+    }, { timeout: 120_000 });
+  });
 });

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -44,8 +44,15 @@ test.describe('E2E Gate: Full User Journey', () => {
   let sharedPage: Page;
   let clerkUserId: string;
 
-  /** Get a fresh Clerk JWT from the browser (tokens expire after 60s). */
+  /** Get a fresh Clerk JWT from the browser (tokens expire after 60s).
+   *  Waits for Clerk to be loaded and session to exist before requesting. */
   async function getToken(): Promise<string> {
+    // Ensure Clerk is loaded on the current page (may have navigated)
+    await sharedPage.waitForFunction(() => {
+      const w = window as Window & { Clerk?: { loaded?: boolean; session?: unknown } };
+      return w.Clerk?.loaded === true && w.Clerk?.session != null;
+    }, { timeout: 30_000 });
+
     return sharedPage.evaluate(async () => {
       const w = window as Window & { Clerk?: { session?: { getToken: () => Promise<string> } } };
       return (await w.Clerk?.session?.getToken()) ?? '';

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright';
-import { cancelSubscriptionIfExists, getBackendStripeCustomerId, createSubscription, waitForSubscriptionActive } from './helpers/stripe';
+import { cancelSubscriptionIfExists, ensureBillingCustomer, createSubscription, waitForSubscriptionActive } from './helpers/stripe';
 import { deprovisionIfExists, waitForRunning } from './helpers/provision';
 
 const DEV_STARTER_PRICE_ID = 'price_1TF5MDI54BysGS3rlT80MMI8';
@@ -182,9 +182,10 @@ test.describe('E2E Gate: Full User Journey', () => {
       }
     }, { timeout: 30_000 });
     await test.step('Create Stripe subscription via backend customer', async () => {
-      // Get the Stripe customer ID the backend uses (searches by owner_id metadata)
-      const customerId = await getBackendStripeCustomerId(clerkUserId, API_URL, getToken);
-      console.log('[e2e] Backend Stripe customer:', customerId);
+      // Trigger customer creation via POST /billing/checkout (creates both
+      // the Stripe customer and the DynamoDB billing account row)
+      const customerId = await ensureBillingCustomer(API_URL, getToken, clerkUserId);
+      console.log('[e2e] Stripe customer:', customerId);
       await createSubscription(customerId, DEV_STARTER_PRICE_ID);
     }, { timeout: 60_000 });
     await test.step('Wait for subscription to propagate to backend', async () => {

--- a/apps/frontend/tests/e2e/landing.spec.ts
+++ b/apps/frontend/tests/e2e/landing.spec.ts
@@ -7,7 +7,7 @@ test('landing page loads and redirects to chat', async ({ page }) => {
 
   // 2. Check for key landing page elements
   await expect(page).toHaveTitle(/isol8/); 
-  await expect(page.locator('h1')).toContainText('every part');
+  await expect(page.locator('h1')).toContainText('Deploy an agent');
 
   // Check for the "Start your pod" CTA
   const getStartedBtn = page.getByRole('link', { name: /Start your pod/i });

--- a/apps/infra/lib/app.ts
+++ b/apps/infra/lib/app.ts
@@ -85,12 +85,10 @@ pipeline.addStageWithGitHubOptions(devStage, {
 });
 
 // ---------------------------------------------------------------------------
-// Automated e2e gate between dev and prod — TEMPORARILY DISABLED
-// See note on pipeline.addStageWithGitHubOptions(prodStage, ...) below.
-// Definition retained (prefixed with _ to mark intentionally unused) so
-// re-enabling is a one-line change on the `pre: [...]` array below.
+// Automated e2e gate between dev and prod — runs after dev deploy,
+// blocks prod deploy until the E2E journey test passes.
 // ---------------------------------------------------------------------------
-const _e2eGate = new GitHubActionStep("E2EGate", {
+const e2eGate = new GitHubActionStep("E2EGate", {
   jobSteps: [
     { name: "Checkout", uses: "actions/checkout@v4" },
     { name: "Setup pnpm", uses: "pnpm/action-setup@v4" },
@@ -145,10 +143,7 @@ pipeline.addStageWithGitHubOptions(prodStage, {
     StackCapabilities.NAMED_IAM,
     StackCapabilities.AUTO_EXPAND,
   ],
-  // TEMPORARILY DISABLED — Clerk sign-in-ticket flow produces a token the
-  // backend rejects with 401. The product works on dev (verified manually);
-  // the test's auth flow is broken, not the app. Re-enable after fixing.
-  // pre: [_e2eGate],
+  pre: [e2eGate],
   post: [
     // Deploy frontend to Vercel (production) and alias to isol8.co
     new GitHubActionStep("DeployVercelProd", {


### PR DESCRIPTION
## Summary
- Re-enables the E2E gate in the CDK pipeline (`apps/infra/lib/app.ts`) and the regenerated `deploy.yml` so prod deploy is blocked on a passing Playwright journey test.
- Re-enables **Step 5 Chat** in `journey.spec.ts` — previously skipped while the WebSocket 500 (#180) was investigated; now passing.
- Fixes three issues uncovered running the gate end-to-end:
  - **Clerk token race:** `getToken()` ran before Clerk JS finished loading after navigation, returning an empty token and 401ing `/users/sync`. Now waits for `Clerk.loaded && Clerk.session`.
  - **Stripe customer not created:** `GET /billing/account` does not create a Stripe customer — only `POST /billing/checkout` does. Switched the helper to POST checkout, then look up the customer via Stripe List API (no Search indexing delay).
  - **Landing h1 drift:** updated assertion to match current copy ("Deploy an agent").

## Test plan
- [x] CDK deploy + `E2EGate` green on this branch (run [24549807508](https://github.com/Isol8AI/isol8/actions/runs/24549807508), 17m19s, 2026-04-17)
- [ ] Squash-merge so the five fix-iteration commits collapse into one on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)