### PR TITLE
fix(e2e): exercise real provision + onboarding paths in journey

### DIFF
--- a/apps/frontend/tests/e2e/helpers/clerk.ts
+++ b/apps/frontend/tests/e2e/helpers/clerk.ts
@@ -1,25 +1,43 @@
 /**
- * Set the Clerk `unsafeMetadata.onboarded` flag to true for the given user.
+ * Set the Clerk `unsafeMetadata.onboarded` flag for the given user.
  *
  * `ChatLayout` gates the chat UI on this flag (`src/components/chat/ChatLayout.tsx`);
- * when false, it renders `ProvisioningStepper` (the channel setup wizard) instead
- * of `ChatInput`. The test user's flag can drift to false after a Clerk-side
- * reset or when a fresh account is created, so we set it explicitly.
+ * when false, it redirects to `/onboarding` where the user picks "Personal" or
+ * "Organization". The onboarding page then flips the flag to true.
  *
  * Uses the /metadata endpoint (merges, does not replace), so other fields on
  * unsafe_metadata are preserved.
  */
-export async function markUserOnboarded(userId: string): Promise<void> {
+export async function setUserOnboardedFlag(userId: string, value: boolean): Promise<void> {
   const secretKey = process.env.CLERK_SECRET_KEY;
   if (!secretKey) throw new Error('[e2e] CLERK_SECRET_KEY not set');
 
   const res = await fetch(`https://api.clerk.com/v1/users/${userId}/metadata`, {
     method: 'PATCH',
     headers: { Authorization: `Bearer ${secretKey}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ unsafe_metadata: { onboarded: true } }),
+    body: JSON.stringify({ unsafe_metadata: { onboarded: value } }),
   });
   if (!res.ok) {
     throw new Error(`[e2e] Clerk metadata PATCH ${res.status}: ${await res.text()}`);
   }
-  console.log(`[e2e] Marked user ${userId} as onboarded`);
+  console.log(`[e2e] Set onboarded=${value} for user ${userId}`);
+}
+
+/**
+ * Force-flip `unsafeMetadata.onboarded=true`. Shortcut used by the fast chat
+ * smoke gate so it can skip the /onboarding click-through and go straight to
+ * /chat. The full journey spec should NOT use this — it's supposed to drive
+ * the real onboarding flow.
+ */
+export async function markUserOnboarded(userId: string): Promise<void> {
+  await setUserOnboardedFlag(userId, true);
+}
+
+/**
+ * Force-flip `unsafeMetadata.onboarded=false`. Used by the full journey spec
+ * to reset the test user before each run so /chat redirects to /onboarding
+ * and the test exercises the real first-login flow.
+ */
+export async function markUserNotOnboarded(userId: string): Promise<void> {
+  await setUserOnboardedFlag(userId, false);
 }

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright';
 import { cancelSubscriptionIfExists, ensureBillingCustomer, createSubscription, waitForSubscriptionActive } from './helpers/stripe';
 import { waitForRunning } from './helpers/provision';
-import { markUserOnboarded } from './helpers/clerk';
+import { markUserNotOnboarded } from './helpers/clerk';
 import { dismissChannelSetupIfPresent } from './helpers/onboarding';
 
 const DEV_STARTER_PRICE_ID = 'price_1TF5MDI54BysGS3rlT80MMI8';
@@ -90,11 +90,13 @@ test.describe('E2E Gate: Full User Journey', () => {
     const { ticket, userId } = await createSignInToken();
     clerkUserId = userId;
 
-    // Force-set the onboarded flag on Clerk's unsafeMetadata. ChatLayout gates
-    // the chat UI on this flag; if it's false, ProvisioningStepper replaces the
-    // chat view and Step 5 can't find ChatInput. Must run before the browser
-    // activates the session so Clerk serves the fresh metadata on page load.
-    await markUserOnboarded(userId);
+    // Reset the onboarded flag on Clerk's unsafeMetadata so /chat redirects
+    // to /onboarding and the test exercises the real first-login flow. The
+    // flag is durable on the user, so without an explicit reset previous runs
+    // would leave it true and we'd skip onboarding. Must run before the
+    // browser activates the session so Clerk serves the fresh metadata on
+    // page load.
+    await markUserNotOnboarded(userId);
 
     // Use the ticket to create an authenticated session
     await sharedPage.evaluate(async (t: string) => {
@@ -146,13 +148,22 @@ test.describe('E2E Gate: Full User Journey', () => {
     // start a second drain cycle, causing long timeouts.
   });
 
-  test('Step 2: Auth', async () => {
-    test.setTimeout(60_000);
+  test('Step 2: Auth + Onboarding', async () => {
+    test.setTimeout(90_000);
     await test.step('Verify authenticated (not redirected to sign-in)', async () => {
-      // After cleanup, page may be on /chat or /onboarding — just confirm session is active
       const url = sharedPage.url();
       console.log('[e2e] Step 2 URL:', url);
       expect(url).not.toContain('/sign-in');
+    }, { timeout: 15_000 });
+
+    await test.step('Complete onboarding by clicking "Personal"', async () => {
+      // beforeAll reset unsafeMetadata.onboarded=false, so ChatLayout redirected
+      // us to /onboarding. Click "Personal" to exercise the real first-login
+      // flow: handlePersonal() flips onboarded=true, runs api.syncUser(), and
+      // redirects to /chat. This replaces the old markUserOnboarded shortcut.
+      await sharedPage.waitForURL(/\/onboarding/, { timeout: 30_000 });
+      await sharedPage.getByRole('button', { name: 'Personal' }).click();
+      await sharedPage.waitForURL(/\/chat/, { timeout: 30_000 });
     }, { timeout: 60_000 });
   });
 
@@ -185,13 +196,15 @@ test.describe('E2E Gate: Full User Journey', () => {
   test('Step 4: Provision container', async () => {
     test.setTimeout(14 * 60_000);
     await test.step('Ensure container exists', async () => {
-      // POST /debug/provision is idempotent — returns 200 if already provisioned.
-      // Retry on 503 (ECS service still rolling from CDK deploy).
+      // POST /container/provision is idempotent — returns 200 if already provisioned.
+      // Uses the real prod endpoint (ProvisioningStepper hits the same one) so
+      // this gate actually exercises the production provisioning path, not a
+      // dev-only shortcut. Retry on 503 (ECS service still rolling from CDK deploy).
       const deadline = Date.now() + 3 * 60_000;
       let lastStatus = 0;
       while (Date.now() < deadline) {
         const token = await getToken();
-        const res = await fetch(`${API_URL}/debug/provision`, {
+        const res = await fetch(`${API_URL}/container/provision`, {
           method: 'POST',
           headers: { Authorization: `Bearer ${token}` },
         });


### PR DESCRIPTION
## Summary
- Swap `POST /debug/provision` for the real `POST /container/provision` in the journey spec so the gate actually exercises the production provisioning path (same endpoint `ProvisioningStepper` hits).
- Drop the `markUserOnboarded` shortcut in `journey.spec.ts`; reset `unsafeMetadata.onboarded=false` in `beforeAll` and drive the `/onboarding` flow by clicking **Personal** so `handlePersonal` flips the flag, runs `syncUser`, and redirects to `/chat` — same code path a real new user takes.
- Refactor `helpers/clerk.ts` to expose `setUserOnboardedFlag(userId, value)` plus thin wrappers `markUserOnboarded` / `markUserNotOnboarded`.
- `chat-smoke` is untouched — it still uses the fast `markUserOnboarded` shortcut because it is a steady-state gate, not an onboarding gate.

## Related
- Issue #293 — `POST /container/provision` defaults `tier="free"` regardless of subscription tier. Surfaced while swapping endpoints. Out of scope for this PR.

## Test plan
- [ ] CI E2EGate (journey spec) passes end-to-end on the dev environment.
- [ ] Sanity-check the new Step 2 actually navigates `/onboarding → Personal → /chat` (visible in Playwright trace).
- [ ] Sanity-check Step 4 hits `POST /container/provision` (not `/debug/provision`) in the captured request log.
- [ ] `chat-smoke` still passes — confirms the steady-state shortcut path still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
