### PR TITLE
fix(gateway): scale-to-zero spares fresh containers (no last_active_at yet)

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -1094,18 +1094,26 @@ class GatewayConnectionPool:
 
         for row in rows:
             owner_id = row["owner_id"]
-            last_active_str = row.get("last_active_at")
-            if last_active_str:
+            # last_active_at is bumped by record_activity() when traffic flows
+            # through the gateway. A freshly-provisioned container that just
+            # finished its provisioning→running transition has no last_active_at
+            # yet (no chat has happened), so we fall back to updated_at — that's
+            # the moment the row last changed state, including the transition
+            # to running. Final fallback is created_at, then epoch 0.
+            #
+            # Without this fallback chain, the reaper would kill every newly-
+            # provisioned free-tier container ~1 cycle after it became healthy
+            # (before the user ever sent a message), leaving the container
+            # bouncing between provisioning and stopped forever.
+            ts_str = row.get("last_active_at") or row.get("updated_at") or row.get("created_at")
+            last_active_epoch = 0.0
+            if ts_str:
                 try:
                     # Our writer emits `+00:00`, but replace a trailing `Z` so
                     # any external writer (or pre-3.11 Python) parses cleanly.
-                    last_active_epoch = datetime.fromisoformat(last_active_str.replace("Z", "+00:00")).timestamp()
+                    last_active_epoch = datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
                 except Exception:
                     last_active_epoch = 0.0
-            else:
-                # Deploy-day path: pre-change rows have no last_active_at.
-                # Treat as epoch 0 so they're reaped on the first cycle.
-                last_active_epoch = 0.0
 
             if now_ts - last_active_epoch < _IDLE_TIMEOUT:
                 continue

--- a/apps/backend/tests/unit/gateway/test_idle_checker.py
+++ b/apps/backend/tests/unit/gateway/test_idle_checker.py
@@ -140,18 +140,71 @@ async def test_skips_not_yet_idle():
 
 
 @pytest.mark.asyncio
-async def test_reaps_row_with_null_last_active_at():
-    """Deploy-day path: rows from before this change have no last_active_at.
-    They must be treated as very old and reaped on first cycle."""
+async def test_does_not_reap_fresh_running_container_with_no_last_active_at():
+    """A container that just transitioned provisioning→running has no
+    last_active_at yet (no chat traffic has flowed). The reaper must fall
+    back to updated_at (or created_at) and grant the row its full 5-minute
+    grace window from the moment it became running. Otherwise free-tier
+    users get their containers killed seconds after they boot, before they
+    can ever send a message — see investigation 2026-04-19."""
     from core.gateway.connection_pool import GatewayConnectionPool
 
+    # Row entered running state 30 seconds ago — well inside the 5-min window.
+    fresh_ts = _iso(datetime.now(timezone.utc) - timedelta(seconds=30))
     pool = GatewayConnectionPool(management_api=None)
 
     with (
         patch(
             "core.repositories.container_repo.get_by_status",
             new_callable=AsyncMock,
-            return_value=[{"owner_id": "user_stale", "status": "running"}],
+            return_value=[
+                {
+                    "owner_id": "user_fresh",
+                    "status": "running",
+                    "updated_at": fresh_ts,
+                    "created_at": fresh_ts,
+                }
+            ],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"owner_id": "user_fresh", "plan_tier": "free"},
+        ),
+        patch("core.containers.get_ecs_manager") as mock_get_ecs,
+    ):
+        ecs = mock_get_ecs.return_value
+        ecs.stop_user_service = AsyncMock()
+
+        stopped = await pool._reap_once()
+
+        ecs.stop_user_service.assert_not_awaited()
+        assert stopped == []
+
+
+@pytest.mark.asyncio
+async def test_reaps_old_running_container_with_no_last_active_at():
+    """A row that's been running for hours with no recorded activity (e.g.
+    legacy row from before record_activity was implemented, or a container
+    whose record_activity writes have been failing) should still get reaped
+    once its updated_at falls outside the idle window."""
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    pool = GatewayConnectionPool(management_api=None)
+    old_ts = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[
+                {
+                    "owner_id": "user_stale",
+                    "status": "running",
+                    "updated_at": old_ts,
+                    "created_at": old_ts,
+                }
+            ],
         ),
         patch(
             "core.repositories.billing_repo.get_by_owner_id",
@@ -172,6 +225,43 @@ async def test_reaps_row_with_null_last_active_at():
 
         ecs.stop_user_service.assert_awaited_once_with("user_stale")
         assert stopped == ["user_stale"]
+
+
+@pytest.mark.asyncio
+async def test_reaps_row_with_no_timestamps_at_all():
+    """Defense in depth: a row with no last_active_at, no updated_at, and
+    no created_at falls all the way through the chain to epoch 0 and gets
+    reaped. Should never happen in practice (DynamoDB rows always have
+    created_at set by upsert) but the fallback chain shouldn't crash."""
+    from core.gateway.connection_pool import GatewayConnectionPool
+
+    pool = GatewayConnectionPool(management_api=None)
+
+    with (
+        patch(
+            "core.repositories.container_repo.get_by_status",
+            new_callable=AsyncMock,
+            return_value=[{"owner_id": "user_no_ts", "status": "running"}],
+        ),
+        patch(
+            "core.repositories.billing_repo.get_by_owner_id",
+            new_callable=AsyncMock,
+            return_value={"owner_id": "user_no_ts", "plan_tier": "free"},
+        ),
+        patch("core.containers.get_ecs_manager") as mock_get_ecs,
+        patch(
+            "core.repositories.container_repo.mark_stopped_if_running",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        ecs = mock_get_ecs.return_value
+        ecs.stop_user_service = AsyncMock()
+
+        stopped = await pool._reap_once()
+
+        ecs.stop_user_service.assert_awaited_once_with("user_no_ts")
+        assert stopped == ["user_no_ts"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Free-tier containers are killed seconds after they finish provisioning, before the user can ever send a message.
- Locks every fresh free-tier signup into an infinite provision → reap → re-provision loop.
- Caught while debugging the e2e rewrite — the test waited 10+ min for `gateway_healthy` while the backend reaper kept stopping the container ~40s after each transition.

## Root cause
`connection_pool.py:_reap_once` treated rows with no `last_active_at` as last-active-at-epoch-0 (the "deploy-day path" comment, locked in by `test_reaps_row_with_null_last_active_at`). But every freshly-provisioned container also has no `last_active_at` — `record_activity()` only fires when traffic flows through the gateway WebSocket, which only happens after the user sends their first chat. Result: the reaper killed every brand-new free container ~1 idle-check cycle (60s) after the provisioning→running transition.

## Fix
Fall back to `updated_at` (set by the provisioning→running flip), then `created_at`, then 0. Fresh containers now get the full 5-minute idle window starting from when they actually became reachable.

## Verified
- 12/12 unit tests in `test_idle_checker.py` pass
- Replaced obsolete `test_reaps_row_with_null_last_active_at` with three new cases:
  - **fresh**: row entered running 30s ago → NOT reaped
  - **stale**: row stuck running for 1h with no traffic → reaped
  - **no-timestamps**: defensive fallback to epoch 0 → reaped

## Repro on dev
- User `user_3CaiTOOzoEEYLBAdVrCf3Bu89lJ`
- Container row `created_at: 20:21:35`, gateway ready in container at 20:29:14
- Backend log: `scale-to-zero: stopped user_3CaiTOOzoEEYLBAdVrCf3Bu89lJ (tier=free)` at 20:29:53 (39s after gateway ready, no chat traffic)
- Re-provision attempt → killed again at 20:38:51 (10s after second gateway-ready)

## Test plan
- [x] Unit: `uv run pytest tests/unit/gateway/test_idle_checker.py -v` → 12 passed
- [ ] After merge: confirm fresh-user provision path on dev gets past `gateway_healthy` and stays running

🤖 Generated with [Claude Code](https://claude.com/claude-code)