### PR TITLE
fix(gateway): decouple Tauri identity push from WebSocket lifecycle

### DIFF
--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -241,18 +241,13 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
       const token = await getToken();
       if (!token) throw new Error("Not authenticated");
 
-      // Post token to Tauri desktop app for node-host auth
-      if (typeof window !== "undefined" && token) {
-        const tauri = // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (window as any).__TAURI__;
-        if (tauri?.core?.invoke) {
-          tauri.core.invoke("send_auth_token", {
-            token,
-            displayName: user?.fullName || user?.firstName || "User",
-            userId: user?.id || "",
-          }).catch(() => {});
-        }
-      }
+      // NOTE: the Tauri `send_auth_token` IPC used to fire from here too,
+      // but that tied `connect` to `user.*` and tore the WebSocket down
+      // every time Clerk resolved the user on mount — which silently
+      // killed in-flight RPCs (notably agents.list on a returning user).
+      // The desktop-identity push now runs in its own effect below,
+      // keyed on user.id — so identity and token are always fetched
+      // together and the WS lifecycle is decoupled from user changes.
 
       const ws = new WebSocket(`${WS_URL}?token=${token}`);
 
@@ -306,7 +301,7 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to connect");
     }
-  }, [getToken, handleMessage, clearPingInterval, user?.firstName, user?.fullName, user?.id]);
+  }, [getToken, handleMessage, clearPingInterval]);
 
   // Keep ref in sync for stable reconnect closure
   connectRef.current = connect;
@@ -351,6 +346,32 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
     }).then((fn: () => void) => { unlisten = fn; });
     return () => { unlisten?.(); };
   }, []);
+
+  // ---- Tauri desktop: push auth identity when Clerk user changes ----
+  //
+  // Fetches a fresh token alongside the current user so identity and token
+  // always travel together (important if user A signs out and user B signs
+  // in — we can't have stale ref-captured displayName paired with a fresh
+  // token). Decoupled from `connect` above so the WebSocket lifecycle isn't
+  // disturbed every time Clerk resolves.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const tauri = // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).__TAURI__;
+    if (!tauri?.core?.invoke) return;
+    if (!user?.id) return;  // wait for Clerk to resolve before pushing
+
+    let cancelled = false;
+    getToken().then((token) => {
+      if (cancelled || !token) return;
+      tauri.core.invoke("send_auth_token", {
+        token,
+        displayName: user.fullName || user.firstName || "User",
+        userId: user.id,
+      }).catch(() => {});
+    });
+    return () => { cancelled = true; };
+  }, [user?.id, user?.fullName, user?.firstName, getToken]);
 
   // ---- sendReq ----
 


### PR DESCRIPTION
## Summary
The \`connect\` callback in \`useGateway\` had \`user?.firstName | fullName | id\` in its deps array because it called \`tauri.core.invoke(\"send_auth_token\", …)\` with those fields. This tied WebSocket lifecycle to Clerk's user-resolution timing, tearing the WS down every time \`user\` went from \`undefined\` → resolved.

Fix: split the concern. \`connect\` depends only on \`[getToken, handleMessage, clearPingInterval]\`. A separate effect keyed on \`user.*\` pushes identity to Tauri (token fetched fresh inside that effect so identity + token always travel together — no ref-staleness window).

## Why
Verified live on dev tonight: returning user opens /chat, \`agents.list\` fires on the initial WebSocket, Clerk resolves user ~300ms later, auto-connect effect tears down the WS with \`code=1000 "Provider unmounted"\`, the in-flight \`agents.list\` RPC is killed, SWR caches empty, sidebar shows "Select an agent" until hard-refresh. This shipped in PR #279.

## Security
The naive alternative (capture \`user\` in a \`useRef\`) has a subtle race: if user A signs out and user B signs in, the ref can be stale at the moment \`connect\` runs — causing the desktop to receive User A's displayName paired with User B's JWT. The split-effect approach avoids this by fetching token *inside* the user-keyed effect, so identity and token always come from the same render pass.

## Test plan
- [x] Lint clean (0 errors)
- [x] \`tsc --noEmit\` clean
- [ ] Manual: close the /chat tab, reopen → agent should appear quickly (not after a hard-refresh)
- [ ] Desktop app: sign-in still pushes displayName + userId to Tauri on Clerk resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)