### PR TITLE
feat(e2e): add chat-smoke PR gate for frontend changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1083,6 +1083,7 @@ jobs:
         run: cd apps/frontend && npx playwright install chromium --with-deps
       - name: Run E2E gate tests
         run: cd apps/frontend && npx playwright test --project=chromium
+          --grep-invert='Chat Smoke'
         env:
           BASE_URL: https://dev.isol8.co
           NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL_DEV }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -45,3 +45,50 @@ jobs:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
           NEXT_PUBLIC_API_URL: https://api-dev.isol8.co/api/v1
         run: pnpm --filter @isol8/frontend run build
+
+  chat-smoke:
+    name: Chat Smoke (dev)
+    runs-on: ubuntu-latest
+    # Serialize smoke runs across PRs so two concurrent runs don't both sign in
+    # as the E2E user and race on the shared container. cancel-in-progress:false
+    # queues rather than cancels, so no PR loses its smoke run.
+    concurrency:
+      group: chat-smoke-dev
+      cancel-in-progress: false
+    # Fork PRs don't get access to secrets; skip cleanly rather than fail.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: cd apps/frontend && npx playwright install chromium --with-deps
+
+      - name: Run chat smoke test
+        run: cd apps/frontend && npx playwright test --project=chromium --grep='Chat Smoke'
+        env:
+          BASE_URL: https://dev.isol8.co
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL_DEV }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_DEV }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_DEV }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: chat-smoke-report
+          path: apps/frontend/playwright-report/
+          retention-days: 7

--- a/apps/frontend/tests/e2e/chat.smoke.spec.ts
+++ b/apps/frontend/tests/e2e/chat.smoke.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, type Page } from '@playwright/test';
+import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright';
+import { waitForRunning } from './helpers/provision';
+import { markUserOnboarded } from './helpers/clerk';
+import { dismissChannelSetupIfPresent } from './helpers/onboarding';
+
+const E2E_EMAIL = 'isol8-e2e-testing@mailsac.com';
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000';
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000/api/v1';
+
+/**
+ * Create a one-time sign-in ticket via the Clerk Backend API so the browser
+ * can start an authenticated session without running a password/MFA flow.
+ */
+async function createSignInToken(): Promise<{ ticket: string; userId: string }> {
+  const secretKey = process.env.CLERK_SECRET_KEY;
+  if (!secretKey) throw new Error('[smoke] CLERK_SECRET_KEY not set');
+
+  const usersRes = await fetch(
+    `https://api.clerk.com/v1/users?email_address[]=${encodeURIComponent(E2E_EMAIL)}`,
+    { headers: { Authorization: `Bearer ${secretKey}` } },
+  );
+  if (!usersRes.ok) throw new Error(`[smoke] Users API ${usersRes.status}: ${await usersRes.text()}`);
+  const users = await usersRes.json() as Array<{ id: string }>;
+  if (!users.length) throw new Error(`[smoke] No Clerk user found for ${E2E_EMAIL}`);
+
+  const tokenRes = await fetch('https://api.clerk.com/v1/sign_in_tokens', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${secretKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: users[0].id }),
+  });
+  if (!tokenRes.ok) throw new Error(`[smoke] Sign-in token API ${tokenRes.status}: ${await tokenRes.text()}`);
+  const { token } = await tokenRes.json() as { token: string };
+  return { ticket: token, userId: users[0].id };
+}
+
+test.describe('Chat Smoke', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let sharedPage: Page;
+
+  async function getToken(): Promise<string> {
+    await sharedPage.waitForFunction(() => {
+      const w = window as Window & { Clerk?: { loaded?: boolean; session?: unknown } };
+      return w.Clerk?.loaded === true && w.Clerk?.session != null;
+    }, { timeout: 30_000 });
+    return sharedPage.evaluate(async () => {
+      const w = window as Window & { Clerk?: { session?: { getToken: () => Promise<string> } } };
+      return (await w.Clerk?.session?.getToken()) ?? '';
+    });
+  }
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(90_000);
+    await clerkSetup();
+    const ctx = await browser.newContext({
+      extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+        ? { 'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET }
+        : {},
+    });
+    sharedPage = await ctx.newPage();
+    await setupClerkTestingToken({ page: sharedPage });
+
+    await sharedPage.goto(BASE_URL, { waitUntil: 'domcontentloaded' });
+    await sharedPage.waitForFunction(() => {
+      const w = window as Window & { Clerk?: { loaded?: boolean; client?: unknown } };
+      return w.Clerk?.loaded === true && w.Clerk?.client != null;
+    }, { timeout: 30_000 });
+
+    const { ticket, userId } = await createSignInToken();
+
+    // Ensure ChatLayout doesn't render ProvisioningStepper over the chat.
+    // See helpers/clerk.ts for why this flag can drift to false.
+    await markUserOnboarded(userId);
+
+    await sharedPage.evaluate(async (t: string) => {
+      const w = window as unknown as {
+        Clerk: {
+          client: { signIn: { create: (opts: Record<string, string>) => Promise<{ createdSessionId: string }> } };
+          setActive: (opts: { session: string }) => Promise<void>;
+        };
+      };
+      const si = await w.Clerk.client.signIn.create({ strategy: 'ticket', ticket: t });
+      await w.Clerk.setActive({ session: si.createdSessionId });
+    }, ticket);
+  });
+
+  test.afterAll(async () => {
+    await sharedPage?.context().close();
+  });
+
+  test('Steady-state precheck: subscription + container healthy', async () => {
+    test.setTimeout(3 * 60_000);
+
+    await test.step('E2E account is subscribed', async () => {
+      const token = await getToken();
+      const res = await fetch(`${API_URL}/billing/account`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error(`GET /billing/account failed: ${res.status}`);
+      const data = await res.json();
+      if (data.is_subscribed !== true) {
+        throw new Error(
+          `[smoke] E2E account is_subscribed=${data.is_subscribed}. ` +
+            `Expected steady-state — the deploy pipeline's journey should leave a live subscription. ` +
+            `If this fails repeatedly, the last E2EGate run may have failed mid-flight; rerun the deploy.`,
+        );
+      }
+    });
+
+    // Covers the ~3-5 min window after a deploy where the new ECS task is still rolling.
+    await test.step('Container gateway_healthy', async () => {
+      await waitForRunning(API_URL, getToken, 2 * 60_000);
+    });
+  });
+
+  test('Chat: connect, send, receive', async () => {
+    test.setTimeout(3 * 60_000);
+
+    await sharedPage.goto(`${BASE_URL}/chat`, { waitUntil: 'domcontentloaded' });
+
+    await sharedPage.getByText('Connected').waitFor({ state: 'visible', timeout: 60_000 });
+
+    // Dismiss the Telegram setup wizard if shown — ProvisioningStepper's
+    // onboardingComplete state is in-memory only, so it re-appears on every
+    // fresh /chat load until dismissed.
+    await dismissChannelSetupIfPresent(sharedPage);
+
+    const input = sharedPage.getByPlaceholder('Ask anything');
+    await input.waitFor({ state: 'visible', timeout: 10_000 });
+    await input.fill('Say "hello" and nothing else.');
+    await sharedPage.getByTestId('send-button').click();
+
+    const assistantMsg = sharedPage.locator('[data-role="assistant"]').last();
+    await assistantMsg.waitFor({ state: 'visible', timeout: 90_000 });
+    await expect(assistantMsg).not.toBeEmpty();
+  });
+});

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright';
 import { cancelSubscriptionIfExists, ensureBillingCustomer, createSubscription, waitForSubscriptionActive } from './helpers/stripe';
-import { deprovisionIfExists, waitForRunning } from './helpers/provision';
+import { waitForRunning } from './helpers/provision';
 import { markUserOnboarded } from './helpers/clerk';
 import { dismissChannelSetupIfPresent } from './helpers/onboarding';
 
@@ -124,33 +124,14 @@ test.describe('E2E Gate: Full User Journey', () => {
   });
 
   test.afterAll(async () => {
-    // Retry cancellation up to 3 times with exponential backoff. If all retries
-    // fail, log loudly so a human can clean up manually — but do not throw, since
-    // the test itself may have passed and we don't want to mask the real result.
-    const backoffs = [1_000, 2_000, 4_000];
-    let lastErr: unknown;
-    for (let attempt = 0; attempt < backoffs.length; attempt++) {
-      try {
-        await cancelSubscriptionIfExists(E2E_EMAIL);
-        lastErr = undefined;
-        break;
-      } catch (err) {
-        lastErr = err;
-        console.error(`[e2e] afterAll cancelSubscriptionIfExists attempt ${attempt + 1} failed:`, err);
-        if (attempt < backoffs.length - 1) {
-          await new Promise((r) => setTimeout(r, backoffs[attempt]));
-        }
-      }
-    }
-    if (lastErr !== undefined) {
-      console.error(
-        `[e2e] CRITICAL: afterAll cleanup FAILED after ${backoffs.length} retries for ${E2E_EMAIL}. ` +
-          `A subscription may be leaked. Manual cleanup required. Last error:`,
-        lastErr,
-      );
-    }
-    // Don't deprovision — leave the container running for the next run.
-    // This avoids triggering ECS drain cycles that cause long timeouts.
+    // Intentionally leave the Stripe subscription active so the chat-smoke test
+    // (runs on every frontend PR) can assume a steady subscribed state without
+    // re-running the full billing setup. beforeAll + Step 1 cancel any stale
+    // subscription at the start of the next journey run, so only one sub is
+    // ever live at a time. Test-mode customers accumulating is harmless.
+    //
+    // Container is also left running — avoids triggering ECS drain cycles that
+    // cause long timeouts.
     await sharedPage?.context().close();
   });
 

--- a/apps/infra/lib/app.ts
+++ b/apps/infra/lib/app.ts
@@ -106,8 +106,12 @@ const e2eGate = new GitHubActionStep("E2EGate", {
       run: "cd apps/frontend && npx playwright install chromium --with-deps",
     },
     {
+      // Exclude the chat-smoke spec — it runs on frontend PRs pre-merge and is
+      // redundant with journey Step 5 post-deploy. Also, smoke's short
+      // waitForRunning timeout (2 min) is too tight to survive an ECS rolling
+      // update; the journey's 10 min timeout is required for the deploy path.
       name: "Run E2E gate tests",
-      run: "cd apps/frontend && npx playwright test --project=chromium",
+      run: "cd apps/frontend && npx playwright test --project=chromium --grep-invert='Chat Smoke'",
       env: {
         BASE_URL: "https://dev.isol8.co",
         NEXT_PUBLIC_API_URL: "${{ secrets.NEXT_PUBLIC_API_URL_DEV }}",


### PR DESCRIPTION
## Summary
Adds a fast per-PR chat smoke test so every frontend change is gated on a working chat end-to-end against dev, without paying the full journey's 17-min setup cost.

- **New** `apps/frontend/tests/e2e/chat.smoke.spec.ts` — Clerk ticket sign-in → `/billing/account` precheck → wait-for-gateway-healthy (2 min) → `/chat` → send message → assert assistant reply. Target runtime ~1–2 min.
- **New** `chat-smoke` job in `frontend-ci.yml` — runs on PRs touching `apps/frontend/**`, against `https://dev.isol8.co`.
- **Changed** `journey.spec.ts` — drop the `afterAll` subscription cancel so the dev Stripe sub persists between deploys. `beforeAll` + Step 1 still cancel stale subs at the start of every journey run, so only one sub is ever live at a time.
- **Changed** `apps/infra/lib/app.ts` — `E2EGate` runs `--grep-invert='Chat Smoke'` to skip the smoke on deploy (redundant with journey Step 5; smoke's 2-min healthy-poll is too tight for post-deploy ECS rollout anyway). `deploy.yml` regenerated.

## Guardrails against merge-time failure modes
- **Concurrent PRs**: job-level `concurrency: chat-smoke-dev` with `cancel-in-progress: false` queues runs so two PRs don't race on the shared E2E account.
- **Post-deploy window**: smoke polls `/container/status` for up to 2 min to ride out the tail end of an ECS rolling update.
- **Fork PRs**: skipped cleanly via `if: head.repo.full_name == repository` (no secrets available on forks).
- **Subscription drift**: if `is_subscribed` is ever false, precheck fails with a self-diagnosing error pointing at the deploy pipeline.

## What this deliberately does NOT cover
- Backend PRs: pre-merge backend code isn't deployed to dev, so pre-merge E2E would test old backend. Backend regressions remain covered by the post-merge `E2EGate` full journey.

## Test plan
- [ ] Frontend CI green on this PR (lint/build + chat-smoke)
- [ ] Post-merge deploy pipeline's `E2EGate` still green (verifies the journey `afterAll` change didn't break the full flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
