### PR TITLE
fix(e2e): match Clerk user by email in JS, never trust the ?email_address[] filter

### DIFF
--- a/apps/frontend/tests/e2e/chat.smoke.spec.ts
+++ b/apps/frontend/tests/e2e/chat.smoke.spec.ts
@@ -16,22 +16,35 @@ async function createSignInToken(): Promise<{ ticket: string; userId: string }> 
   const secretKey = process.env.CLERK_SECRET_KEY;
   if (!secretKey) throw new Error('[smoke] CLERK_SECRET_KEY not set');
 
+  // Clerk's ?email_address[]=X filter is unreliable — verified 2026-04-17
+  // it returned ALL users regardless of the param. Match in JS to avoid
+  // signing in as the wrong user.
   const usersRes = await fetch(
     `https://api.clerk.com/v1/users?email_address[]=${encodeURIComponent(E2E_EMAIL)}`,
     { headers: { Authorization: `Bearer ${secretKey}` } },
   );
   if (!usersRes.ok) throw new Error(`[smoke] Users API ${usersRes.status}: ${await usersRes.text()}`);
-  const users = await usersRes.json() as Array<{ id: string }>;
-  if (!users.length) throw new Error(`[smoke] No Clerk user found for ${E2E_EMAIL}`);
+  const allUsers = await usersRes.json() as Array<{
+    id: string;
+    email_addresses?: Array<{ email_address?: string }>;
+  }>;
+  const matched = allUsers.find((u) =>
+    u.email_addresses?.some((e) => e.email_address?.toLowerCase() === E2E_EMAIL.toLowerCase()),
+  );
+  if (!matched) {
+    throw new Error(
+      `[smoke] No Clerk user with email ${E2E_EMAIL} (Clerk returned ${allUsers.length} candidates, none matched)`,
+    );
+  }
 
   const tokenRes = await fetch('https://api.clerk.com/v1/sign_in_tokens', {
     method: 'POST',
     headers: { Authorization: `Bearer ${secretKey}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ user_id: users[0].id }),
+    body: JSON.stringify({ user_id: matched.id }),
   });
   if (!tokenRes.ok) throw new Error(`[smoke] Sign-in token API ${tokenRes.status}: ${await tokenRes.text()}`);
   const { token } = await tokenRes.json() as { token: string };
-  return { ticket: token, userId: users[0].id };
+  return { ticket: token, userId: matched.id };
 }
 
 test.describe('Chat Smoke', () => {

--- a/apps/frontend/tests/e2e/journey.spec.ts
+++ b/apps/frontend/tests/e2e/journey.spec.ts
@@ -18,26 +18,39 @@ async function createSignInToken(): Promise<{ ticket: string; userId: string }> 
   const secretKey = process.env.CLERK_SECRET_KEY;
   if (!secretKey) throw new Error('[e2e] CLERK_SECRET_KEY not set');
 
-  // Find user by email
+  // Find user by email. Clerk's ?email_address[]=X filter is unreliable —
+  // verified 2026-04-17: it returned ALL users regardless of the param,
+  // and we were taking users[0] which clobbered whichever user had signed
+  // up most recently. Filter the response in JS to make the match exact.
   const usersRes = await fetch(
     `https://api.clerk.com/v1/users?email_address[]=${encodeURIComponent(E2E_EMAIL)}`,
     { headers: { Authorization: `Bearer ${secretKey}` } },
   );
   if (!usersRes.ok) throw new Error(`[e2e] Users API ${usersRes.status}: ${await usersRes.text()}`);
-  const users = await usersRes.json() as Array<{ id: string }>;
-  if (!users.length) throw new Error(`[e2e] No user found for ${E2E_EMAIL}`);
-  console.log(`[e2e] Found user: ${users[0].id}`);
+  const allUsers = await usersRes.json() as Array<{
+    id: string;
+    email_addresses?: Array<{ email_address?: string }>;
+  }>;
+  const matched = allUsers.find((u) =>
+    u.email_addresses?.some((e) => e.email_address?.toLowerCase() === E2E_EMAIL.toLowerCase()),
+  );
+  if (!matched) {
+    throw new Error(
+      `[e2e] No Clerk user with email ${E2E_EMAIL} (Clerk returned ${allUsers.length} candidates, none matched)`,
+    );
+  }
+  console.log(`[e2e] Found user: ${matched.id}`);
 
   // Create sign-in token
   const tokenRes = await fetch('https://api.clerk.com/v1/sign_in_tokens', {
     method: 'POST',
     headers: { Authorization: `Bearer ${secretKey}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ user_id: users[0].id }),
+    body: JSON.stringify({ user_id: matched.id }),
   });
   if (!tokenRes.ok) throw new Error(`[e2e] Sign-in token API ${tokenRes.status}: ${await tokenRes.text()}`);
   const { token } = await tokenRes.json() as { token: string };
   console.log('[e2e] Sign-in token created');
-  return { ticket: token, userId: users[0].id };
+  return { ticket: token, userId: matched.id };
 }
 
 test.describe('E2E Gate: Full User Journey', () => {


### PR DESCRIPTION
## Summary
Stops the post-deploy E2E gate from clobbering whichever Clerk user signed up most recently.

## Problem (incident 2026-04-17)
\`tests/e2e/journey.spec.ts\` and \`tests/e2e/chat.smoke.spec.ts\` both look up the e2e user via:

\`\`\`ts
fetch(\`https://api.clerk.com/v1/users?email_address[]=\${E2E_EMAIL}\`)
\`\`\`

Then take \`users[0].id\` from the response, generate a sign-in token for that user, and run the full subscribe → cancel → re-subscribe flow.

**Verified tonight:** Clerk's \`?email_address[]=X\` filter does NOT actually filter — it returned ALL users in the dev instance (2 users, ordered by recency). The most-recent signup was a manual testing account (\`prasiddha@gmail.com\`); the e2e gate signed in as them every deploy and silently created a fresh Stripe customer + Starter sub on their account.

## Fix
Match the email in JS using \`array.find\` on \`email_addresses\`, only returning the user whose email_addresses contains an exact match for \`isol8-e2e-testing@mailsac.com\`. If no match, throw a clear error so a missing e2e user **fails the gate** instead of clobbering the wrong account.

Both spec files patched (journey + smoke).

## Test plan
- [ ] Manually verify in dev Clerk after merge: \`/v1/users?email_address[]=isol8-e2e-testing@mailsac.com\` returns >1 user; the JS filter selects only the e2e user
- [ ] Next deploy's E2E gate logs \`[e2e] Found user: <e2e user id>\` (not the most-recent manual signup)
- [ ] Cleanup: delete the orphan Stripe customer / sub created on the manual account tonight (one-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)