### PR TITLE
fix(e2e): set Clerk unsafeMetadata.onboarded=true in journey beforeAll

### DIFF
--- a/apps/frontend/tests/e2e/helpers/clerk.ts
+++ b/apps/frontend/tests/e2e/helpers/clerk.ts
@@ -1,0 +1,25 @@
+/**
+ * Set the Clerk `unsafeMetadata.onboarded` flag to true for the given user.
+ *
+ * `ChatLayout` gates the chat UI on this flag (`src/components/chat/ChatLayout.tsx`);
+ * when false, it renders `ProvisioningStepper` (the channel setup wizard) instead
+ * of `ChatInput`. The test user's flag can drift to false after a Clerk-side
+ * reset or when a fresh account is created, so we set it explicitly.
+ *
+ * Uses the /metadata endpoint (merges, does not replace), so other fields on
+ * unsafe_metadata are preserved.
+ */
+export async function markUserOnboarded(userId: string): Promise<void> {
+  const secretKey = process.env.CLERK_SECRET_KEY;
+  if (!secretKey) throw new Error('[e2e] CLERK_SECRET_KEY not set');
+
+  const res = await fetch(`https://api.clerk.com/v1/users/${userId}/metadata`, {
+    method: 'PATCH',
+    headers: { Authorization: `Bearer ${secretKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ unsafe_metadata: { onboarded: true } }),
+  });
+  if (!res.ok) {
+    throw new Error(`[e2e] Clerk metadata PATCH ${res.status}: ${await res.text()}`);
+  }
+  console.log(`[e2e] Marked user ${userId} as onboarded`);
+}

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright';
 import { cancelSubscriptionIfExists, ensureBillingCustomer, createSubscription, waitForSubscriptionActive } from './helpers/stripe';
 import { deprovisionIfExists, waitForRunning } from './helpers/provision';
+import { markUserOnboarded } from './helpers/clerk';
 
 const DEV_STARTER_PRICE_ID = 'price_1TF5MDI54BysGS3rlT80MMI8';
 const E2E_EMAIL = 'isol8-e2e-testing@mailsac.com';
@@ -87,6 +88,12 @@ test.describe('E2E Gate: Full User Journey', () => {
     // Create a backend-issued sign-in token — bypasses password + MFA entirely
     const { ticket, userId } = await createSignInToken();
     clerkUserId = userId;
+
+    // Force-set the onboarded flag on Clerk's unsafeMetadata. ChatLayout gates
+    // the chat UI on this flag; if it's false, ProvisioningStepper replaces the
+    // chat view and Step 5 can't find ChatInput. Must run before the browser
+    // activates the session so Clerk serves the fresh metadata on page load.
+    await markUserOnboarded(userId);
 
     // Use the ticket to create an authenticated session
     await sharedPage.evaluate(async (t: string) => {


### PR DESCRIPTION
## Summary
Unblocks the E2E gate, which started failing post-merge of #289 (run [24565327704](https://github.com/Isol8AI/isol8/actions/runs/24565327704)).

`ChatLayout.tsx:119` gates the chat UI on `user.unsafeMetadata.onboarded === true`. When false, `ProvisioningStepper` (the channel setup wizard) replaces the chat view — so `ChatInput` is not in the DOM at all, and Step 5's `getByPlaceholder('Ask anything')` times out.

Screenshot from the failing run confirmed the stepper was stuck on "Set up Telegram — Step 1 of 4". The E2E user's `onboarded` flag drifts to `false` after any Clerk-side reset or account recreation, and nothing in the test ever sets it.

## Change
- **New** `apps/frontend/tests/e2e/helpers/clerk.ts` — `markUserOnboarded(userId)` PATCHes `user.unsafe_metadata` via Clerk Backend API (`/v1/users/{id}/metadata`, which merges rather than replaces).
- **Changed** `apps/frontend/tests/e2e/journey.spec.ts` — call `markUserOnboarded` in `beforeAll` immediately after `createSignInToken`, before the browser activates the session, so Clerk serves the fresh metadata on page load.

## Test plan
- [ ] Post-merge E2EGate passes
- [ ] Unblocks PR #290 (chat smoke), which will pick up the fix on rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
