### PR TITLE
fix(container): resolve tier from billing on provision (#293)

### DIFF
--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -26,7 +26,7 @@ from core.containers.config import (
     write_openclaw_config,
 )
 from core.containers.workspace import get_workspace
-from core.repositories import container_repo
+from core.repositories import billing_repo, container_repo
 
 logger = logging.getLogger(__name__)
 
@@ -794,7 +794,30 @@ class EcsManager:
             pass
         return None
 
-    async def provision_user_container(self, user_id: str, owner_type: str = "personal", tier: str = "free") -> str:
+    async def _resolve_tier_for_owner(self, owner_id: str) -> str:
+        """Resolve the plan tier for an owner from the billing record.
+
+        Returns "free" if the billing row is missing, has no plan_tier, or
+        the lookup itself raises. A failing tier lookup must not crash the
+        provision path -- the container can still boot on free-tier configs
+        and the next config patch (via queue_tier_change on the subscription
+        webhook) will correct anything that drifts.
+        """
+        try:
+            account = await billing_repo.get_by_owner_id(owner_id)
+        except Exception:
+            logger.warning("billing_repo lookup failed for %s; defaulting tier=free", owner_id, exc_info=True)
+            return "free"
+        if not account:
+            return "free"
+        return account.get("plan_tier") or "free"
+
+    async def provision_user_container(
+        self,
+        user_id: str,
+        owner_type: str = "personal",
+        tier: str | None = None,
+    ) -> str:
         """Provision or recover a user's container.
 
         Handles all scenarios:
@@ -807,6 +830,12 @@ class EcsManager:
 
         Args:
             user_id: Clerk user ID.
+            owner_type: "personal" or "org".
+            tier: Plan tier for config generation. When None (the usual
+                case -- every production router caller omits this arg), the
+                tier is resolved from the billing account; a missing or
+                unreadable account falls back to "free" so we never crash
+                the provision path on a billing lookup error.
 
         Returns:
             The ECS service name.
@@ -814,6 +843,8 @@ class EcsManager:
         Raises:
             EcsManagerError: If any provisioning step fails.
         """
+        if tier is None:
+            tier = await self._resolve_tier_for_owner(user_id)
         service_name = self._service_name(user_id)
 
         # Check current state

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -1925,3 +1925,65 @@ class TestProvisionUserContainer:
             assert kwargs.get("tier") == "pro"
             # Explicit tier should bypass the billing lookup entirely.
             mock_billing.get_by_owner_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provision_produces_paid_tier_openclaw_config_for_starter(
+        self, manager, mock_ecs_client, mock_efs_client
+    ):
+        """End-to-end assertion: a router-style provision call (no tier arg)
+        for a starter-subscribed user must produce an openclaw.json on EFS
+        whose primary model is Qwen3 VL 235B, not the free-tier MiniMax.
+
+        This is the real chain #293 fixes:
+            router (no tier)
+              -> provision_user_container
+                -> _resolve_tier_for_owner (billing.plan_tier="starter")
+                  -> write_user_configs(tier="starter")
+                    -> write_openclaw_config(tier="starter")
+
+        Runs the real write_openclaw_config; only the EFS boundary and the
+        KMS-heavy device-identity step are stubbed.
+        """
+        import json as _json
+
+        mock_ecs_client.describe_services.return_value = {"services": []}
+        captured_writes: dict[str, str] = {}
+
+        fake_workspace = MagicMock()
+        fake_workspace.write_file = MagicMock(
+            side_effect=lambda _uid, path, content: captured_writes.__setitem__(path, content)
+        )
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.billing_repo") as mock_billing,
+            patch("core.containers.ecs_manager.get_workspace", return_value=fake_workspace),
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+            patch.object(manager, "ensure_device_identities", new_callable=AsyncMock),
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=None)
+            mock_repo.upsert = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_status = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_billing.get_by_owner_id = AsyncMock(return_value={"owner_id": "user_test_123", "plan_tier": "starter"})
+
+            await manager.provision_user_container("user_test_123")
+
+            assert "openclaw.json" in captured_writes, (
+                f"openclaw.json was not written. Files seen: {list(captured_writes)}"
+            )
+            config = _json.loads(captured_writes["openclaw.json"])
+
+            # Primary model must be Qwen3 VL 235B for starter, not MiniMax.
+            # Before the fix, tier resolved to "free" so primary was MiniMax.
+            primary = config["agents"]["defaults"]["model"]["primary"]
+            assert "qwen.qwen3-vl-235b-a22b" in primary, (
+                f"Expected Qwen3 VL 235B primary for starter, got {primary!r}. "
+                "If this is MiniMax, provision_user_container fell back to free tier."
+            )
+
+            # Starter catalog exposes BOTH MiniMax and Qwen, not just MiniMax.
+            bedrock_models = config["models"]["providers"]["amazon-bedrock"]["models"]
+            model_ids = {m["id"] for m in bedrock_models}
+            assert "qwen.qwen3-vl-235b-a22b" in model_ids, f"Starter must expose Qwen3 VL 235B; got {model_ids}"
+            assert "minimax.minimax-m2.5" in model_ids, f"Starter must still expose MiniMax M2.5; got {model_ids}"

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -1809,3 +1809,119 @@ class TestProvisionUserContainer:
             mock_await.assert_not_called()
             # Also no DDB update (status already correct).
             mock_repo.update_fields.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provision_resolves_tier_from_billing_when_not_passed(
+        self, manager, mock_ecs_client, mock_efs_client
+    ):
+        """When no tier argument is passed (the usual router call), the
+        billing record's plan_tier must be forwarded to write_user_configs.
+
+        Regression test for issue #293: the router called
+        provision_user_container without a tier arg, so the function-level
+        default ("free") was used regardless of the caller's actual plan.
+        A paying starter/pro/enterprise user ended up with free-tier
+        configs written to EFS on first provision.
+        """
+        # No service exists -> full-provisioning path (writes configs).
+        mock_ecs_client.describe_services.return_value = {"services": []}
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.billing_repo") as mock_billing,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+            patch.object(manager, "write_user_configs", new_callable=AsyncMock) as mock_write_configs,
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=None)
+            mock_repo.upsert = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_status = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_billing.get_by_owner_id = AsyncMock(return_value={"owner_id": "user_test_123", "plan_tier": "starter"})
+
+            await manager.provision_user_container("user_test_123")
+
+            mock_billing.get_by_owner_id.assert_awaited_once_with("user_test_123")
+            # write_user_configs must be invoked with tier="starter", not "free".
+            assert mock_write_configs.await_count >= 1
+            kwargs = mock_write_configs.await_args_list[-1].kwargs
+            assert kwargs.get("tier") == "starter", (
+                f"Expected tier='starter' from billing record, got {kwargs.get('tier')!r}. "
+                "Router callers don't pass a tier, so provision_user_container must "
+                "resolve it from billing or paying users get free-tier configs."
+            )
+
+    @pytest.mark.asyncio
+    async def test_provision_defaults_to_free_when_no_billing_record(self, manager, mock_ecs_client, mock_efs_client):
+        """No billing row yet -> fall back to tier='free'. This is the path
+        a brand-new user hits before Stripe webhook creates the billing
+        account row."""
+        mock_ecs_client.describe_services.return_value = {"services": []}
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.billing_repo") as mock_billing,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+            patch.object(manager, "write_user_configs", new_callable=AsyncMock) as mock_write_configs,
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=None)
+            mock_repo.upsert = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_status = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_billing.get_by_owner_id = AsyncMock(return_value=None)
+
+            await manager.provision_user_container("user_test_123")
+
+            kwargs = mock_write_configs.await_args_list[-1].kwargs
+            assert kwargs.get("tier") == "free"
+
+    @pytest.mark.asyncio
+    async def test_provision_falls_back_to_free_on_billing_lookup_error(
+        self, manager, mock_ecs_client, mock_efs_client
+    ):
+        """A billing_repo exception must not crash the provision path.
+        Worst case: user boots on free-tier configs and the next patch
+        (via queue_tier_change on the subscription webhook) corrects it."""
+        mock_ecs_client.describe_services.return_value = {"services": []}
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.billing_repo") as mock_billing,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+            patch.object(manager, "write_user_configs", new_callable=AsyncMock) as mock_write_configs,
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=None)
+            mock_repo.upsert = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_status = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_billing.get_by_owner_id = AsyncMock(side_effect=RuntimeError("dynamodb down"))
+
+            await manager.provision_user_container("user_test_123")
+
+            kwargs = mock_write_configs.await_args_list[-1].kwargs
+            assert kwargs.get("tier") == "free"
+
+    @pytest.mark.asyncio
+    async def test_provision_respects_explicit_tier_arg_over_billing(self, manager, mock_ecs_client, mock_efs_client):
+        """Explicit tier arg wins over the billing lookup. This keeps the
+        /debug/provision-style override possible and makes the function
+        composable for tests."""
+        mock_ecs_client.describe_services.return_value = {"services": []}
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch("core.containers.ecs_manager.billing_repo") as mock_billing,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+            patch.object(manager, "write_user_configs", new_callable=AsyncMock) as mock_write_configs,
+        ):
+            mock_repo.get_by_owner_id = AsyncMock(return_value=None)
+            mock_repo.upsert = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_repo.update_status = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+            mock_billing.get_by_owner_id = AsyncMock(return_value={"plan_tier": "starter"})
+
+            await manager.provision_user_container("user_test_123", tier="pro")
+
+            kwargs = mock_write_configs.await_args_list[-1].kwargs
+            assert kwargs.get("tier") == "pro"
+            # Explicit tier should bypass the billing lookup entirely.
+            mock_billing.get_by_owner_id.assert_not_called()


### PR DESCRIPTION
## Summary
- Fixes #293 — `POST /container/provision` (and all sibling callers: `/status` auto-retry, `/container/retry`, recovery paths) wrote **free-tier** configs to EFS regardless of the user's actual subscription tier.
- Root cause: `provision_user_container` had `tier: str = "free"`, and none of the 5 production callers passed a tier arg. Paying starter/pro/enterprise users got MiniMax M2.5 + free-tier agent defaults on first provision. Later tier patches (via `queue_tier_change` on the subscription webhook) eventually corrected it, but the first chat was wrong.
- Fix: move tier resolution into `provision_user_container` itself. Signature is now `tier: str | None = None`; when `None`, look up `billing_repo.get_by_owner_id(owner)` and use `plan_tier`. Missing billing row or a lookup error fall back to `"free"` so we never crash the provision path on a billing hiccup.
- Explicit `tier=` overrides stay supported (used by `/debug/provision` and tests).

## Why this shape
- **Resolve at the sink, not each caller.** Five production callers currently pass no tier. Fixing every call site would spread the lookup; centralizing it in `provision_user_container` keeps the fix to one place and avoids missing a future caller.
- **Fail-soft on billing lookup errors.** A DynamoDB blip shouldn't stop a user from getting a container. Worst case: user boots free-tier, then the subscription webhook's existing tier-patch flow corrects the config.

## Test plan
- [x] New unit tests in `tests/unit/containers/test_ecs_manager.py::TestProvisionUserContainer`:
  - `test_provision_resolves_tier_from_billing_when_not_passed` — router-style call → `write_user_configs(tier="starter")`.
  - `test_provision_defaults_to_free_when_no_billing_record` — brand-new user, no billing row → `tier="free"`.
  - `test_provision_falls_back_to_free_on_billing_lookup_error` — `billing_repo` raises → `tier="free"`.
  - `test_provision_respects_explicit_tier_arg_over_billing` — explicit `tier="pro"` wins; billing not queried.
- [x] Full `tests/unit/containers/` suite: **151 passed**.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Post-deploy: verify a fresh dev provision for a starter-subscribed user produces an `openclaw.json` on EFS with Qwen3 VL 235B as primary model (not MiniMax M2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
