### PR TITLE
feat(provisioning): require explicit click to wake scale-to-zero containers

### DIFF
--- a/apps/frontend/src/components/chat/ChatLayout.tsx
+++ b/apps/frontend/src/components/chat/ChatLayout.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { usePostHog } from "posthog-js/react";
 import { useAuth, useOrganization, useOrganizationList, useUser, UserButton } from "@clerk/nextjs";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Settings, Plus, Bot, CheckCircle, CreditCard, Menu, X, FolderOpen, Pencil, Trash2 } from "lucide-react";
+import { Settings, Plus, Bot, CheckCircle, CreditCard, Menu, X, FolderOpen, Pencil, Trash2, Loader2 } from "lucide-react";
 import Link from "next/link";
 
 import { ProvisioningStepper } from "@/components/chat/ProvisioningStepper";
@@ -66,7 +66,7 @@ export function ChatLayout({
   });
   const router = useRouter();
   const api = useApi();
-  const { agents, defaultId, createAgent, deleteAgent, updateAgent } = useAgents();
+  const { agents, defaultId, isLoading: agentsLoading, createAgent, deleteAgent, updateAgent } = useAgents();
   const { refresh: refreshBilling, account } = useBilling();
   const { nodeConnected } = useGateway();
   // Emit throttled user_active pings so the backend scale-to-zero reaper
@@ -274,6 +274,22 @@ export function ChatLayout({
 
               {/* Agent List */}
               <div className="agent-list">
+                {agentsLoading && !agents.length ? (
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      gap: 8,
+                      padding: "12px 8px",
+                      color: "#8a8578",
+                      fontSize: 13,
+                    }}
+                  >
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    <span>Loading agents…</span>
+                  </div>
+                ) : null}
                 {agents.map((agent) => {
                   const isDefault = agent.id === defaultId;
                   return (

--- a/apps/frontend/src/components/chat/ProvisioningStepper.tsx
+++ b/apps/frontend/src/components/chat/ProvisioningStepper.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircle,
   Circle,
   AlertTriangle,
+  Moon,
 } from "lucide-react";
 import { useOrganization } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
@@ -155,6 +156,11 @@ export function ProvisioningStepper({
   // of truth for "is the channel onboarding step needed for this user". Cancel
   // hides the wizard for the current session; next mount re-checks the data.
   const [onboardingComplete, setOnboardingComplete] = useState(false);
+  // Records the "stopped session" id (updated_at) the user explicitly waked,
+  // so we don't keep showing the wake card while status flips stopped →
+  // provisioning. A new stopped session (different updated_at) shows the
+  // card again, which is what we want for the second 5-min-idle cycle.
+  const [wakedSessionId, setWakedSessionId] = useState<string | null>(null);
 
   // Poll container status every 3s once subscribed or on free tier (auto-provisioned)
   const shouldPollContainer = isSubscribed || isFree;
@@ -163,9 +169,11 @@ export function ProvisioningStepper({
     enabled: shouldPollContainer,
   });
 
-  // When container status returns null (404), trigger provisioning once
-  // Trigger provisioning when no container (404) or container is stopped (scale-to-zero)
-  const needsProvision = container === null || container?.status === "stopped";
+  // Auto-provision only on first-time onboarding (container === null / 404).
+  // Containers that have scaled to zero require an explicit user click —
+  // see the wake card below — so we don't pay the ~3-min cold-start cost
+  // every time the user navigates back to /chat.
+  const isFirstTime = container === null;
   useEffect(() => {
     // Defensive: don't fire provision until Clerk's org state has fully
     // hydrated. ChatLayout already gates this component behind an onboarded
@@ -174,17 +182,25 @@ export function ProvisioningStepper({
     // can't accidentally fire /container/provision with a still-loading JWT
     // and get a personal container when an org was expected.
     if (!orgLoaded) return;
-    if (needsProvision && shouldPollContainer && !provisionRequestedRef.current) {
+    if (isFirstTime && shouldPollContainer && !provisionRequestedRef.current) {
       provisionRequestedRef.current = true;
       api.post("/container/provision", {}).catch((err: unknown) => {
         console.error("Container provision failed:", err);
       });
     }
-    // Reset the ref when container comes back so it can re-provision on next stop
-    if (container && container.status !== "stopped") {
+    // Reset once a container exists so a future delete → re-provision works.
+    if (container) {
       provisionRequestedRef.current = false;
     }
-  }, [needsProvision, orgLoaded, container, shouldPollContainer, api]);
+  }, [isFirstTime, orgLoaded, container, shouldPollContainer, api]);
+
+  const handleWake = () => {
+    posthog?.capture("container_wake_clicked");
+    setWakedSessionId(container?.updated_at ?? "wake");
+    api.post("/container/provision", {}).catch((err: unknown) => {
+      console.error("Container wake failed:", err);
+    });
+  };
 
   const containerReady = container?.status === "running" || container?.substatus === "gateway_healthy";
 
@@ -340,6 +356,34 @@ export function ProvisioningStepper({
               <a href="mailto:support@isol8.co">Contact Support</a>
             </Button>
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Sleeping (scale-to-zero) container — require explicit click to wake.
+  // Auto-firing here would cost the user a 3-min cold-start every time
+  // they navigate back to /chat, which is hostile UX for the free tier.
+  const stoppedSessionId = container?.status === "stopped" ? (container.updated_at ?? "stopped") : null;
+  const alreadyWaked = stoppedSessionId !== null && wakedSessionId === stoppedSessionId;
+  if (stoppedSessionId !== null && !alreadyWaked) {
+    return (
+      <div className="flex-1 flex items-center justify-center bg-[#faf7f2]">
+        <div className="text-center space-y-6 max-w-sm px-6">
+          <div className="space-y-2">
+            <Moon className="h-8 w-8 text-[#06402B] mx-auto" />
+            <h2 className="text-lg font-medium text-[#1a1a1a]">Your container is sleeping</h2>
+            <p className="text-sm text-[#8a8578]">
+              Free-tier agents scale to zero after 5 minutes of inactivity to save resources.
+              Waking takes about 3 minutes with the slim image.
+            </p>
+          </div>
+          <Button
+            className="rounded-full bg-[#06402B] hover:bg-[#0a5c3e] text-white"
+            onClick={handleWake}
+          >
+            Wake container
+          </Button>
         </div>
       </div>
     );


### PR DESCRIPTION
## Bug

`ProvisioningStepper.tsx` auto-fired `POST /container/provision` whenever a free-tier container had scaled to zero (`container?.status === "stopped"`). Every navigation back to `/chat` therefore triggered a ~3-minute cold start the user never asked for — even if they were just popping back to glance at the dashboard.

## Fix

Split the auto-provision condition:

- **`container === null` (first-time onboarding):** keep current behaviour — silent auto-provision.
- **`container?.status === "stopped"` (returning user, scaled to zero):** show a wake card requiring an explicit click.

Wake card matches the existing aesthetic (`#faf7f2` bg, `#06402B` primary, `Moon` icon). On click we fire `POST /container/provision`, record the waked session id (the container's `updated_at`), and fall through to the existing stepper. The session-id approach means a *second* 5-min-idle cycle will show the card again, while the first wake doesn't flicker the card during `stopped → provisioning` transition.

PostHog event: `container_wake_clicked` on click.

### Recovery flow

The `trigger === "recovery"` prop is preserved — it still skips billing as before. But a recovery user with a stopped container now also goes through the wake gate. Billing and cold-start cost are independent concerns; the user should consent to the 3-min wait either way.

## Manual test plan

- [ ] On dev, sign in as a free-tier user with a running container
- [ ] Wait 5+ minutes (or scale-to-zero manually) until status flips to `stopped`
- [ ] Navigate away from `/chat`, then back
- [ ] Expect: wake card with "Your container is sleeping" copy, no automatic provision call in network tab
- [ ] Click "Wake container"
- [ ] Expect: `POST /container/provision` fires once, stepper takes over, container cold-starts (~3 min with the slim image), eventually lands in chat
- [ ] Verify PostHog `container_wake_clicked` event fires on click
- [ ] (Regression) Sign up as a brand-new user with no container at all
- [ ] Expect: silent auto-provision and stepper appears immediately, NO wake card

🤖 Generated with [Claude Code](https://claude.com/claude-code)