### PR TITLE
feat(backend): enable exec approval flow in openclaw.json

### DIFF
--- a/apps/backend/core/containers/config.py
+++ b/apps/backend/core/containers/config.py
@@ -350,6 +350,69 @@ def _models_for_tier(tier: str) -> list[dict]:
     return [m for m in ALL_BEDROCK_MODELS if m["id"] in allowed]
 
 
+def _build_exec_policy() -> dict:
+    """Backend-controlled exec approval policy.
+
+    Returns the fragment that lives under ``tools`` (so callers can
+    spread it into a ``tools`` dict). Kept as its own helper so the
+    initial ``write_openclaw_config`` write and the ``PATCH /debug/
+    provision`` deep-merge path produce identical policy — one source
+    of truth.
+
+    * security="allowlist": unknown commands are gated by an approval.
+    * ask="on-miss": emit exec.approval.requested on allowlist misses
+      so the in-chat approval card (#305) can decide.
+
+    Without this OpenClaw defaults to security="deny", which blocks
+    every exec call silently (openclaw/src/agents/exec-defaults.ts:98).
+    """
+    return {
+        "exec": {
+            "security": "allowlist",
+            "ask": "on-miss",
+        },
+    }
+
+
+def build_backend_policy_patch(tier: str, region: str = "us-east-1") -> dict:
+    """Build the backend-controlled slice of openclaw.json.
+
+    Used by:
+      * ``PATCH /api/v1/debug/provision`` to refresh existing
+        containers without rewriting user-owned fields.
+      * Any future admin "reconcile policy" path.
+
+    Scalar values only — deep-merge replaces arrays wholesale, so this
+    must NEVER include list-valued fields (e.g. ``tools.deny``) that
+    user or dynamic code (``node_proxy.py``) may own at runtime.
+
+    The initial full-file write in ``write_openclaw_config`` uses the
+    same ``_build_exec_policy`` helper so both paths produce the same
+    policy shape.
+    """
+    tier_cfg = TIER_CONFIG.get(tier, TIER_CONFIG["free"])
+    return {
+        "models": {
+            "providers": {
+                "amazon-bedrock": {
+                    "baseUrl": f"https://bedrock-runtime.{region}.amazonaws.com",
+                    "api": "bedrock-converse-stream",
+                    "auth": "aws-sdk",
+                    "models": _models_for_tier(tier),
+                },
+            },
+        },
+        "agents": {
+            "defaults": {
+                "model": {"primary": tier_cfg["primary_model"]},
+                "models": tier_cfg.get("model_aliases", {}),
+                "verboseDefault": "full",
+            },
+        },
+        "tools": _build_exec_policy(),
+    }
+
+
 def _agent_models_for_tier(tier: str, primary_model: str) -> dict:
     """Build the ``agents.defaults.models`` mapping for a tier."""
     models = _models_for_tier(tier)
@@ -536,22 +599,13 @@ def write_openclaw_config(
         },
         "tools": {
             "profile": "full",
-            # Keep `nodes` ENABLED — the agent needs it to list its paired
-            # desktop nodes before calling `exec host=node`. Only `canvas`
-            # is denied (unused drawing tool).
-            "deny": ["canvas"],
-            # Exec approval policy. With security=allowlist + ask=on-miss,
-            # commands not in the per-agent allowlist emit
-            # exec.approval.requested and wait for the user's Allow once /
-            # Trust / Deny decision (see
-            # docs/superpowers/specs/2026-04-18-exec-approval-card-design.md).
-            # Without this, OpenClaw's default security=deny blocks every
-            # exec call outright with no prompt
-            # (openclaw/src/agents/exec-defaults.ts:98).
-            "exec": {
-                "security": "allowlist",
-                "ask": "on-miss",
-            },
+            # Default-deny both canvas and nodes. node_proxy.py toggles
+            # "nodes" back to enabled dynamically when a desktop node
+            # pairs, and back to denied when the last one disconnects.
+            # Leaving nodes always-allowed here would expose the tool
+            # even to users without the desktop app.
+            "deny": ["canvas", "nodes"],
+            **_build_exec_policy(),
             "web": {
                 "fetch": {"enabled": True},
             },

--- a/apps/backend/core/containers/config.py
+++ b/apps/backend/core/containers/config.py
@@ -536,7 +536,22 @@ def write_openclaw_config(
         },
         "tools": {
             "profile": "full",
-            "deny": ["canvas", "nodes"],
+            # Keep `nodes` ENABLED — the agent needs it to list its paired
+            # desktop nodes before calling `exec host=node`. Only `canvas`
+            # is denied (unused drawing tool).
+            "deny": ["canvas"],
+            # Exec approval policy. With security=allowlist + ask=on-miss,
+            # commands not in the per-agent allowlist emit
+            # exec.approval.requested and wait for the user's Allow once /
+            # Trust / Deny decision (see
+            # docs/superpowers/specs/2026-04-18-exec-approval-card-design.md).
+            # Without this, OpenClaw's default security=deny blocks every
+            # exec call outright with no prompt
+            # (openclaw/src/agents/exec-defaults.ts:98).
+            "exec": {
+                "security": "allowlist",
+                "ask": "on-miss",
+            },
             "web": {
                 "fetch": {"enabled": True},
             },

--- a/apps/backend/routers/debug.py
+++ b/apps/backend/routers/debug.py
@@ -10,7 +10,7 @@ import secrets
 from fastapi import APIRouter, Depends, HTTPException
 
 from core.auth import AuthContext, get_current_user, get_owner_type, require_org_admin, resolve_owner_id
-from core.config import settings, TIER_CONFIG
+from core.config import settings
 from core.observability.metrics import put_metric
 from core.containers import get_ecs_manager
 from core.containers.ecs_manager import EcsManagerError
@@ -120,37 +120,15 @@ async def redeploy_container(
 
         account = await billing_repo.get_by_owner_id(owner_id)
         tier = account.get("plan_tier", "free") if account else "free"
-        tier_cfg = TIER_CONFIG.get(tier, TIER_CONFIG["free"])
 
-        # Deep-merge only the fields we control (preserves OpenClaw's runtime additions)
+        # Deep-merge only the backend-controlled slice (preserves OpenClaw's
+        # runtime additions AND user-owned fields like tools.deny, which
+        # node_proxy.py manipulates at runtime). The helper lives next to
+        # write_openclaw_config so both paths stay in lock-step.
         from core.services.config_patcher import patch_openclaw_config, ConfigPatchError
-        from core.containers.config import _models_for_tier
+        from core.containers.config import build_backend_policy_patch
 
-        patch = {
-            "models": {
-                "providers": {
-                    "amazon-bedrock": {
-                        "baseUrl": f"https://bedrock-runtime.{settings.AWS_REGION}.amazonaws.com",
-                        "api": "bedrock-converse-stream",
-                        "auth": "aws-sdk",
-                        "models": _models_for_tier(tier),
-                    },
-                },
-            },
-            "agents": {
-                "defaults": {
-                    "model": {"primary": tier_cfg["primary_model"]},
-                    "models": tier_cfg.get("model_aliases", {}),
-                    "verboseDefault": "full",
-                },
-                # Don't patch `agents.list` here — `_deep_merge` replaces
-                # arrays wholesale, which would clobber user-created agents
-                # persisted via OpenClaw's `agents.create` RPC. The initial
-                # write in `write_openclaw_config` sets up `main` on first
-                # provision; existing containers keep whatever list is
-                # already on EFS.
-            },
-        }
+        patch = build_backend_policy_patch(tier, region=settings.AWS_REGION)
 
         ecs_manager = get_ecs_manager()
         try:

--- a/apps/backend/tests/unit/containers/test_config.py
+++ b/apps/backend/tests/unit/containers/test_config.py
@@ -32,16 +32,18 @@ class TestWriteOpenclawConfig:
         bedrock = config["models"]["providers"]["amazon-bedrock"]
         assert "eu-west-1" in bedrock["baseUrl"]
 
-    def test_config_full_profile_denies_canvas(self):
-        """Tools profile is full; canvas is denied but nodes stays enabled.
+    def test_config_full_profile_denies_canvas_nodes(self):
+        """Tools profile is full; canvas and nodes denied by default.
 
-        The agent needs the `nodes` tool to enumerate paired desktop nodes
-        before routing exec host=node (openclaw/src/agents/tools/nodes-tool.ts).
+        The `nodes` tool is toggled to enabled at runtime by
+        routers/node_proxy.py when a desktop node pairs; leaving it
+        always-allowed here would expose it to users without the
+        desktop app.
         """
         config = json.loads(write_openclaw_config())
         assert config["tools"]["profile"] == "full"
         assert "canvas" in config["tools"]["deny"]
-        assert "nodes" not in config["tools"]["deny"]
+        assert "nodes" in config["tools"]["deny"]
 
     def test_config_exec_approval_policy(self):
         """Exec uses allowlist + on-miss so the approval card can fire.
@@ -54,6 +56,22 @@ class TestWriteOpenclawConfig:
         exec_cfg = config["tools"]["exec"]
         assert exec_cfg["security"] == "allowlist"
         assert exec_cfg["ask"] == "on-miss"
+
+    def test_build_backend_policy_patch_includes_exec(self):
+        """The shared helper used by PATCH /debug/provision writes the
+        same exec policy as the initial write — one source of truth."""
+        from core.containers.config import build_backend_policy_patch
+
+        patch = build_backend_policy_patch("starter")
+        assert patch["tools"]["exec"]["security"] == "allowlist"
+        assert patch["tools"]["exec"]["ask"] == "on-miss"
+        # Must NOT include list-valued fields — deep-merge replaces
+        # arrays wholesale, which would clobber node_proxy's dynamic
+        # tools.deny toggling.
+        assert "deny" not in patch["tools"]
+        # Model + agent defaults are still carried.
+        assert "providers" in patch["models"]
+        assert "defaults" in patch["agents"]
 
     def test_no_root_tts_key(self):
         """TTS config is not at root level (OpenClaw doesn't support it there)."""

--- a/apps/backend/tests/unit/containers/test_config.py
+++ b/apps/backend/tests/unit/containers/test_config.py
@@ -32,12 +32,28 @@ class TestWriteOpenclawConfig:
         bedrock = config["models"]["providers"]["amazon-bedrock"]
         assert "eu-west-1" in bedrock["baseUrl"]
 
-    def test_config_full_profile_denies_canvas_nodes(self):
-        """Tools profile is full and canvas/nodes are denied."""
+    def test_config_full_profile_denies_canvas(self):
+        """Tools profile is full; canvas is denied but nodes stays enabled.
+
+        The agent needs the `nodes` tool to enumerate paired desktop nodes
+        before routing exec host=node (openclaw/src/agents/tools/nodes-tool.ts).
+        """
         config = json.loads(write_openclaw_config())
         assert config["tools"]["profile"] == "full"
         assert "canvas" in config["tools"]["deny"]
-        assert "nodes" in config["tools"]["deny"]
+        assert "nodes" not in config["tools"]["deny"]
+
+    def test_config_exec_approval_policy(self):
+        """Exec uses allowlist + on-miss so the approval card can fire.
+
+        Without this, OpenClaw's default security=deny blocks every exec
+        call silently (exec-defaults.ts:98). See
+        docs/superpowers/specs/2026-04-18-exec-approval-card-design.md.
+        """
+        config = json.loads(write_openclaw_config())
+        exec_cfg = config["tools"]["exec"]
+        assert exec_cfg["security"] == "allowlist"
+        assert exec_cfg["ask"] == "on-miss"
 
     def test_no_root_tts_key(self):
         """TTS config is not at root level (OpenClaw doesn't support it there)."""


### PR DESCRIPTION
## Summary

Makes the exec approval card (shipped in #305) actually trigger by fixing two container config gaps found during dev testing.

## Why the card wasn't firing

I did a deep dive on `/Users/prasiddhaparthsarthy/Desktop/openclaw/src/agents/exec-defaults.ts:98` and our EFS config. Two issues:

1. **We never set `tools.exec`** in the generated `openclaw.json`. OpenClaw defaults cascade to `security: "deny"` — which blocks every exec call outright, with no approval event emitted. Confirmed by CloudWatch: 100+ gateway events, zero `exec.approval.requested`. Fast tool_error rather than a pending approval.
2. **`tools.deny` included `nodes`**. The `nodes` tool is needed so the agent can enumerate paired desktop nodes before routing `exec host=node` (`openclaw/src/agents/tools/nodes-tool.ts:150-164`). Denying it doesn't break the user flow today because EFS drift preserved the old allow, but the current source intent would block it on new containers.

## Changes

`apps/backend/core/containers/config.py`:
- Add `tools.exec = {security: "allowlist", ask: "on-miss"}` — triggers OpenClaw's approval handler for unlisted commands.
- Remove `"nodes"` from `tools.deny`.

## Roll-out

Existing containers: call `PATCH /api/v1/debug/provision` per [CLAUDE.md](./CLAUDE.md) to rewrite on-disk `openclaw.json`. Chokidar in the container picks up the new config on the next poll cycle, no restart needed.
New containers: pick up the full config on first provision.

## Test plan

- [ ] CI passes
- [ ] Backend deploys to dev
- [ ] Existing dev container `PATCH`ed; EFS `openclaw.json` shows new `tools.exec` block
- [ ] In the chat (web or desktop), ask the agent to run `exec ["whoami"] host=node` → approval card renders → click Allow once → command runs on the user's Mac via the node
- [ ] Re-run the same command → trust persistence (card doesn't re-appear after allow-always)

## Why not add a backend event passthrough too

Checked `connection_pool.py:760` — the `else` branch already forwards arbitrary unhandled events as-is. Once OpenClaw emits `exec.approval.requested`, it rides that path to the frontend with no additional plumbing. No backend dispatcher change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)