### PR TITLE
fix(e2e): dismiss channel setup wizard before asserting chat input

### DIFF
--- a/apps/frontend/tests/e2e/helpers/onboarding.ts
+++ b/apps/frontend/tests/e2e/helpers/onboarding.ts
@@ -1,0 +1,25 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * The /chat page wraps its content in `ProvisioningStepper`. After provisioning
+ * succeeds, the stepper advances to phase `"channels"` whenever the user has
+ * no main bot linked (`hasMainBot(linksData) === false`) and shows a "Set up
+ * Telegram" wizard over the chat view — `ChatInput` is not mounted. The
+ * stepper's `onboardingComplete` state is in-memory only (useState), so it
+ * re-shows on every fresh page load until the user clicks "Cancel" or
+ * completes the wizard.
+ *
+ * This helper detects the wizard and clicks "Cancel" to dismiss it, falling
+ * through if it's not present (user is already past channel setup).
+ */
+export async function dismissChannelSetupIfPresent(page: Page): Promise<void> {
+  const setupHeading = page.getByRole('heading', { name: 'Set up Telegram' });
+  try {
+    await setupHeading.waitFor({ state: 'visible', timeout: 5_000 });
+  } catch {
+    return;
+  }
+  await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+  await setupHeading.waitFor({ state: 'hidden', timeout: 5_000 });
+  console.log('[e2e] Dismissed channel setup wizard');
+}

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -3,6 +3,7 @@ import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright';
 import { cancelSubscriptionIfExists, ensureBillingCustomer, createSubscription, waitForSubscriptionActive } from './helpers/stripe';
 import { deprovisionIfExists, waitForRunning } from './helpers/provision';
 import { markUserOnboarded } from './helpers/clerk';
+import { dismissChannelSetupIfPresent } from './helpers/onboarding';
 
 const DEV_STARTER_PRICE_ID = 'price_1TF5MDI54BysGS3rlT80MMI8';
 const E2E_EMAIL = 'isol8-e2e-testing@mailsac.com';
@@ -243,6 +244,10 @@ test.describe('E2E Gate: Full User Journey', () => {
       // and the gateway pool is healthy.
       await sharedPage.getByText('Connected').waitFor({ state: 'visible', timeout: 60_000 });
     }, { timeout: 90_000 });
+
+    await test.step('Dismiss channel setup wizard if present', async () => {
+      await dismissChannelSetupIfPresent(sharedPage);
+    }, { timeout: 15_000 });
 
     await test.step('Send a message and receive a response', async () => {
       // Type a simple message into the chat input


### PR DESCRIPTION
## Summary
Second hotfix on top of #291. #291 set `unsafeMetadata.onboarded=true`, which correctly prevents the `/onboarding` page redirect in `ChatLayout` — but it does NOT gate the in-chat `ProvisioningStepper`. Run [24566476531](https://github.com/Isol8AI/isol8/actions/runs/24566476531) confirmed: the stepper still rendered "Set up Telegram" over the chat view and Step 5 timed out.

Re-reading `ProvisioningStepper.tsx` in detail: phase advances to `"channels"` whenever `hasMainBot(linksData) === false`, and the `onboardingComplete` state that would skip it is `useState(false)` — in-memory only, re-shown on every fresh `/chat` load until the user clicks Cancel or completes the wizard.

## Change
- **New** `apps/frontend/tests/e2e/helpers/onboarding.ts` — `dismissChannelSetupIfPresent(page)` detects the "Set up Telegram" heading (5s timeout) and clicks the associated Cancel button. Idempotent — returns silently if the wizard isn't present.
- **Changed** `journey.spec.ts` Step 5 — new `test.step` inserted between the "Connected" wait and the send-message assertion. Called after the gateway is confirmed healthy, so we know the stepper has reached its final phase.

## Out of scope (follow-up)
The real UX fix is persisting `onboardingComplete` across reloads (likely to Clerk `unsafeMetadata` or a backend flag), so new paying users don't see the setup wizard on every page reload after dismissing once. Separate issue.

## Test plan
- [ ] Post-merge deploy pipeline's `E2EGate` passes Step 5
- [ ] Unblocks PR #290 (chat smoke) — will pick up the same helper on rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
