### PR TITLE
fix(containers): pin per-user task def base to ARN, never family-latest

### DIFF
--- a/apps/backend/core/containers/ecs_manager.py
+++ b/apps/backend/core/containers/ecs_manager.py
@@ -132,12 +132,69 @@ class EcsManager:
     # Per-user task definition revisions
     # ------------------------------------------------------------------
 
-    def _register_task_definition(self, access_point_id: str) -> str:
-        """Clone the base task definition with a per-user EFS access point.
+    def _build_register_kwargs_from_base(
+        self,
+        access_point_id: str,
+        new_image: str | None = None,
+        new_cpu: str | None = None,
+        new_memory: str | None = None,
+    ) -> dict:
+        """Build register_task_definition kwargs by cloning the CDK-managed base.
 
-        Reads the Terraform-managed base task definition, replaces the
-        EFS volume's access point ID with the per-user one, and registers
-        a new revision in the same family.
+        Always reads from ``self._task_def`` (the pinned ARN exported by
+        container-stack.ts). NEVER reads from a per-user revision — per-user
+        clones register into the same family, so the family name resolves
+        non-deterministically depending on provision order. Pinning to the
+        full ARN keeps env vars / command / mountPoints in sync with what CDK
+        deployed.
+
+        Per-user state layered on top:
+          - access_point_id  (per-user EFS access point, replaces the volume's)
+          - new_image        (image_update flow only — None preserves base image)
+          - new_cpu/memory   (tier-resize flow only — None preserves base values)
+        """
+        desc_resp = self._ecs.describe_task_definition(taskDefinition=self._task_def)
+        base = desc_resp["taskDefinition"]
+
+        volumes = []
+        for vol in base.get("volumes", []):
+            vol_copy = dict(vol)
+            efs_config = vol_copy.get("efsVolumeConfiguration")
+            if efs_config:
+                efs_copy = dict(efs_config)
+                auth_config = dict(efs_copy.get("authorizationConfig", {}))
+                auth_config["accessPointId"] = access_point_id
+                efs_copy["authorizationConfig"] = auth_config
+                vol_copy["efsVolumeConfiguration"] = efs_copy
+            volumes.append(vol_copy)
+
+        # Deep-copy containerDefinitions because we may mutate `image`. Each
+        # entry is itself a dict — we shallow-copy each before mutation.
+        container_defs = []
+        for cd in base["containerDefinitions"]:
+            cd_copy = dict(cd)
+            if new_image:
+                cd_copy["image"] = new_image
+            container_defs.append(cd_copy)
+
+        reg_kwargs = dict(
+            family=base["family"],
+            taskRoleArn=base.get("taskRoleArn", ""),
+            executionRoleArn=base.get("executionRoleArn", ""),
+            networkMode=base.get("networkMode", "awsvpc"),
+            containerDefinitions=container_defs,
+            volumes=volumes,
+            requiresCompatibilities=base.get("requiresCompatibilities", ["FARGATE"]),
+            cpu=new_cpu or base.get("cpu", "256"),
+            memory=new_memory or base.get("memory", "512"),
+        )
+        if base.get("runtimePlatform"):
+            reg_kwargs["runtimePlatform"] = base["runtimePlatform"]
+
+        return reg_kwargs
+
+    def _register_task_definition(self, access_point_id: str) -> str:
+        """Clone the CDK base for a new per-user container.
 
         Args:
             access_point_id: The per-user EFS access point ID.
@@ -149,39 +206,7 @@ class EcsManager:
             EcsManagerError: If the ECS API calls fail.
         """
         try:
-            # Read the base task definition
-            desc_resp = self._ecs.describe_task_definition(taskDefinition=self._task_def)
-            base = desc_resp["taskDefinition"]
-
-            # Clone volumes with per-user access point
-            volumes = []
-            for vol in base.get("volumes", []):
-                vol_copy = dict(vol)
-                efs_config = vol_copy.get("efsVolumeConfiguration")
-                if efs_config:
-                    efs_copy = dict(efs_config)
-                    auth_config = dict(efs_copy.get("authorizationConfig", {}))
-                    auth_config["accessPointId"] = access_point_id
-                    efs_copy["authorizationConfig"] = auth_config
-                    vol_copy["efsVolumeConfiguration"] = efs_copy
-                volumes.append(vol_copy)
-
-            # Register new revision in the same family
-            reg_kwargs = dict(
-                family=base["family"],
-                taskRoleArn=base.get("taskRoleArn", ""),
-                executionRoleArn=base.get("executionRoleArn", ""),
-                networkMode=base.get("networkMode", "awsvpc"),
-                containerDefinitions=base["containerDefinitions"],
-                volumes=volumes,
-                requiresCompatibilities=base.get("requiresCompatibilities", ["FARGATE"]),
-                cpu=base.get("cpu", "256"),
-                memory=base.get("memory", "512"),
-            )
-            # runtimePlatform is optional; passing None causes ParamValidationError
-            if base.get("runtimePlatform"):
-                reg_kwargs["runtimePlatform"] = base["runtimePlatform"]
-
+            reg_kwargs = self._build_register_kwargs_from_base(access_point_id)
             reg_resp = self._ecs.register_task_definition(**reg_kwargs)
             task_def_arn = reg_resp["taskDefinition"]["taskDefinitionArn"]
             put_metric("container.task_def.register", dimensions={"status": "ok"})
@@ -453,38 +478,26 @@ class EcsManager:
         if not container:
             raise EcsManagerError(f"No container found for user {user_id}", user_id)
 
-        current_task_def_arn = container.get("task_definition_arn")
-        if not current_task_def_arn:
-            raise EcsManagerError(f"No task definition ARN for user {user_id}", user_id)
+        access_point_id = container.get("access_point_id")
+        if not access_point_id:
+            raise EcsManagerError(f"No EFS access point for user {user_id}", user_id)
 
         service_name = self._service_name(user_id)
 
         try:
-            # Read the current per-user task definition
-            desc_resp = await asyncio.to_thread(self._ecs.describe_task_definition, taskDefinition=current_task_def_arn)
-            base = desc_resp["taskDefinition"]
-
-            # Build updated kwargs
-            reg_kwargs = dict(
-                family=base["family"],
-                taskRoleArn=base.get("taskRoleArn", ""),
-                executionRoleArn=base.get("executionRoleArn", ""),
-                networkMode=base.get("networkMode", "awsvpc"),
-                containerDefinitions=base["containerDefinitions"],
-                volumes=base.get("volumes", []),
-                requiresCompatibilities=base.get("requiresCompatibilities", ["FARGATE"]),
-                cpu=new_cpu or base.get("cpu", "256"),
-                memory=new_memory or base.get("memory", "512"),
+            # Always read containerDefinitions/env/command/mounts from the
+            # CDK-managed base, NEVER from the user's prior per-user revision.
+            # Reading from a prior per-user revision propagates any drift it
+            # had (e.g., missing CLAWHUB_WORKDIR — incident 2026-04-17). Per-
+            # user state (EFS access point, image, cpu/memory) is layered here.
+            reg_kwargs = await asyncio.to_thread(
+                self._build_register_kwargs_from_base,
+                access_point_id,
+                new_image=new_image,
+                new_cpu=new_cpu,
+                new_memory=new_memory,
             )
-            if base.get("runtimePlatform"):
-                reg_kwargs["runtimePlatform"] = base["runtimePlatform"]
 
-            # Update image if specified
-            if new_image and reg_kwargs["containerDefinitions"]:
-                for container_def in reg_kwargs["containerDefinitions"]:
-                    container_def["image"] = new_image
-
-            # Register new revision
             reg_resp = await asyncio.to_thread(self._ecs.register_task_definition, **reg_kwargs)
             new_task_def_arn = reg_resp["taskDefinition"]["taskDefinitionArn"]
             logger.info("Registered resized task definition %s for user %s", new_task_def_arn, user_id)

--- a/apps/backend/tests/unit/containers/test_ecs_manager.py
+++ b/apps/backend/tests/unit/containers/test_ecs_manager.py
@@ -116,11 +116,16 @@ def _make_container_dict(
     service_name="openclaw-user_test_123-f4ae64abb2db",
     gateway_token="tok-abc",
     status="running",
-    access_point_id=None,
+    access_point_id="fsap-test-default",
     task_definition_arn=None,
     substatus=None,
 ):
-    """Helper to create a container dict for mocking DynamoDB repo responses."""
+    """Helper to create a container dict for mocking DynamoDB repo responses.
+
+    Default access_point_id is set so resize_user_container (which now reads
+    it from the row) works in tests that don't override it explicitly. Pass
+    access_point_id=None to omit it (e.g. to test the missing-field error).
+    """
     d = {
         "owner_id": user_id,
         "service_name": service_name,
@@ -280,6 +285,54 @@ class TestRegisterTaskDefinition:
 
         with pytest.raises(EcsManagerError, match="Failed to register per-user task definition"):
             manager._register_task_definition("fsap-user123")
+
+    def test_register_preserves_env_vars_from_base(self, manager, mock_ecs_client):
+        """Per-user registration must preserve env vars on the base container.
+
+        Regression: in incident 2026-04-17 the per-user cloner produced task
+        defs missing CLAWHUB_WORKDIR, even though the CDK base had it. This
+        sent every clawhub-installed skill to a path no agent scanner reads.
+        """
+        mock_ecs_client.describe_task_definition.return_value = {
+            "taskDefinition": {
+                "family": "isol8-dev-openclaw",
+                "taskRoleArn": "arn:aws:iam::123456789:role/task-role",
+                "executionRoleArn": "arn:aws:iam::123456789:role/exec-role",
+                "networkMode": "awsvpc",
+                "containerDefinitions": [
+                    {
+                        "name": "openclaw",
+                        "image": "alpine/openclaw:latest",
+                        "environment": [
+                            {"name": "HOME", "value": "/home/node"},
+                            {"name": "CHOKIDAR_USEPOLLING", "value": "true"},
+                            {"name": "CLAWHUB_WORKDIR", "value": "/home/node/.openclaw"},
+                        ],
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "openclaw-workspace",
+                        "efsVolumeConfiguration": {
+                            "fileSystemId": "fs-test123",
+                            "transitEncryption": "ENABLED",
+                            "authorizationConfig": {"accessPointId": "fsap-base", "iam": "ENABLED"},
+                        },
+                    }
+                ],
+                "requiresCompatibilities": ["FARGATE"],
+                "cpu": "256",
+                "memory": "512",
+            }
+        }
+
+        manager._register_task_definition("fsap-user123")
+
+        call_kwargs = mock_ecs_client.register_task_definition.call_args.kwargs
+        env = {e["name"]: e["value"] for e in call_kwargs["containerDefinitions"][0]["environment"]}
+        assert env["CLAWHUB_WORKDIR"] == "/home/node/.openclaw"
+        assert env["HOME"] == "/home/node"
+        assert env["CHOKIDAR_USEPOLLING"] == "true"
 
 
 # ---------------------------------------------------------------------------
@@ -675,7 +728,7 @@ class TestDeleteUserService:
     @pytest.mark.asyncio
     async def test_delete_without_per_user_resources(self, manager, mock_ecs_client, mock_efs_client):
         """delete_user_service skips cleanup when container has no per-user resources."""
-        container_dict = _make_container_dict(status="running")
+        container_dict = _make_container_dict(status="running", access_point_id=None)
         with patch("core.containers.ecs_manager.container_repo") as mock_repo:
             mock_repo.get_by_owner_id = AsyncMock(return_value=container_dict)
             mock_repo.delete = AsyncMock()
@@ -1429,6 +1482,89 @@ class TestResizeUserContainer:
     resize writes status=provisioning via update_fields + ECS forceNewDeployment.
     Without firing the poller, the row stays stuck at provisioning until the
     next backend restart catches it via the startup reconciler."""
+
+    @pytest.mark.asyncio
+    async def test_resize_reads_env_from_base_not_current(self, manager, mock_ecs_client):
+        """resize must read containerDefinitions from the CDK-managed base
+        (self._task_def), NOT from the user's prior per-user revision.
+
+        Regression: incident 2026-04-17 — the resize path read from the user's
+        own task def, propagating any env-var drift forever. After this fix,
+        the base ARN is always read, so a user with a stale per-user task def
+        still gets the current CDK env on the next resize.
+        """
+        # Base task def has CLAWHUB_WORKDIR. User's *prior* per-user task def
+        # does NOT (simulating tonight's incident). Resize must produce an env
+        # that mirrors the base, not the user's drifted prior state.
+        mock_ecs_client.describe_task_definition.return_value = {
+            "taskDefinition": {
+                "family": "isol8-dev-openclaw",
+                "taskRoleArn": "",
+                "executionRoleArn": "",
+                "networkMode": "awsvpc",
+                "containerDefinitions": [
+                    {
+                        "name": "openclaw",
+                        "image": "alpine/openclaw:latest",
+                        "environment": [
+                            {"name": "HOME", "value": "/home/node"},
+                            {"name": "CLAWHUB_WORKDIR", "value": "/home/node/.openclaw"},
+                        ],
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "openclaw-workspace",
+                        "efsVolumeConfiguration": {
+                            "fileSystemId": "fs-test123",
+                            "transitEncryption": "ENABLED",
+                            "authorizationConfig": {"accessPointId": "fsap-base", "iam": "ENABLED"},
+                        },
+                    }
+                ],
+                "requiresCompatibilities": ["FARGATE"],
+                "cpu": "256",
+                "memory": "512",
+            }
+        }
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "openclaw-user_test_123-f4ae64abb2db",
+                    "status": "ACTIVE",
+                    "desiredCount": 1,
+                    "runningCount": 1,
+                    "deployments": [{"id": "ecs-svc/primary", "status": "PRIMARY", "rolloutState": "IN_PROGRESS"}],
+                }
+            ]
+        }
+
+        with (
+            patch("core.containers.ecs_manager.container_repo") as mock_repo,
+            patch.object(manager, "_await_running_transition", new_callable=AsyncMock),
+            patch("core.containers.ecs_manager.asyncio.to_thread") as mock_to_thread,
+        ):
+
+            async def passthrough(fn, *args, **kwargs):
+                return fn(*args, **kwargs)
+
+            mock_to_thread.side_effect = passthrough
+            mock_repo.get_by_owner_id = AsyncMock(
+                return_value=_make_container_dict(status="running", access_point_id="fsap-user-789")
+            )
+            mock_repo.update_fields = AsyncMock(return_value=_make_container_dict(status="provisioning"))
+
+            await manager.resize_user_container("user_test_123", new_cpu="1024", new_memory="2048")
+
+            call_kwargs = mock_ecs_client.register_task_definition.call_args.kwargs
+            env = {e["name"]: e["value"] for e in call_kwargs["containerDefinitions"][0]["environment"]}
+            assert env["CLAWHUB_WORKDIR"] == "/home/node/.openclaw"
+
+            # Per-user state correctly layered on top of base
+            volumes = call_kwargs["volumes"]
+            assert volumes[0]["efsVolumeConfiguration"]["authorizationConfig"]["accessPointId"] == "fsap-user-789"
+            assert call_kwargs["cpu"] == "1024"
+            assert call_kwargs["memory"] == "2048"
 
     @pytest.mark.asyncio
     async def test_resize_fires_running_transition_poller(self, manager, mock_ecs_client):

--- a/apps/infra/lib/isol8-stage.ts
+++ b/apps/infra/lib/isol8-stage.ts
@@ -95,6 +95,7 @@ export class Isol8Stage extends cdk.Stage {
         containerSecurityGroup: container.containerSecurityGroup,
         taskExecutionRole: container.taskExecutionRole,
         taskRole: container.taskRole,
+        openclawTaskDef: container.openclawTaskDef,
       },
       managementApiUrl: api.managementApiUrl,
       connectionsTableName: api.connectionsTableName,

--- a/apps/infra/lib/local-stage.ts
+++ b/apps/infra/lib/local-stage.ts
@@ -98,6 +98,7 @@ export class LocalStage extends cdk.Stage {
         containerSecurityGroup: container.containerSecurityGroup,
         taskExecutionRole: container.taskExecutionRole,
         taskRole: container.taskRole,
+        openclawTaskDef: container.openclawTaskDef,
       },
       managementApiUrl: api.managementApiUrl,
       connectionsTableName: api.connectionsTableName,

--- a/apps/infra/lib/stacks/container-stack.ts
+++ b/apps/infra/lib/stacks/container-stack.ts
@@ -51,6 +51,11 @@ export class ContainerStack extends cdk.Stack {
   public readonly taskExecutionRole: iam.Role;
   public readonly taskRole: iam.Role;
   public readonly openclawExtendedRepo: ecr.IRepository;
+  // Exposed so service-stack can pin the backend's ECS_TASK_DEFINITION env to
+  // a specific revision ARN — never the family name. The backend cloner
+  // reads this ARN to build per-user task defs; pinning prevents per-user
+  // clones (which register into the same family) from poisoning family-latest.
+  public readonly openclawTaskDef: ecs.FargateTaskDefinition;
 
   constructor(scope: Construct, id: string, props: ContainerStackProps) {
     super(scope, id, props);
@@ -281,7 +286,7 @@ export class ContainerStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
-    const openclawTaskDef = new ecs.FargateTaskDefinition(this, "OpenClawTaskDef", {
+    this.openclawTaskDef = new ecs.FargateTaskDefinition(this, "OpenClawTaskDef", {
       family: `isol8-${env}-openclaw`,
       cpu: 1024,
       memoryLimitMiB: 2048,
@@ -316,7 +321,7 @@ export class ContainerStack extends cdk.Stack {
         ? ecs.ContainerImage.fromRegistry(OPENCLAW_VERSION.full)
         : ecs.ContainerImage.fromEcrRepository(this.openclawExtendedRepo, envTag);
 
-    const openclawContainer = openclawTaskDef.addContainer("openclaw", {
+    const openclawContainer = this.openclawTaskDef.addContainer("openclaw", {
       image: containerImage,
       essential: true,
       command: ["sh", "-c", startupCommand],
@@ -346,7 +351,7 @@ export class ContainerStack extends cdk.Stack {
     });
 
     // Add EFS volume — the backend replaces the access point per user
-    openclawTaskDef.addVolume({
+    this.openclawTaskDef.addVolume({
       name: "openclaw-workspace",
       efsVolumeConfiguration: {
         fileSystemId: this.efsFileSystem.fileSystemId,

--- a/apps/infra/lib/stacks/service-stack.ts
+++ b/apps/infra/lib/stacks/service-stack.ts
@@ -53,6 +53,7 @@ export interface ServiceStackProps extends cdk.StackProps {
     containerSecurityGroup: ec2.ISecurityGroup;
     taskExecutionRole: iam.IRole;
     taskRole: iam.IRole;
+    openclawTaskDef: ecs.ITaskDefinition;
   };
   managementApiUrl: string;
   connectionsTableName: string;
@@ -559,7 +560,12 @@ export class ServiceStack extends cdk.Stack {
         CONTAINER_EXECUTION_ROLE_ARN:
           props.container.taskExecutionRole.roleArn,
         ECS_CLUSTER_ARN: props.container.cluster.clusterArn,
-        ECS_TASK_DEFINITION: `isol8-${env}-openclaw`,
+        // Pin to the full ARN (with revision) so the backend cloner always
+        // reads the CDK-managed base, never a per-user clone. Per-user clones
+        // register into the same family, so the family name resolves to
+        // family-latest — which can be a poisoned per-user revision and was
+        // the root cause of the CLAWHUB_WORKDIR drift incident on 2026-04-17.
+        ECS_TASK_DEFINITION: props.container.openclawTaskDef.taskDefinitionArn,
         ECS_SUBNETS: privateSubnetIds,
         ECS_SECURITY_GROUP_ID:
           props.container.containerSecurityGroup.securityGroupId,


### PR DESCRIPTION
## Summary
Stops per-user ECS task defs from drifting from the CDK-managed base. Two-part structural fix:

1. **CDK pins the base ARN.** \`container-stack.ts\` exposes \`openclawTaskDef\` as a public readonly. \`service-stack.ts\` sets \`ECS_TASK_DEFINITION\` to the **full ARN with revision** (\`props.container.openclawTaskDef.taskDefinitionArn\`) instead of the family name. CDK deploys auto-roll the backend with the new ARN.

2. **Backend cloner always reads from base.** Both \`_register_task_definition\` (initial provision) AND \`resize_user_container\` (Update Now / tier change) now use a shared helper \`_build_register_kwargs_from_base\` that reads container-definitions / env / mounts from \`self._task_def\` (the pinned ARN). Per-user state — EFS access point, image override, cpu/memory — is layered on top.

## Why
Tonight's CLAWHUB_WORKDIR incident: per-user task defs from \`:953\` onward were missing the env var even though CDK base \`:955\` had it. Two paths leaked:

- \`_register_task_definition\` read \`describe_task_definition("isol8-dev-openclaw")\` (family name) → ECS resolves to family-latest → which is a per-user clone, not CDK base. Adding env vars to CDK silently failed to propagate once a single per-user clone existed.
- \`resize_user_container\` read from the user's CURRENT task def → any drift stayed forever. Update Now couldn't self-heal.

After this fix, all clones read from a fixed ARN that only CDK can change, and resize always re-syncs to the current base.

## Test plan
- [x] Backend: 747 passed
- [x] CDK: \`tsc --noEmit\` clean
- [x] New tests assert CLAWHUB_WORKDIR survives both clone paths
- [ ] After merge + deploy: re-provision a user (\`DELETE /debug/provision\` + \`POST /debug/provision\`) and verify the new task def has CLAWHUB_WORKDIR
- [ ] After merge + deploy: click Update Now on a drifted user and verify the resulting task def has CLAWHUB_WORKDIR (self-heal)

## Known follow-ups (out of scope here)
- Existing drifted per-user task defs (\`:953\`, \`:956\`, \`:957\` on dev) keep their bug until re-provisioned or resized.
- Surface clawhub install paths in container logs so silent misroutes are detectable. Worth filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)