### PR TITLE
feat(desktop): OpenClaw node-host as Tauri sidecar for browser.proxy

### DIFF
--- a/apps/backend/core/containers/config.py
+++ b/apps/backend/core/containers/config.py
@@ -410,9 +410,18 @@ def build_backend_policy_patch(tier: str, region: str = "us-east-1") -> dict:
             },
         },
         "tools": _build_exec_policy(),
+        # Mirror write_openclaw_config's browser block in full — the
+        # upgrade path deep-merges this patch into an existing config,
+        # and omitting `profiles.user.driver` would leave defaultProfile
+        # pointing at an undefined profile.
         "browser": {
             "enabled": True,
             "defaultProfile": "user",
+            "profiles": {
+                "user": {
+                    "driver": "existing-session",
+                },
+            },
         },
         "nodeHost": {
             "browserProxy": {

--- a/apps/backend/core/containers/config.py
+++ b/apps/backend/core/containers/config.py
@@ -410,6 +410,15 @@ def build_backend_policy_patch(tier: str, region: str = "us-east-1") -> dict:
             },
         },
         "tools": _build_exec_policy(),
+        "browser": {
+            "enabled": True,
+            "defaultProfile": "user",
+        },
+        "nodeHost": {
+            "browserProxy": {
+                "enabled": True,
+            },
+        },
     }
 
 
@@ -671,7 +680,28 @@ def write_openclaw_config(
         "web": {
             "enabled": True,
         },
-        "browser": {"enabled": False},
+        "browser": {
+            # Enables OpenClaw's browser tool. Default profile is `user`
+            # which attaches to the user's real signed-in Chrome 144+ via
+            # chrome-devtools-mcp + CDP. No Chromium bundled in the
+            # container image.
+            "enabled": True,
+            "defaultProfile": "user",
+            "profiles": {
+                "user": {
+                    "driver": "existing-session",
+                },
+            },
+        },
+        "nodeHost": {
+            "browserProxy": {
+                # Auto-route browser tool calls to the paired desktop
+                # node. The Isol8 Tauri app runs the sidecar
+                # (openclaw/extensions/browser + chrome-devtools-mcp)
+                # colocated with Chrome on the user's Mac.
+                "enabled": True,
+            },
+        },
         "update": {"checkOnStart": False},
     }
 

--- a/apps/backend/tests/unit/containers/test_config.py
+++ b/apps/backend/tests/unit/containers/test_config.py
@@ -198,10 +198,27 @@ class TestWriteOpenclawConfig:
         main_entry = next(a for a in config["agents"]["list"] if a.get("id") == "main")
         assert main_entry.get("workspace") == "/home/node/.openclaw/workspaces/main"
 
-    def test_browser_disabled(self):
-        """Browser automation is disabled by default."""
+    def test_config_browser_enabled_with_user_profile(self):
+        """Browser tool uses the user profile (attach to real Chrome)."""
         config = json.loads(write_openclaw_config())
-        assert config["browser"]["enabled"] is False
+        browser = config["browser"]
+        assert browser["enabled"] is True
+        assert browser["defaultProfile"] == "user"
+        assert browser["profiles"]["user"]["driver"] == "existing-session"
+
+    def test_config_node_host_browser_proxy_enabled(self):
+        """Gateway auto-routes browser tool calls to the paired node."""
+        config = json.loads(write_openclaw_config())
+        assert config["nodeHost"]["browserProxy"]["enabled"] is True
+
+    def test_build_backend_policy_patch_includes_browser(self):
+        """Refresh path carries the same browser + nodeHost scalars."""
+        from core.containers.config import build_backend_policy_patch
+
+        patch = build_backend_policy_patch("starter")
+        assert patch["browser"]["enabled"] is True
+        assert patch["browser"]["defaultProfile"] == "user"
+        assert patch["nodeHost"]["browserProxy"]["enabled"] is True
 
     def test_update_check_disabled(self):
         """Auto-update check is disabled."""

--- a/apps/backend/tests/unit/containers/test_config.py
+++ b/apps/backend/tests/unit/containers/test_config.py
@@ -212,12 +212,18 @@ class TestWriteOpenclawConfig:
         assert config["nodeHost"]["browserProxy"]["enabled"] is True
 
     def test_build_backend_policy_patch_includes_browser(self):
-        """Refresh path carries the same browser + nodeHost scalars."""
+        """Refresh path carries the full browser block, not just scalars.
+
+        Without `profiles.user.driver`, a deep-merge onto a pre-browser
+        container leaves `defaultProfile = "user"` pointing at an
+        undefined profile.
+        """
         from core.containers.config import build_backend_policy_patch
 
         patch = build_backend_policy_patch("starter")
         assert patch["browser"]["enabled"] is True
         assert patch["browser"]["defaultProfile"] == "user"
+        assert patch["browser"]["profiles"]["user"]["driver"] == "existing-session"
         assert patch["nodeHost"]["browserProxy"]["enabled"] is True
 
     def test_update_check_disabled(self):

--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -1,0 +1,3 @@
+# Sidecar binaries produced by scripts/vendor-sidecars.sh.
+# Regenerated at CI build time; not committed.
+src-tauri/bin/

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -451,6 +451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,8 +1327,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1332,9 +1340,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1631,6 +1641,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1916,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "open",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -1902,6 +1929,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "url",
+ "urlencoding",
  "uuid",
 ]
 
@@ -2122,6 +2150,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3050,6 +3084,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,6 +3346,44 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3287,6 +3414,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3328,10 +3469,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3571,6 +3753,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3865,6 +4059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4016,7 +4216,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4431,6 +4631,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4465,6 +4680,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -4805,6 +5030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4816,6 +5047,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -5053,6 +5290,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5106,6 +5353,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5347,6 +5603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5900,6 +6165,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,6 +21,8 @@ uuid = { version = "1", features = ["v4"] }
 url = "2"
 open = "5.3.3"
 lazy_static = "1.5.0"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+urlencoding = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
+++ b/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
 # Vendor sidecars for the Isol8 desktop browser node.
-# Produces: src-tauri/bin/ containing a Node.js binary, the OpenClaw
-# browser control service, and chrome-devtools-mcp — all referenced
-# from tauri.conf.json's bundle.externalBin array.
+# Produces: src-tauri/bin/ containing a Node.js binary + a pinned
+# install of the `openclaw` npm package, launched via the `openclaw
+# node run` subcommand. The browser plugin ships inside the `openclaw`
+# tarball (dist/extensions/browser/...) and is loaded automatically
+# by node-host mode — no separate plugin install needed.
 #
-# Versions are pinned here. When bumping the OpenClaw container
-# image, also update OPENCLAW_REF to the matching openclaw git SHA.
+# Mirrors OpenClaw's own macOS app pattern: a native host spawns the
+# CLI as a node daemon and hits it over loopback.
 set -euo pipefail
 
-NODE_VERSION="20.18.0"       # LTS; matches chrome-devtools-mcp's engines.node
-OPENCLAW_REF="v2026.4.5"     # must match openclaw-version.json's tag
-CHROME_DEVTOOLS_MCP_VERSION="latest"
+NODE_VERSION="20.18.0"    # LTS; matches openclaw's engines.node
+OPENCLAW_VERSION="2026.4.5"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TAURI_DIR="$(dirname "$SCRIPT_DIR")"
 BIN_DIR="$TAURI_DIR/bin"
 TMP_DIR="$TAURI_DIR/.sidecar-tmp"
 
-# Tauri's externalBin naming convention: <name>-<target-triple>.
-# We build a universal mac binary naming: aarch64-apple-darwin for M1+.
-# Intel Macs: add x86_64-apple-darwin in a follow-up if we still ship to them.
+# Tauri externalBin naming: <name>-<target-triple>. aarch64-apple-darwin
+# covers M1+; add x86_64-apple-darwin in a follow-up if needed.
 TARGET_TRIPLE="aarch64-apple-darwin"
 
 rm -rf "$TMP_DIR"
@@ -34,36 +34,40 @@ tar -xf "$TMP_DIR/$NODE_TARBALL" -C "$TMP_DIR"
 cp "$TMP_DIR/node-v${NODE_VERSION}-darwin-arm64/bin/node" "$BIN_DIR/node-${TARGET_TRIPLE}"
 chmod +x "$BIN_DIR/node-${TARGET_TRIPLE}"
 
-# ---- OpenClaw browser control service ----
-# Clone openclaw at the pinned ref (sparse: only extensions/browser/).
-echo "==> Vendoring openclaw extensions/browser at $OPENCLAW_REF"
-git -C "$TMP_DIR" clone --depth 1 --branch "$OPENCLAW_REF" --no-checkout \
-    https://github.com/openclaw/openclaw.git openclaw-src
+# ---- OpenClaw runtime ----
+# One npm install in a scratch project pulls openclaw + its bundled
+# plugins (including extensions/browser). Postinstall hydrates each
+# plugin's runtime deps into the root node_modules.
+echo "==> Installing openclaw@${OPENCLAW_VERSION}"
+OPENCLAW_DIR="$BIN_DIR/openclaw-host"
+mkdir -p "$OPENCLAW_DIR"
+cat > "$OPENCLAW_DIR/package.json" <<EOF
+{
+  "name": "isol8-openclaw-host",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "openclaw": "${OPENCLAW_VERSION}"
+  }
+}
+EOF
 (
-    cd "$TMP_DIR/openclaw-src"
-    git sparse-checkout init --cone
-    git sparse-checkout set extensions/browser
-    git checkout "$OPENCLAW_REF"
-)
-mkdir -p "$BIN_DIR/openclaw-browser"
-cp -R "$TMP_DIR/openclaw-src/extensions/browser/." "$BIN_DIR/openclaw-browser/"
-
-# Install openclaw browser's own npm deps + add chrome-devtools-mcp.
-(
-    cd "$BIN_DIR/openclaw-browser"
-    npm install --production --no-audit --no-fund
-    npm install --no-save --no-audit --no-fund \
-        "chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION}"
+    cd "$OPENCLAW_DIR"
+    # Use the bundled node for the install to pin the runtime the
+    # package expects at install time.
+    PATH="$BIN_DIR:$PATH" npm install --production --no-audit --no-fund
 )
 
-# Tauri externalBin expects a direct binary, so write a tiny launcher
-# that execs node against the service entry point. This lets us keep
-# the TS code in openclaw-browser/ without restructuring it.
+# Tauri externalBin expects a concrete binary file, so write a tiny
+# launcher that execs our bundled node against the openclaw CLI.
+# Port is pinned to 18789; browser control port derives to 18791.
 cat > "$BIN_DIR/isol8-browser-service-${TARGET_TRIPLE}" <<'LAUNCHER'
 #!/usr/bin/env bash
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "$HERE/node-aarch64-apple-darwin" "$HERE/openclaw-browser/dist/control-service.js" "$@"
+exec "$HERE/node-aarch64-apple-darwin" \
+    "$HERE/openclaw-host/node_modules/openclaw/openclaw.mjs" \
+    node run --host 127.0.0.1 --port 18789 "$@"
 LAUNCHER
 chmod +x "$BIN_DIR/isol8-browser-service-${TARGET_TRIPLE}"
 

--- a/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
+++ b/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Vendor sidecars for the Isol8 desktop browser node.
+# Produces: src-tauri/bin/ containing a Node.js binary, the OpenClaw
+# browser control service, and chrome-devtools-mcp — all referenced
+# from tauri.conf.json's bundle.externalBin array.
+#
+# Versions are pinned here. When bumping the OpenClaw container
+# image, also update OPENCLAW_REF to the matching openclaw git SHA.
+set -euo pipefail
+
+NODE_VERSION="20.18.0"       # LTS; matches chrome-devtools-mcp's engines.node
+OPENCLAW_REF="v2026.4.5"     # must match openclaw-version.json's tag
+CHROME_DEVTOOLS_MCP_VERSION="latest"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TAURI_DIR="$(dirname "$SCRIPT_DIR")"
+BIN_DIR="$TAURI_DIR/bin"
+TMP_DIR="$TAURI_DIR/.sidecar-tmp"
+
+# Tauri's externalBin naming convention: <name>-<target-triple>.
+# We build a universal mac binary naming: aarch64-apple-darwin for M1+.
+# Intel Macs: add x86_64-apple-darwin in a follow-up if we still ship to them.
+TARGET_TRIPLE="aarch64-apple-darwin"
+
+rm -rf "$TMP_DIR"
+mkdir -p "$BIN_DIR" "$TMP_DIR"
+
+# ---- Node.js ----
+NODE_TARBALL="node-v${NODE_VERSION}-darwin-arm64.tar.xz"
+NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TARBALL}"
+echo "==> Downloading $NODE_URL"
+curl -fsSL -o "$TMP_DIR/$NODE_TARBALL" "$NODE_URL"
+tar -xf "$TMP_DIR/$NODE_TARBALL" -C "$TMP_DIR"
+cp "$TMP_DIR/node-v${NODE_VERSION}-darwin-arm64/bin/node" "$BIN_DIR/node-${TARGET_TRIPLE}"
+chmod +x "$BIN_DIR/node-${TARGET_TRIPLE}"
+
+# ---- OpenClaw browser control service ----
+# Clone openclaw at the pinned ref (sparse: only extensions/browser/).
+echo "==> Vendoring openclaw extensions/browser at $OPENCLAW_REF"
+git -C "$TMP_DIR" clone --depth 1 --branch "$OPENCLAW_REF" --no-checkout \
+    https://github.com/openclaw/openclaw.git openclaw-src
+(
+    cd "$TMP_DIR/openclaw-src"
+    git sparse-checkout init --cone
+    git sparse-checkout set extensions/browser
+    git checkout "$OPENCLAW_REF"
+)
+mkdir -p "$BIN_DIR/openclaw-browser"
+cp -R "$TMP_DIR/openclaw-src/extensions/browser/." "$BIN_DIR/openclaw-browser/"
+
+# Install openclaw browser's own npm deps + add chrome-devtools-mcp.
+(
+    cd "$BIN_DIR/openclaw-browser"
+    npm install --production --no-audit --no-fund
+    npm install --no-save --no-audit --no-fund \
+        "chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION}"
+)
+
+# Tauri externalBin expects a direct binary, so write a tiny launcher
+# that execs node against the service entry point. This lets us keep
+# the TS code in openclaw-browser/ without restructuring it.
+cat > "$BIN_DIR/isol8-browser-service-${TARGET_TRIPLE}" <<'LAUNCHER'
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$HERE/node-aarch64-apple-darwin" "$HERE/openclaw-browser/dist/control-service.js" "$@"
+LAUNCHER
+chmod +x "$BIN_DIR/isol8-browser-service-${TARGET_TRIPLE}"
+
+rm -rf "$TMP_DIR"
+echo "==> Sidecars vendored at $BIN_DIR"

--- a/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
+++ b/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
@@ -14,7 +14,9 @@
 # spawns the CLI (`openclaw node run`) and hits it over loopback.
 set -euo pipefail
 
-NODE_VERSION="20.18.0"
+# openclaw@2026.4.x requires Node >=22.14 (see its package.json
+# engines). Node 22 is the current LTS line.
+NODE_VERSION="22.14.0"
 OPENCLAW_VERSION="2026.4.5"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
+++ b/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 # Vendor sidecars for the Isol8 desktop browser node.
-# Produces: src-tauri/bin/ containing a Node.js binary + a pinned
-# install of the `openclaw` npm package, launched via the `openclaw
-# node run` subcommand. The browser plugin ships inside the `openclaw`
-# tarball (dist/extensions/browser/...) and is loaded automatically
-# by node-host mode — no separate plugin install needed.
+# Produces: src-tauri/bin/ containing Node.js binaries AND pinned
+# installs of the `openclaw` npm package for BOTH macOS architectures
+# (aarch64 + x86_64), so universal-apple-darwin bundles resolve a
+# target-triple-specific launcher at runtime.
 #
-# Mirrors OpenClaw's own macOS app pattern: a native host spawns the
-# CLI as a node daemon and hits it over loopback.
+# Per-arch installs are required because openclaw ships many
+# arch-specific native addons via npm optionalDependencies (node-pty,
+# clipboard, sharp, canvas, koffi, sqlite-vec). Sharing one
+# node_modules across architectures misresolves these.
+#
+# Mirrors OpenClaw's own macOS Swift integration: a native host
+# spawns the CLI (`openclaw node run`) and hits it over loopback.
 set -euo pipefail
 
-NODE_VERSION="20.18.0"    # LTS; matches openclaw's engines.node
+NODE_VERSION="20.18.0"
 OPENCLAW_VERSION="2026.4.5"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -18,32 +22,33 @@ TAURI_DIR="$(dirname "$SCRIPT_DIR")"
 BIN_DIR="$TAURI_DIR/bin"
 TMP_DIR="$TAURI_DIR/.sidecar-tmp"
 
-# Tauri externalBin naming: <name>-<target-triple>. aarch64-apple-darwin
-# covers M1+; add x86_64-apple-darwin in a follow-up if needed.
-TARGET_TRIPLE="aarch64-apple-darwin"
-
 rm -rf "$TMP_DIR"
 mkdir -p "$BIN_DIR" "$TMP_DIR"
 
-# ---- Node.js ----
-NODE_TARBALL="node-v${NODE_VERSION}-darwin-arm64.tar.xz"
-NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TARBALL}"
-echo "==> Downloading $NODE_URL"
-curl -fsSL -o "$TMP_DIR/$NODE_TARBALL" "$NODE_URL"
-tar -xf "$TMP_DIR/$NODE_TARBALL" -C "$TMP_DIR"
-cp "$TMP_DIR/node-v${NODE_VERSION}-darwin-arm64/bin/node" "$BIN_DIR/node-${TARGET_TRIPLE}"
-chmod +x "$BIN_DIR/node-${TARGET_TRIPLE}"
+vendor_arch() {
+    local TRIPLE="$1"     # aarch64-apple-darwin | x86_64-apple-darwin
+    local NODE_ARCH="$2"  # arm64 | x64
+    local NPM_CPU="$3"    # arm64 | x64
 
-# ---- OpenClaw runtime ----
-# One npm install in a scratch project pulls openclaw + its bundled
-# plugins (including extensions/browser). Postinstall hydrates each
-# plugin's runtime deps into the root node_modules.
-echo "==> Installing openclaw@${OPENCLAW_VERSION}"
-OPENCLAW_DIR="$BIN_DIR/openclaw-host"
-mkdir -p "$OPENCLAW_DIR"
-cat > "$OPENCLAW_DIR/package.json" <<EOF
+    echo "==> Vendoring $TRIPLE (node-$NODE_ARCH, npm --cpu=$NPM_CPU)"
+
+    # Node.js for this arch.
+    local NODE_TARBALL="node-v${NODE_VERSION}-darwin-${NODE_ARCH}.tar.xz"
+    local NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TARBALL}"
+    curl -fsSL -o "$TMP_DIR/$NODE_TARBALL" "$NODE_URL"
+    tar -xf "$TMP_DIR/$NODE_TARBALL" -C "$TMP_DIR"
+    cp "$TMP_DIR/node-v${NODE_VERSION}-darwin-${NODE_ARCH}/bin/node" \
+       "$BIN_DIR/node-${TRIPLE}"
+    chmod +x "$BIN_DIR/node-${TRIPLE}"
+
+    # Arch-specific openclaw install. --cpu/--os/--libc force npm to
+    # resolve optional deps for the target arch, regardless of the
+    # host the vendor script runs on.
+    local HOST_DIR="$BIN_DIR/openclaw-host-${TRIPLE}"
+    mkdir -p "$HOST_DIR"
+    cat > "$HOST_DIR/package.json" <<EOF
 {
-  "name": "isol8-openclaw-host",
+  "name": "isol8-openclaw-host-${TRIPLE}",
   "private": true,
   "version": "0.0.0",
   "dependencies": {
@@ -51,25 +56,35 @@ cat > "$OPENCLAW_DIR/package.json" <<EOF
   }
 }
 EOF
-(
-    cd "$OPENCLAW_DIR"
-    # Use the bundled node for the install to pin the runtime the
-    # package expects at install time.
-    PATH="$BIN_DIR:$PATH" npm install --production --no-audit --no-fund
-)
+    (
+        cd "$HOST_DIR"
+        # Use the arch-matching node for the install pass. npm uses
+        # its own runtime's arch for platform-dep resolution unless
+        # overridden, so set explicitly.
+        PATH="$BIN_DIR:$PATH" \
+        npm install \
+            --production \
+            --no-audit \
+            --no-fund \
+            --cpu="${NPM_CPU}" \
+            --os=darwin
+    )
 
-# Tauri externalBin expects a concrete binary file, so write a tiny
-# launcher that execs our bundled node against the openclaw CLI.
-# Port is pinned to 18789; browser control port derives to 18791.
-cat > "$BIN_DIR/isol8-browser-service-${TARGET_TRIPLE}" <<'LAUNCHER'
+    # Tauri externalBin expects a concrete file per target triple.
+    cat > "$BIN_DIR/isol8-browser-service-${TRIPLE}" <<LAUNCHER
 #!/usr/bin/env bash
 set -euo pipefail
-HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "$HERE/node-aarch64-apple-darwin" \
-    "$HERE/openclaw-host/node_modules/openclaw/openclaw.mjs" \
-    node run --host 127.0.0.1 --port 18789 "$@"
+HERE="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+exec "\$HERE/node-${TRIPLE}" \\
+    "\$HERE/openclaw-host-${TRIPLE}/node_modules/openclaw/openclaw.mjs" \\
+    node run --host 127.0.0.1 --port 18789 "\$@"
 LAUNCHER
-chmod +x "$BIN_DIR/isol8-browser-service-${TARGET_TRIPLE}"
+    chmod +x "$BIN_DIR/isol8-browser-service-${TRIPLE}"
+}
+
+vendor_arch "aarch64-apple-darwin" "arm64" "arm64"
+vendor_arch "x86_64-apple-darwin"  "x64"   "x64"
 
 rm -rf "$TMP_DIR"
 echo "==> Sidecars vendored at $BIN_DIR"
+ls -1 "$BIN_DIR"

--- a/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
+++ b/apps/desktop/src-tauri/scripts/vendor-sidecars.sh
@@ -73,12 +73,24 @@ EOF
     )
 
     # Tauri externalBin expects a concrete file per target triple.
+    # The shim must locate node + openclaw-host at runtime in two
+    # different layouts:
+    #   dev:   target/debug/<shim> + sibling node-<triple> and openclaw-host-<triple>
+    #   prod:  Isol8.app/Contents/MacOS/<shim>; node-<triple> and
+    #          openclaw-host-<triple> live in ../Resources/ (they're
+    #          declared in tauri.conf.json's `resources`, which macOS
+    #          places under Contents/Resources).
     cat > "$BIN_DIR/isol8-browser-service-${TRIPLE}" <<LAUNCHER
 #!/usr/bin/env bash
 set -euo pipefail
 HERE="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
-exec "\$HERE/node-${TRIPLE}" \\
-    "\$HERE/openclaw-host-${TRIPLE}/node_modules/openclaw/openclaw.mjs" \\
+if [ -f "\$HERE/../Resources/node-${TRIPLE}" ]; then
+    ASSETS="\$HERE/../Resources"
+else
+    ASSETS="\$HERE"
+fi
+exec "\$ASSETS/node-${TRIPLE}" \\
+    "\$ASSETS/openclaw-host-${TRIPLE}/node_modules/openclaw/openclaw.mjs" \\
     node run --host 127.0.0.1 --port 18789 "\$@"
 LAUNCHER
     chmod +x "$BIN_DIR/isol8-browser-service-${TRIPLE}"

--- a/apps/desktop/src-tauri/src/browser_sidecar.rs
+++ b/apps/desktop/src-tauri/src/browser_sidecar.rs
@@ -1,0 +1,73 @@
+//! Subprocess supervisor for the Node.js-based browser control service
+//! (openclaw/extensions/browser/ + chrome-devtools-mcp). Spawned on
+//! demand when the first browser.proxy RPC arrives; stays alive until
+//! the app exits or the subprocess dies (in which case the next
+//! browser.proxy call respawns it).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+#[derive(Debug)]
+pub enum SidecarState {
+    Stopped,
+    Running { pid: Option<u32>, port: u16 },
+}
+
+pub struct BrowserSidecar {
+    binary: PathBuf,
+    args: Vec<String>,
+    child: Arc<Mutex<Option<Child>>>,
+    port: Arc<Mutex<u16>>,
+}
+
+impl BrowserSidecar {
+    /// Constructor for tests — lets us swap the binary path without
+    /// forcing the real sidecar to be built.
+    pub fn new_for_test(binary: PathBuf, args: Vec<String>) -> Self {
+        Self {
+            binary,
+            args,
+            child: Arc::new(Mutex::new(None)),
+            port: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub async fn start(&self) -> Result<(), String> {
+        let mut guard = self.child.lock().await;
+        if guard.is_some() {
+            return Ok(()); // already running
+        }
+        let child = Command::new(&self.binary)
+            .args(&self.args)
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| format!("spawn failed: {}", e))?;
+        *guard = Some(child);
+        // Placeholder: real impl (Task 6) will parse stdout for "listening
+        // on port N" and populate self.port. Tests pass with 0 for now.
+        Ok(())
+    }
+
+    pub async fn stop(&self) {
+        let mut guard = self.child.lock().await;
+        if let Some(mut c) = guard.take() {
+            let _ = c.kill().await;
+        }
+    }
+
+    pub fn state(&self) -> SidecarState {
+        let child_present = self
+            .child
+            .try_lock()
+            .map(|g| g.is_some())
+            .unwrap_or(false);
+        if child_present {
+            let port = self.port.try_lock().map(|g| *g).unwrap_or(0);
+            SidecarState::Running { pid: None, port }
+        } else {
+            SidecarState::Stopped
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/browser_sidecar.rs
+++ b/apps/desktop/src-tauri/src/browser_sidecar.rs
@@ -124,6 +124,34 @@ fn parse_listening_port(line: &str) -> Option<u16> {
     rest[..end].parse().ok()
 }
 
+impl BrowserSidecar {
+    /// Production constructor: resolves the bundled sidecar binary
+    /// path from Tauri's resource dir. Call from a Tauri context
+    /// where AppHandle is available.
+    pub fn for_app(app: &tauri::AppHandle) -> Result<Self, String> {
+        use tauri::Manager;
+        let sidecar = app
+            .path()
+            .resolve(
+                "isol8-browser-service",
+                tauri::path::BaseDirectory::Resource,
+            )
+            .map_err(|e| format!("resolve sidecar path: {}", e))?;
+        Ok(Self {
+            binary: sidecar,
+            args: vec![],
+            child: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+            port: std::sync::Arc::new(tokio::sync::Mutex::new(0)),
+        })
+    }
+}
+
+/// Shared-state handle passed through Tauri's `.manage()`. The inner
+/// Option is None until the first browser.proxy invoke spawns the
+/// sidecar.
+pub type BrowserSidecarHandle =
+    std::sync::Arc<tokio::sync::RwLock<Option<BrowserSidecar>>>;
+
 #[cfg(test)]
 mod tests {
     use super::parse_listening_port;

--- a/apps/desktop/src-tauri/src/browser_sidecar.rs
+++ b/apps/desktop/src-tauri/src/browser_sidecar.rs
@@ -5,7 +5,9 @@
 //! browser.proxy call respawns it).
 
 use std::path::PathBuf;
+use std::process::Stdio;
 use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
@@ -23,8 +25,6 @@ pub struct BrowserSidecar {
 }
 
 impl BrowserSidecar {
-    /// Constructor for tests — lets us swap the binary path without
-    /// forcing the real sidecar to be built.
     pub fn new_for_test(binary: PathBuf, args: Vec<String>) -> Self {
         Self {
             binary,
@@ -37,16 +37,45 @@ impl BrowserSidecar {
     pub async fn start(&self) -> Result<(), String> {
         let mut guard = self.child.lock().await;
         if guard.is_some() {
-            return Ok(()); // already running
+            return Ok(());
         }
-        let child = Command::new(&self.binary)
+        let mut child = Command::new(&self.binary)
             .args(&self.args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
             .map_err(|e| format!("spawn failed: {}", e))?;
+
+        // Pipe stdout: parse for "listening on 127.0.0.1:<port>" and
+        // forward every line to the file logger.
+        if let Some(out) = child.stdout.take() {
+            let port_slot = self.port.clone();
+            tokio::spawn(async move {
+                let reader = BufReader::new(out);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    crate::log(&format!("[browser-sidecar] {}", line));
+                    if let Some(port) = parse_listening_port(&line) {
+                        if let Ok(mut slot) = port_slot.try_lock() {
+                            *slot = port;
+                        }
+                    }
+                }
+            });
+        }
+        // Pipe stderr: forward to log with a prefix.
+        if let Some(err) = child.stderr.take() {
+            tokio::spawn(async move {
+                let reader = BufReader::new(err);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    crate::log(&format!("[browser-sidecar err] {}", line));
+                }
+            });
+        }
+
         *guard = Some(child);
-        // Placeholder: real impl (Task 6) will parse stdout for "listening
-        // on port N" and populate self.port. Tests pass with 0 for now.
         Ok(())
     }
 
@@ -54,6 +83,9 @@ impl BrowserSidecar {
         let mut guard = self.child.lock().await;
         if let Some(mut c) = guard.take() {
             let _ = c.kill().await;
+        }
+        if let Ok(mut slot) = self.port.try_lock() {
+            *slot = 0;
         }
     }
 
@@ -69,5 +101,48 @@ impl BrowserSidecar {
         } else {
             SidecarState::Stopped
         }
+    }
+
+    pub async fn port(&self) -> Option<u16> {
+        let p = *self.port.lock().await;
+        if p == 0 {
+            None
+        } else {
+            Some(p)
+        }
+    }
+}
+
+/// Parse "listening on 127.0.0.1:PORT" style lines. Accepts both
+/// "listening on 127.0.0.1:54321" and "…http://127.0.0.1:54321/…"
+/// so minor log-format drift in the upstream service doesn't break us.
+fn parse_listening_port(line: &str) -> Option<u16> {
+    let needle = "127.0.0.1:";
+    let idx = line.find(needle)?;
+    let rest = &line[idx + needle.len()..];
+    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    rest[..end].parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_listening_port;
+
+    #[test]
+    fn parses_plain_form() {
+        assert_eq!(parse_listening_port("listening on 127.0.0.1:54321"), Some(54321));
+    }
+
+    #[test]
+    fn parses_url_form() {
+        assert_eq!(
+            parse_listening_port("[info] http://127.0.0.1:18791/ ready"),
+            Some(18791)
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_lines() {
+        assert_eq!(parse_listening_port("starting chrome-devtools-mcp"), None);
     }
 }

--- a/apps/desktop/src-tauri/src/browser_sidecar.rs
+++ b/apps/desktop/src-tauri/src/browser_sidecar.rs
@@ -1,8 +1,9 @@
-//! Subprocess supervisor for the Node.js-based browser control service
-//! (openclaw/extensions/browser/ + chrome-devtools-mcp). Spawned on
-//! demand when the first browser.proxy RPC arrives; stays alive until
-//! the app exits or the subprocess dies (in which case the next
-//! browser.proxy call respawns it).
+//! Subprocess supervisor for the OpenClaw node-host running on the
+//! user's Mac. The launcher at bin/isol8-browser-service-<triple>
+//! invokes `node openclaw.mjs node run --port 18789`, which serves
+//! the browser control HTTP API on 18789+2 = 18791 (per
+//! src/config/port-defaults.ts:deriveDefaultBrowserControlPort in
+//! openclaw@v2026.4.5). Port is deterministic so we don't parse stdout.
 
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -11,17 +12,19 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-#[derive(Debug)]
-pub enum SidecarState {
-    Stopped,
-    Running { pid: Option<u32>, port: u16 },
-}
+/// Gateway port we pass to `openclaw node run --port`. Must match
+/// what the launcher shim in scripts/vendor-sidecars.sh sets.
+pub const GATEWAY_PORT: u16 = 18789;
+
+/// Browser control HTTP port. OpenClaw derives this as
+/// `gatewayPort + 2` in src/config/port-defaults.ts. Pinning the
+/// gateway port pins this.
+pub const BROWSER_CONTROL_PORT: u16 = GATEWAY_PORT + 2;
 
 pub struct BrowserSidecar {
     binary: PathBuf,
     args: Vec<String>,
     child: Arc<Mutex<Option<Child>>>,
-    port: Arc<Mutex<u16>>,
 }
 
 impl BrowserSidecar {
@@ -30,7 +33,6 @@ impl BrowserSidecar {
             binary,
             args,
             child: Arc::new(Mutex::new(None)),
-            port: Arc::new(Mutex::new(0)),
         }
     }
 
@@ -47,24 +49,15 @@ impl BrowserSidecar {
             .spawn()
             .map_err(|e| format!("spawn failed: {}", e))?;
 
-        // Pipe stdout: parse for "listening on 127.0.0.1:<port>" and
-        // forward every line to the file logger.
         if let Some(out) = child.stdout.take() {
-            let port_slot = self.port.clone();
             tokio::spawn(async move {
                 let reader = BufReader::new(out);
                 let mut lines = reader.lines();
                 while let Ok(Some(line)) = lines.next_line().await {
                     crate::log(&format!("[browser-sidecar] {}", line));
-                    if let Some(port) = parse_listening_port(&line) {
-                        if let Ok(mut slot) = port_slot.try_lock() {
-                            *slot = port;
-                        }
-                    }
                 }
             });
         }
-        // Pipe stderr: forward to log with a prefix.
         if let Some(err) = child.stderr.take() {
             tokio::spawn(async move {
                 let reader = BufReader::new(err);
@@ -79,55 +72,14 @@ impl BrowserSidecar {
         Ok(())
     }
 
-    pub async fn stop(&self) {
-        let mut guard = self.child.lock().await;
-        if let Some(mut c) = guard.take() {
-            let _ = c.kill().await;
-        }
-        if let Ok(mut slot) = self.port.try_lock() {
-            *slot = 0;
-        }
+    pub fn port(&self) -> u16 {
+        BROWSER_CONTROL_PORT
     }
-
-    pub fn state(&self) -> SidecarState {
-        let child_present = self
-            .child
-            .try_lock()
-            .map(|g| g.is_some())
-            .unwrap_or(false);
-        if child_present {
-            let port = self.port.try_lock().map(|g| *g).unwrap_or(0);
-            SidecarState::Running { pid: None, port }
-        } else {
-            SidecarState::Stopped
-        }
-    }
-
-    pub async fn port(&self) -> Option<u16> {
-        let p = *self.port.lock().await;
-        if p == 0 {
-            None
-        } else {
-            Some(p)
-        }
-    }
-}
-
-/// Parse "listening on 127.0.0.1:PORT" style lines. Accepts both
-/// "listening on 127.0.0.1:54321" and "…http://127.0.0.1:54321/…"
-/// so minor log-format drift in the upstream service doesn't break us.
-fn parse_listening_port(line: &str) -> Option<u16> {
-    let needle = "127.0.0.1:";
-    let idx = line.find(needle)?;
-    let rest = &line[idx + needle.len()..];
-    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
-    rest[..end].parse().ok()
 }
 
 impl BrowserSidecar {
     /// Production constructor: resolves the bundled sidecar binary
-    /// path from Tauri's resource dir. Call from a Tauri context
-    /// where AppHandle is available.
+    /// path from Tauri's resource dir.
     pub fn for_app(app: &tauri::AppHandle) -> Result<Self, String> {
         use tauri::Manager;
         let sidecar = app
@@ -141,7 +93,6 @@ impl BrowserSidecar {
             binary: sidecar,
             args: vec![],
             child: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
-            port: std::sync::Arc::new(tokio::sync::Mutex::new(0)),
         })
     }
 }
@@ -154,23 +105,10 @@ pub type BrowserSidecarHandle =
 
 #[cfg(test)]
 mod tests {
-    use super::parse_listening_port;
+    use super::*;
 
     #[test]
-    fn parses_plain_form() {
-        assert_eq!(parse_listening_port("listening on 127.0.0.1:54321"), Some(54321));
-    }
-
-    #[test]
-    fn parses_url_form() {
-        assert_eq!(
-            parse_listening_port("[info] http://127.0.0.1:18791/ ready"),
-            Some(18791)
-        );
-    }
-
-    #[test]
-    fn ignores_unrelated_lines() {
-        assert_eq!(parse_listening_port("starting chrome-devtools-mcp"), None);
+    fn browser_port_derives_from_gateway() {
+        assert_eq!(BROWSER_CONTROL_PORT, GATEWAY_PORT + 2);
     }
 }

--- a/apps/desktop/src-tauri/src/browser_sidecar.rs
+++ b/apps/desktop/src-tauri/src/browser_sidecar.rs
@@ -95,22 +95,44 @@ impl BrowserSidecar {
 }
 
 impl BrowserSidecar {
-    /// Production constructor: resolves the bundled sidecar binary
-    /// path from Tauri's resource dir.
-    pub fn for_app(app: &tauri::AppHandle) -> Result<Self, String> {
-        use tauri::Manager;
-        let sidecar = app
-            .path()
-            .resolve(
-                "isol8-browser-service",
-                tauri::path::BaseDirectory::Resource,
-            )
-            .map_err(|e| format!("resolve sidecar path: {}", e))?;
+    /// Production constructor: resolves the externalBin sidecar path.
+    /// Tauri places externalBin binaries next to the main executable
+    /// (not in Resources/) with a `-<target-triple>` suffix — mirror
+    /// that resolution here. Works for both dev (`target/debug/`) and
+    /// packaged builds (`Isol8.app/Contents/MacOS/`).
+    pub fn for_app(_app: &tauri::AppHandle) -> Result<Self, String> {
+        let exe = std::env::current_exe()
+            .map_err(|e| format!("current_exe: {}", e))?;
+        let parent = exe
+            .parent()
+            .ok_or_else(|| "current_exe has no parent".to_string())?;
+        let triple = current_sidecar_triple()?;
+        let binary = parent.join(format!("isol8-browser-service-{}", triple));
+        if !binary.exists() {
+            return Err(format!(
+                "sidecar binary not found at {} (arch={})",
+                binary.display(),
+                std::env::consts::ARCH,
+            ));
+        }
         Ok(Self {
-            binary: sidecar,
+            binary,
             args: vec![],
             child: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
         })
+    }
+}
+
+/// Pick the externalBin target-triple suffix matching the slice of
+/// the (potentially universal) binary we are executing under. On
+/// universal-apple-darwin, `std::env::consts::ARCH` reflects the
+/// slice selected by the loader at launch time, so Intel Macs pick
+/// the x86_64 sidecar and Apple Silicon picks the aarch64 one.
+fn current_sidecar_triple() -> Result<String, String> {
+    match std::env::consts::ARCH {
+        "aarch64" => Ok("aarch64-apple-darwin".into()),
+        "x86_64" => Ok("x86_64-apple-darwin".into()),
+        other => Err(format!("unsupported sidecar arch: {}", other)),
     }
 }
 

--- a/apps/desktop/src-tauri/src/browser_sidecar.rs
+++ b/apps/desktop/src-tauri/src/browser_sidecar.rs
@@ -38,8 +38,25 @@ impl BrowserSidecar {
 
     pub async fn start(&self) -> Result<(), String> {
         let mut guard = self.child.lock().await;
-        if guard.is_some() {
-            return Ok(());
+        // A stored Child is not proof of life — a crashed subprocess
+        // leaves the handle `Some` even though the process is gone.
+        // Probe try_wait() and clear the slot so the next block respawns.
+        if let Some(existing) = guard.as_mut() {
+            match existing.try_wait() {
+                Ok(None) => return Ok(()), // still running
+                Ok(Some(status)) => {
+                    crate::log(&format!(
+                        "[browser-sidecar] previous child exited ({status}); respawning"
+                    ));
+                    *guard = None;
+                }
+                Err(e) => {
+                    crate::log(&format!(
+                        "[browser-sidecar] try_wait failed ({e}); respawning"
+                    ));
+                    *guard = None;
+                }
+            }
         }
         let mut child = Command::new(&self.binary)
             .args(&self.args)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod browser_sidecar;
 mod exec_approvals;
 mod node_client;
 mod node_invoke;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -110,10 +110,11 @@ async fn start_node_host(
     let mut invoke_rx = client.start().await?;
     log("[node] Node client started, listening for invoke requests");
 
+    let app_for_invoke = app.clone();
     tokio::spawn(async move {
         while let Some(request) = invoke_rx.recv().await {
             log(&format!("[node] Invoke: {} ({})", request.command, request.id));
-            node_invoke::handle_invoke(&client, request).await;
+            node_invoke::handle_invoke(&client, app_for_invoke.clone(), request).await;
         }
         log("[node] Invoke receiver closed");
     });
@@ -313,6 +314,9 @@ end tell"#,
         .manage(NodeState {
             status: Mutex::new("disconnected".into()),
         })
+        .manage::<browser_sidecar::BrowserSidecarHandle>(
+            std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        )
         .invoke_handler(tauri::generate_handler![
             send_auth_token,
             is_desktop,

--- a/apps/desktop/src-tauri/src/node_client.rs
+++ b/apps/desktop/src-tauri/src/node_client.rs
@@ -367,6 +367,7 @@ where
                 "device.status",
                 "device.health",
                 "device.permissions",
+                "browser.proxy",
             ],
             "pathEnv": std::env::var("PATH").unwrap_or_default(),
             "auth": {},

--- a/apps/desktop/src-tauri/src/node_invoke.rs
+++ b/apps/desktop/src-tauri/src/node_invoke.rs
@@ -819,7 +819,10 @@ async fn handle_browser_proxy(
     let method = params.method.unwrap_or_else(|| "GET".into());
     let path = params.path.unwrap_or_else(|| "/".into());
 
-    // Lazily start the sidecar on first call. Later calls reuse it.
+    // Ensure the sidecar handle is initialized, then ensure the
+    // subprocess is running. Call start() on every invoke because it's
+    // idempotent and respawns a dead child via try_wait() probe — so
+    // a sidecar that crashed between invokes gets revived here.
     let handle = app.state::<crate::browser_sidecar::BrowserSidecarHandle>();
     {
         let guard = handle.read().await;
@@ -829,16 +832,26 @@ async fn handle_browser_proxy(
             if w.is_none() {
                 let sc = crate::browser_sidecar::BrowserSidecar::for_app(&app)
                     .map_err(|e| format!("sidecar init: {}", e))?;
-                sc.start().await.map_err(|e| format!("sidecar start: {}", e))?;
                 *w = Some(sc);
             }
         }
     }
+    {
+        let guard = handle.read().await;
+        if let Some(sc) = guard.as_ref() {
+            sc.start().await.map_err(|e| format!("sidecar start: {}", e))?;
+        }
+    }
 
-    // Port is deterministic — OpenClaw binds browser control on
-    // gatewayPort+2, and the launcher pins gatewayPort to 18789.
-    // The reqwest client's connect timeout handles the case where
-    // the sidecar is still coming up on first invocation.
+    // Port is deterministic (gatewayPort+2 = 18791), but the child
+    // takes a moment to bind after spawn — cold start on M-series is
+    // ~1-2s. Wait until the port accepts a TCP connection before
+    // issuing the first HTTP request, otherwise the caller sees a
+    // confusing connection-refused mid-race.
+    wait_for_control_port(crate::browser_sidecar::BROWSER_CONTROL_PORT)
+        .await
+        .map_err(|e| format!("sidecar readiness: {}", e))?;
+
     let url = build_proxy_url(
         crate::browser_sidecar::BROWSER_CONTROL_PORT,
         &path,
@@ -883,6 +896,27 @@ async fn handle_browser_proxy(
         payload_json: Some(payload.to_string()),
         error: None,
     })
+}
+
+/// Poll-connect to `127.0.0.1:port` until it accepts or a 10s
+/// deadline elapses. Returns Ok as soon as one connection succeeds.
+/// Used before the first HTTP request so cold-start races don't
+/// surface to the agent as connection-refused.
+async fn wait_for_control_port(port: u16) -> Result<(), String> {
+    use tokio::net::TcpStream;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "control port {} did not accept within 10s",
+                port
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
 }
 
 fn build_proxy_url(port: u16, path: &str, query: Option<&serde_json::Value>) -> String {

--- a/apps/desktop/src-tauri/src/node_invoke.rs
+++ b/apps/desktop/src-tauri/src/node_invoke.rs
@@ -78,7 +78,11 @@ const NOT_IMPLEMENTED_COMMANDS: &[&str] = &[
 ];
 
 /// Dispatch a node.invoke.request to the appropriate handler.
-pub async fn handle_invoke(client: &NodeClient, request: NodeInvokeRequest) {
+pub async fn handle_invoke(
+    client: &NodeClient,
+    app: tauri::AppHandle,
+    request: NodeInvokeRequest,
+) {
     let id = request.id.clone();
     let node_id = request.node_id.clone();
     let command = request.command.clone();
@@ -106,6 +110,7 @@ pub async fn handle_invoke(client: &NodeClient, request: NodeInvokeRequest) {
             payload_json: Some(r#"{"ok":true}"#.into()),
             error: None,
         }),
+        "browser.proxy" => handle_browser_proxy(&request, app.clone()).await,
         cmd if NOT_IMPLEMENTED_COMMANDS.contains(&cmd) => Ok(NodeInvokeResult {
             id,
             node_id,
@@ -778,6 +783,152 @@ fn ok_payload(request: &NodeInvokeRequest, payload: serde_json::Value) -> NodeIn
         payload_json: Some(payload.to_string()),
         error: None,
     }
+}
+
+// ---- browser.proxy ----
+
+#[derive(serde::Deserialize, Debug)]
+struct BrowserProxyParams {
+    // HTTP method (GET/POST/...) the agent's browser tool wants to
+    // invoke against the control service. See
+    // apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift:81-86
+    // for the canonical shape.
+    method: Option<String>,
+    path: Option<String>,
+    #[serde(default)]
+    query: Option<serde_json::Value>,
+    #[serde(default)]
+    body: Option<serde_json::Value>,
+    #[serde(default)]
+    auth: Option<BrowserProxyAuth>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct BrowserProxyAuth {
+    token: Option<String>,
+    password: Option<String>,
+}
+
+async fn handle_browser_proxy(
+    request: &NodeInvokeRequest,
+    app: tauri::AppHandle,
+) -> Result<NodeInvokeResult, Box<dyn std::error::Error + Send + Sync>> {
+    use tauri::Manager;
+
+    let params: BrowserProxyParams = parse_params(&request.params_json)?;
+    let method = params.method.unwrap_or_else(|| "GET".into());
+    let path = params.path.unwrap_or_else(|| "/".into());
+
+    // Lazily start the sidecar on first call. Later calls reuse it.
+    let handle = app.state::<crate::browser_sidecar::BrowserSidecarHandle>();
+    {
+        let guard = handle.read().await;
+        if guard.is_none() {
+            drop(guard);
+            let mut w = handle.write().await;
+            if w.is_none() {
+                let sc = crate::browser_sidecar::BrowserSidecar::for_app(&app)
+                    .map_err(|e| format!("sidecar init: {}", e))?;
+                sc.start().await.map_err(|e| format!("sidecar start: {}", e))?;
+                *w = Some(sc);
+            }
+        }
+    }
+
+    // Poll briefly for the port to appear. The sidecar prints its
+    // listening line within ~1s of start; bail with a helpful error
+    // if it takes longer than 10s.
+    let port = {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let guard = handle.read().await;
+            if let Some(sc) = guard.as_ref() {
+                if let Some(p) = sc.port().await {
+                    break p;
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Ok(error_result(
+                    request,
+                    "SIDECAR_STARTUP_TIMEOUT",
+                    "browser sidecar did not report a listening port within 10s",
+                ));
+            }
+            drop(guard);
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    };
+
+    // Build the outbound HTTP request. Query string is URL-encoded
+    // from the JSON map (flat string->string assumed, mirroring
+    // MacNodeBrowserProxy.swift's shape).
+    let url = build_proxy_url(port, &path, params.query.as_ref());
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("http client: {}", e))?;
+    let mut req = client.request(
+        method.parse().map_err(|e| format!("bad method {}: {}", method, e))?,
+        &url,
+    );
+    if let Some(auth) = params.auth {
+        if let Some(token) = auth.token {
+            req = req.bearer_auth(token);
+        } else if let Some(password) = auth.password {
+            req = req.basic_auth("", Some(password));
+        }
+    }
+    if let Some(body) = params.body {
+        req = req.json(&body);
+    }
+    let resp = req.send().await.map_err(|e| format!("http: {}", e))?;
+    let status = resp.status().as_u16();
+    let bytes = resp.bytes().await.map_err(|e| format!("body read: {}", e))?;
+
+    // Response is JSON most of the time; if it's not, wrap in a
+    // text envelope so the client can still read it.
+    let body: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(_) => serde_json::Value::String(String::from_utf8_lossy(&bytes).into_owned()),
+    };
+    let payload = serde_json::json!({
+        "status": status,
+        "body": body,
+    });
+    Ok(NodeInvokeResult {
+        id: request.id.clone(),
+        node_id: request.node_id.clone(),
+        ok: true,
+        payload_json: Some(payload.to_string()),
+        error: None,
+    })
+}
+
+fn build_proxy_url(port: u16, path: &str, query: Option<&serde_json::Value>) -> String {
+    let mut url = format!("http://127.0.0.1:{}{}", port, path);
+    if let Some(serde_json::Value::Object(map)) = query {
+        let pairs: Vec<String> = map
+            .iter()
+            .filter_map(|(k, v)| match v {
+                serde_json::Value::String(s) => Some(format!(
+                    "{}={}",
+                    urlencoding::encode(k),
+                    urlencoding::encode(s)
+                )),
+                serde_json::Value::Number(n) => Some(format!(
+                    "{}={}",
+                    urlencoding::encode(k),
+                    n
+                )),
+                _ => None,
+            })
+            .collect();
+        if !pairs.is_empty() {
+            url.push('?');
+            url.push_str(&pairs.join("&"));
+        }
+    }
+    url
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/node_invoke.rs
+++ b/apps/desktop/src-tauri/src/node_invoke.rs
@@ -835,34 +835,15 @@ async fn handle_browser_proxy(
         }
     }
 
-    // Poll briefly for the port to appear. The sidecar prints its
-    // listening line within ~1s of start; bail with a helpful error
-    // if it takes longer than 10s.
-    let port = {
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
-        loop {
-            let guard = handle.read().await;
-            if let Some(sc) = guard.as_ref() {
-                if let Some(p) = sc.port().await {
-                    break p;
-                }
-            }
-            if tokio::time::Instant::now() >= deadline {
-                return Ok(error_result(
-                    request,
-                    "SIDECAR_STARTUP_TIMEOUT",
-                    "browser sidecar did not report a listening port within 10s",
-                ));
-            }
-            drop(guard);
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        }
-    };
-
-    // Build the outbound HTTP request. Query string is URL-encoded
-    // from the JSON map (flat string->string assumed, mirroring
-    // MacNodeBrowserProxy.swift's shape).
-    let url = build_proxy_url(port, &path, params.query.as_ref());
+    // Port is deterministic — OpenClaw binds browser control on
+    // gatewayPort+2, and the launcher pins gatewayPort to 18789.
+    // The reqwest client's connect timeout handles the case where
+    // the sidecar is still coming up on first invocation.
+    let url = build_proxy_url(
+        crate::browser_sidecar::BROWSER_CONTROL_PORT,
+        &path,
+        params.query.as_ref(),
+    );
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -35,6 +35,13 @@
       "icons/icon.ico",
       "icons/icon.png"
     ],
+    "externalBin": [
+      "bin/isol8-browser-service"
+    ],
+    "resources": [
+      "bin/node-aarch64-apple-darwin",
+      "bin/openclaw-browser/**/*"
+    ],
     "macOS": {
       "entitlements": "entitlements.plist",
       "signingIdentity": "Developer ID Application: Prasiddha Parthsarthy (WZX4U3C22Y)",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
     ],
     "resources": [
       "bin/node-aarch64-apple-darwin",
-      "bin/openclaw-browser/**/*"
+      "bin/openclaw-host/**/*"
     ],
     "macOS": {
       "entitlements": "entitlements.plist",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -40,7 +40,9 @@
     ],
     "resources": [
       "bin/node-aarch64-apple-darwin",
-      "bin/openclaw-host/**/*"
+      "bin/node-x86_64-apple-darwin",
+      "bin/openclaw-host-aarch64-apple-darwin/**/*",
+      "bin/openclaw-host-x86_64-apple-darwin/**/*"
     ],
     "macOS": {
       "entitlements": "entitlements.plist",

--- a/apps/desktop/src-tauri/tests/browser_sidecar_test.rs
+++ b/apps/desktop/src-tauri/tests/browser_sidecar_test.rs
@@ -25,3 +25,23 @@ async fn start_is_idempotent() {
     sidecar.start().await.expect("second call is a no-op");
     sidecar.stop().await;
 }
+
+#[tokio::test]
+async fn detects_listening_port_from_stdout() {
+    // Fake script that prints the expected line then sleeps.
+    let sidecar = BrowserSidecar::new_for_test(
+        PathBuf::from("/bin/sh"),
+        vec![
+            "-c".into(),
+            "echo 'listening on 127.0.0.1:54321'; sleep 3600".into(),
+        ],
+    );
+    sidecar.start().await.expect("spawn");
+    // Give the reader loop a moment to consume the line.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    match sidecar.state() {
+        SidecarState::Running { port, .. } => assert_eq!(port, 54321),
+        other => panic!("expected Running, got {:?}", other),
+    }
+    sidecar.stop().await;
+}

--- a/apps/desktop/src-tauri/tests/browser_sidecar_test.rs
+++ b/apps/desktop/src-tauri/tests/browser_sidecar_test.rs
@@ -1,0 +1,27 @@
+use isol8_desktop::browser_sidecar::{BrowserSidecar, SidecarState};
+use std::path::PathBuf;
+
+#[tokio::test]
+async fn spawn_fake_binary_reports_ready() {
+    // Use `/bin/sh -c "sleep 3600"` as a stand-in for the real sidecar
+    // so the test doesn't require Node.js / vendored bundle to pass.
+    let sidecar = BrowserSidecar::new_for_test(
+        PathBuf::from("/bin/sh"),
+        vec!["-c".into(), "sleep 3600".into()],
+    );
+    sidecar.start().await.expect("spawn");
+    assert!(matches!(sidecar.state(), SidecarState::Running { .. }));
+    sidecar.stop().await;
+    assert!(matches!(sidecar.state(), SidecarState::Stopped));
+}
+
+#[tokio::test]
+async fn start_is_idempotent() {
+    let sidecar = BrowserSidecar::new_for_test(
+        PathBuf::from("/bin/sh"),
+        vec!["-c".into(), "sleep 3600".into()],
+    );
+    sidecar.start().await.expect("first spawn");
+    sidecar.start().await.expect("second call is a no-op");
+    sidecar.stop().await;
+}

--- a/apps/desktop/src-tauri/tests/browser_sidecar_test.rs
+++ b/apps/desktop/src-tauri/tests/browser_sidecar_test.rs
@@ -24,6 +24,22 @@ async fn start_is_idempotent() {
     sidecar.start().await.expect("second call is a no-op");
 }
 
+#[tokio::test]
+async fn start_respawns_after_child_exits() {
+    // Child that exits immediately. Without the try_wait() probe in
+    // start(), the stale `Child` handle would linger as Some and
+    // subsequent calls would become no-ops — the bug Codex flagged.
+    let sidecar = BrowserSidecar::new_for_test(
+        PathBuf::from("/bin/sh"),
+        vec!["-c".into(), "exit 0".into()],
+    );
+    sidecar.start().await.expect("first spawn");
+    // Give the process a moment to exit.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    // Calling start() again must detect the dead child and respawn.
+    sidecar.start().await.expect("second spawn after exit");
+}
+
 #[test]
 fn port_matches_openclaw_derivation() {
     // OpenClaw src/config/port-defaults.ts:

--- a/apps/desktop/src-tauri/tests/browser_sidecar_test.rs
+++ b/apps/desktop/src-tauri/tests/browser_sidecar_test.rs
@@ -1,18 +1,17 @@
-use isol8_desktop::browser_sidecar::{BrowserSidecar, SidecarState};
+use isol8_desktop::browser_sidecar::{BrowserSidecar, BROWSER_CONTROL_PORT, GATEWAY_PORT};
 use std::path::PathBuf;
 
 #[tokio::test]
-async fn spawn_fake_binary_reports_ready() {
-    // Use `/bin/sh -c "sleep 3600"` as a stand-in for the real sidecar
-    // so the test doesn't require Node.js / vendored bundle to pass.
+async fn spawn_fake_binary_runs() {
+    // Use `/bin/sh -c "sleep 3600"` as a stand-in for the real
+    // sidecar so the test doesn't require the vendored bundle.
     let sidecar = BrowserSidecar::new_for_test(
         PathBuf::from("/bin/sh"),
         vec!["-c".into(), "sleep 3600".into()],
     );
     sidecar.start().await.expect("spawn");
-    assert!(matches!(sidecar.state(), SidecarState::Running { .. }));
-    sidecar.stop().await;
-    assert!(matches!(sidecar.state(), SidecarState::Stopped));
+    // Port is deterministic — no stdout parsing required.
+    assert_eq!(sidecar.port(), BROWSER_CONTROL_PORT);
 }
 
 #[tokio::test]
@@ -23,25 +22,11 @@ async fn start_is_idempotent() {
     );
     sidecar.start().await.expect("first spawn");
     sidecar.start().await.expect("second call is a no-op");
-    sidecar.stop().await;
 }
 
-#[tokio::test]
-async fn detects_listening_port_from_stdout() {
-    // Fake script that prints the expected line then sleeps.
-    let sidecar = BrowserSidecar::new_for_test(
-        PathBuf::from("/bin/sh"),
-        vec![
-            "-c".into(),
-            "echo 'listening on 127.0.0.1:54321'; sleep 3600".into(),
-        ],
-    );
-    sidecar.start().await.expect("spawn");
-    // Give the reader loop a moment to consume the line.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    match sidecar.state() {
-        SidecarState::Running { port, .. } => assert_eq!(port, 54321),
-        other => panic!("expected Running, got {:?}", other),
-    }
-    sidecar.stop().await;
+#[test]
+fn port_matches_openclaw_derivation() {
+    // OpenClaw src/config/port-defaults.ts:
+    //   deriveDefaultBrowserControlPort(gatewayPort) = gatewayPort + 2
+    assert_eq!(BROWSER_CONTROL_PORT, GATEWAY_PORT + 2);
 }

--- a/docs/superpowers/plans/2026-04-19-desktop-browser-node.md
+++ b/docs/superpowers/plans/2026-04-19-desktop-browser-node.md
@@ -1,0 +1,1155 @@
+# Desktop Browser Node Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the container's agent drive the user's real, signed-in Chrome via OpenClaw's `browser.proxy` RPC — no bundled Chromium, no custom extension.
+
+**Architecture:** Bundle Node.js + OpenClaw's `extensions/browser/` TS + `chrome-devtools-mcp` as sidecars inside our Tauri desktop app. Our Rust code supervises the subprocess and relays `browser.proxy` RPCs from the container's WebSocket to the local HTTP control service, which drives chrome-devtools-mcp via CDP to Chrome 144+.
+
+**Tech Stack:** Tauri 2 (Rust), Node.js 20 LTS (bundled), OpenClaw `extensions/browser/` (vendored), `chrome-devtools-mcp` npm package, `reqwest` for HTTP relay, `tokio::process` for subprocess, FastAPI (Python) for backend config.
+
+**Spec:** [`docs/superpowers/specs/2026-04-19-desktop-browser-node-design.md`](../specs/2026-04-19-desktop-browser-node-design.md)
+
+**Scope:** Phase 1 — plumbing end-to-end. Phase 2 (Browser onboarding UI panel) is a follow-up plan.
+
+---
+
+## File Structure
+
+**New:**
+- `apps/desktop/src-tauri/scripts/vendor-sidecars.sh` — build-time script: downloads Node.js, vendors OpenClaw browser TS, runs `npm install` inside it.
+- `apps/desktop/src-tauri/bin/` — (gitignored) built sidecar artifacts consumed by Tauri `externalBin`.
+- `apps/desktop/src-tauri/src/browser_sidecar.rs` — Rust subprocess supervisor for the Node.js browser service.
+- `apps/desktop/src-tauri/tests/browser_proxy_test.rs` — Rust integration tests for the proxy handler.
+
+**Modified:**
+- `apps/desktop/src-tauri/tauri.conf.json` — add `bundle.externalBin` array referencing the sidecar binaries.
+- `apps/desktop/src-tauri/Cargo.toml` — add `reqwest` for HTTP relay.
+- `apps/desktop/src-tauri/src/lib.rs` — hold a `BrowserSidecar` in shared state; stop it on app exit.
+- `apps/desktop/src-tauri/src/node_invoke.rs` — add `browser.proxy` dispatch case + handler.
+- `apps/desktop/src-tauri/src/node_client.rs` — advertise `browser.proxy` in the `commands` list.
+- `apps/backend/core/containers/config.py` — add `browser.enabled=true`, `browser.defaultProfile="user"`, `nodeHost.browserProxy.enabled=true`; include same scalars in `build_backend_policy_patch`.
+- `apps/backend/tests/unit/containers/test_config.py` — lock in the config assertions.
+- `apps/desktop/.gitignore` — ignore the generated `src-tauri/bin/` directory.
+
+**Not modified:** `apps/backend/routers/node_proxy.py` — the existing per-member routing path already handles `browser.proxy` identically to `system.run` (both are generic node.invoke.request forwards).
+
+---
+
+## Task 1: Add `.gitignore` entry for vendored sidecar bin directory
+
+**Files:**
+- Modify: `apps/desktop/.gitignore`
+
+Keep the generated Node.js binary + vendored TS + `node_modules` out of git. They're rebuilt from the script.
+
+- [ ] **Step 1: Add the ignore entry**
+
+Append to `apps/desktop/.gitignore` (or create it if missing):
+
+```
+# Sidecar binaries produced by scripts/vendor-sidecars.sh.
+# Regenerated at CI build time; not committed.
+src-tauri/bin/
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd apps/desktop && git check-ignore src-tauri/bin/foo.txt`
+Expected: prints `src-tauri/bin/foo.txt`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/.gitignore
+git commit -m "$(cat <<'EOF'
+chore(desktop): gitignore vendored sidecar bin directory
+
+The vendor-sidecars.sh script (coming in next task) builds Node.js +
+OpenClaw browser TS + chrome-devtools-mcp into src-tauri/bin/ for
+Tauri externalBin bundling. These artifacts are rebuilt every CI run
+and must not be committed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Build the `vendor-sidecars.sh` script
+
+**Files:**
+- Create: `apps/desktop/src-tauri/scripts/vendor-sidecars.sh`
+
+Single script that produces everything our Tauri `externalBin` needs. Idempotent — re-runs after a clean.
+
+- [ ] **Step 1: Write the script**
+
+Create `apps/desktop/src-tauri/scripts/vendor-sidecars.sh` with content below. `set -euo pipefail` so any failure aborts the build.
+
+```bash
+#!/usr/bin/env bash
+# Vendor sidecars for the Isol8 desktop browser node.
+# Produces: src-tauri/bin/ containing a Node.js binary, the OpenClaw
+# browser control service, and chrome-devtools-mcp — all referenced
+# from tauri.conf.json's bundle.externalBin array.
+#
+# Versions are pinned here. When bumping the OpenClaw container
+# image, also update OPENCLAW_REF to the matching openclaw git SHA.
+set -euo pipefail
+
+NODE_VERSION="20.18.0"       # LTS; matches chrome-devtools-mcp's engines.node
+OPENCLAW_REF="v2026.4.5"     # must match openclaw-version.json's tag
+CHROME_DEVTOOLS_MCP_VERSION="latest"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TAURI_DIR="$(dirname "$SCRIPT_DIR")"
+BIN_DIR="$TAURI_DIR/bin"
+TMP_DIR="$TAURI_DIR/.sidecar-tmp"
+
+# Tauri's externalBin naming convention: <name>-<target-triple>.
+# We build a universal mac binary naming: aarch64-apple-darwin for M1+.
+# Intel Macs: add x86_64-apple-darwin in a follow-up if we still ship to them.
+TARGET_TRIPLE="aarch64-apple-darwin"
+
+rm -rf "$TMP_DIR"
+mkdir -p "$BIN_DIR" "$TMP_DIR"
+
+# ---- Node.js ----
+NODE_TARBALL="node-v${NODE_VERSION}-darwin-arm64.tar.xz"
+NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TARBALL}"
+echo "==> Downloading $NODE_URL"
+curl -fsSL -o "$TMP_DIR/$NODE_TARBALL" "$NODE_URL"
+tar -xf "$TMP_DIR/$NODE_TARBALL" -C "$TMP_DIR"
+cp "$TMP_DIR/node-v${NODE_VERSION}-darwin-arm64/bin/node" "$BIN_DIR/node-${TARGET_TRIPLE}"
+chmod +x "$BIN_DIR/node-${TARGET_TRIPLE}"
+
+# ---- OpenClaw browser control service ----
+# Clone openclaw at the pinned ref (sparse: only extensions/browser/).
+echo "==> Vendoring openclaw extensions/browser at $OPENCLAW_REF"
+git -C "$TMP_DIR" clone --depth 1 --branch "$OPENCLAW_REF" --no-checkout \
+    https://github.com/openclaw/openclaw.git openclaw-src
+(
+    cd "$TMP_DIR/openclaw-src"
+    git sparse-checkout init --cone
+    git sparse-checkout set extensions/browser
+    git checkout "$OPENCLAW_REF"
+)
+mkdir -p "$BIN_DIR/openclaw-browser"
+cp -R "$TMP_DIR/openclaw-src/extensions/browser/." "$BIN_DIR/openclaw-browser/"
+
+# Install openclaw browser's own npm deps + add chrome-devtools-mcp.
+# The OPENCLAW_BROWSER_ENTRY env var below is consumed by Rust at
+# spawn time — if the openclaw ref's main changes, bump it here too.
+(
+    cd "$BIN_DIR/openclaw-browser"
+    npm install --production --no-audit --no-fund
+    npm install --no-save --no-audit --no-fund \
+        "chrome-devtools-mcp@${CHROME_DEVTOOLS_MCP_VERSION}"
+)
+
+# Tauri externalBin expects a direct binary, so write a tiny launcher
+# that execs node against the service entry point. This lets us keep
+# the TS code in openclaw-browser/ without restructuring it.
+cat > "$BIN_DIR/isol8-browser-service-${TARGET_TRIPLE}" <<'LAUNCHER'
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$HERE/node-aarch64-apple-darwin" "$HERE/openclaw-browser/dist/control-service.js" "$@"
+LAUNCHER
+chmod +x "$BIN_DIR/isol8-browser-service-${TARGET_TRIPLE}"
+
+rm -rf "$TMP_DIR"
+echo "==> Sidecars vendored at $BIN_DIR"
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x apps/desktop/src-tauri/scripts/vendor-sidecars.sh`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: DO NOT run the script yet**
+
+Per user preference (write tests/scaffolding first, run at the end), skip execution. The script will be exercised during Task 8's end-of-plan verification + on CI when the image is built.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/desktop/src-tauri/scripts/vendor-sidecars.sh
+git commit -m "$(cat <<'EOF'
+build(desktop): script to vendor browser sidecars
+
+One-shot build step: downloads Node.js 20.18 for aarch64-apple-darwin,
+sparse-clones openclaw's extensions/browser at a pinned ref, runs
+npm install, adds chrome-devtools-mcp, and emits a launcher shim that
+Tauri bundles as an externalBin.
+
+Pinned versions live at the top of the script; bump the OpenClaw ref
+in lockstep with openclaw-version.json. Intel Mac support is a
+follow-up (add x86_64-apple-darwin tarball).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Register the sidecar in `tauri.conf.json`
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/tauri.conf.json:30-43`
+
+Wire the built sidecar into Tauri's `externalBin` so it's copied into the `.app` bundle on `cargo tauri build`.
+
+- [ ] **Step 1: Add externalBin config**
+
+Replace the `"bundle"` block (currently lines 30-43) with:
+
+```json
+  "bundle": {
+    "active": true,
+    "targets": ["dmg"],
+    "icon": [
+      "icons/icon.icns",
+      "icons/icon.ico",
+      "icons/icon.png"
+    ],
+    "externalBin": [
+      "bin/isol8-browser-service"
+    ],
+    "resources": [
+      "bin/node-aarch64-apple-darwin",
+      "bin/openclaw-browser/**/*"
+    ],
+    "macOS": {
+      "entitlements": "entitlements.plist",
+      "signingIdentity": "Developer ID Application: Prasiddha Parthsarthy (WZX4U3C22Y)",
+      "minimumSystemVersion": "10.15"
+    }
+  },
+```
+
+Tauri resolves `externalBin` entries by appending the target triple (so `bin/isol8-browser-service` → `bin/isol8-browser-service-aarch64-apple-darwin`), then sign-and-bundles it alongside the main binary. The sibling `node` binary and `openclaw-browser/` directory ride along via `resources` since they're referenced from the launcher shim at runtime rather than directly by Tauri.
+
+- [ ] **Step 2: Typecheck JSON**
+
+Run: `cd apps/desktop/src-tauri && python3 -c "import json; json.load(open('tauri.conf.json'))"`
+Expected: silent (valid JSON).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/src-tauri/tauri.conf.json
+git commit -m "$(cat <<'EOF'
+build(desktop): register browser sidecar in Tauri bundle
+
+externalBin ships the launcher shim; resources bundle the Node.js
+binary + vendored openclaw browser code alongside it so the shim
+can exec them at runtime.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `reqwest` dep for HTTP relay
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/Cargo.toml`
+
+- [ ] **Step 1: Add the dependency**
+
+In `[dependencies]`, add:
+
+```toml
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+```
+
+`rustls-tls` keeps us off OpenSSL (which Tauri already avoids). We only hit localhost so TLS isn't strictly needed, but `default-features = false` makes that explicit.
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cd apps/desktop/src-tauri && cargo check`
+Expected: compiles (may download + compile reqwest; takes ~30s first time).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/src-tauri/Cargo.toml apps/desktop/src-tauri/Cargo.lock
+git commit -m "$(cat <<'EOF'
+build(desktop): add reqwest for browser.proxy HTTP relay
+
+rustls-tls keeps the dep graph off OpenSSL. Features trimmed to json
+only — we're not doing multipart or streaming bodies over the relay.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `browser_sidecar.rs` — subprocess supervisor (failing test first)
+
+**Files:**
+- Create: `apps/desktop/src-tauri/tests/browser_sidecar_test.rs`
+- Create: `apps/desktop/src-tauri/src/browser_sidecar.rs`
+- Modify: `apps/desktop/src-tauri/src/lib.rs` (register module)
+
+TDD pattern. Test first, then minimal impl that passes it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/desktop/src-tauri/tests/browser_sidecar_test.rs`:
+
+```rust
+use isol8_desktop::browser_sidecar::{BrowserSidecar, SidecarState};
+use std::path::PathBuf;
+
+#[tokio::test]
+async fn spawn_fake_binary_reports_ready() {
+    // Use `/bin/sh -c "sleep 3600"` as a stand-in for the real sidecar
+    // so the test doesn't require Node.js / vendored bundle to pass.
+    let sidecar = BrowserSidecar::new_for_test(
+        PathBuf::from("/bin/sh"),
+        vec!["-c".into(), "sleep 3600".into()],
+    );
+    sidecar.start().await.expect("spawn");
+    assert!(matches!(sidecar.state(), SidecarState::Running { .. }));
+    sidecar.stop().await;
+    assert!(matches!(sidecar.state(), SidecarState::Stopped));
+}
+
+#[tokio::test]
+async fn start_is_idempotent() {
+    let sidecar = BrowserSidecar::new_for_test(
+        PathBuf::from("/bin/sh"),
+        vec!["-c".into(), "sleep 3600".into()],
+    );
+    sidecar.start().await.expect("first spawn");
+    sidecar.start().await.expect("second call is a no-op");
+    sidecar.stop().await;
+}
+```
+
+- [ ] **Step 2: Create minimal browser_sidecar.rs**
+
+Create `apps/desktop/src-tauri/src/browser_sidecar.rs`:
+
+```rust
+//! Subprocess supervisor for the Node.js-based browser control service
+//! (openclaw/extensions/browser/ + chrome-devtools-mcp). Spawned on
+//! demand when the first browser.proxy RPC arrives; stays alive until
+//! the app exits or the subprocess dies (in which case the next
+//! browser.proxy call respawns it).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+#[derive(Debug)]
+pub enum SidecarState {
+    Stopped,
+    Running { pid: Option<u32>, port: u16 },
+}
+
+pub struct BrowserSidecar {
+    binary: PathBuf,
+    args: Vec<String>,
+    child: Arc<Mutex<Option<Child>>>,
+    port: Arc<Mutex<u16>>,
+}
+
+impl BrowserSidecar {
+    /// Constructor for tests — lets us swap the binary path without
+    /// forcing the real sidecar to be built.
+    pub fn new_for_test(binary: PathBuf, args: Vec<String>) -> Self {
+        Self {
+            binary,
+            args,
+            child: Arc::new(Mutex::new(None)),
+            port: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub async fn start(&self) -> Result<(), String> {
+        let mut guard = self.child.lock().await;
+        if guard.is_some() {
+            return Ok(()); // already running
+        }
+        let child = Command::new(&self.binary)
+            .args(&self.args)
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| format!("spawn failed: {}", e))?;
+        *guard = Some(child);
+        // Placeholder: real impl will parse stdout for "listening on port N"
+        // and populate self.port. Tests pass with 0 for now.
+        Ok(())
+    }
+
+    pub async fn stop(&self) {
+        let mut guard = self.child.lock().await;
+        if let Some(mut c) = guard.take() {
+            let _ = c.kill().await;
+        }
+    }
+
+    pub fn state(&self) -> SidecarState {
+        let child_present = self
+            .child
+            .try_lock()
+            .map(|g| g.is_some())
+            .unwrap_or(false);
+        if child_present {
+            let port = self.port.try_lock().map(|g| *g).unwrap_or(0);
+            SidecarState::Running { pid: None, port }
+        } else {
+            SidecarState::Stopped
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Register the module**
+
+Modify `apps/desktop/src-tauri/src/lib.rs`. Find the module declarations near the top of the file and add:
+
+```rust
+pub mod browser_sidecar;
+```
+
+(Make it `pub mod` so the integration test in `tests/` can access it.)
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd apps/desktop/src-tauri && cargo check --tests`
+Expected: compiles. Tests aren't executed per end-of-plan-verification preference.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src-tauri/src/browser_sidecar.rs apps/desktop/src-tauri/src/lib.rs apps/desktop/src-tauri/tests/browser_sidecar_test.rs
+git commit -m "$(cat <<'EOF'
+feat(desktop): browser sidecar supervisor skeleton
+
+BrowserSidecar owns the Node.js child process that runs openclaw's
+browser control service. This commit is the minimal skeleton: spawn,
+kill, idempotent start. Port parsing from stdout + health-check loop
+land in the next task.
+
+Tests use `sh -c sleep 3600` as a stand-in so they don't require the
+vendor-sidecars.sh bundle to have been built.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Port parsing + log forwarding
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/browser_sidecar.rs`
+- Modify: `apps/desktop/src-tauri/tests/browser_sidecar_test.rs`
+
+OpenClaw's control service prints `listening on 127.0.0.1:<port>` shortly after startup. Parse it. Also tee stdout/stderr into our file logger so sidecar diagnostics show up in `/tmp/isol8-desktop.log` alongside the rest.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `apps/desktop/src-tauri/tests/browser_sidecar_test.rs`:
+
+```rust
+#[tokio::test]
+async fn detects_listening_port_from_stdout() {
+    // Fake script that prints the expected line then sleeps.
+    let sidecar = BrowserSidecar::new_for_test(
+        PathBuf::from("/bin/sh"),
+        vec![
+            "-c".into(),
+            "echo 'listening on 127.0.0.1:54321'; sleep 3600".into(),
+        ],
+    );
+    sidecar.start().await.expect("spawn");
+    // Give the reader loop a moment to consume the line.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    match sidecar.state() {
+        SidecarState::Running { port, .. } => assert_eq!(port, 54321),
+        other => panic!("expected Running, got {:?}", other),
+    }
+    sidecar.stop().await;
+}
+```
+
+- [ ] **Step 2: Implement port parsing + log forwarding**
+
+Replace the body of `browser_sidecar.rs` with:
+
+```rust
+//! Subprocess supervisor for the Node.js-based browser control service
+//! (openclaw/extensions/browser/ + chrome-devtools-mcp). Spawned on
+//! demand when the first browser.proxy RPC arrives; stays alive until
+//! the app exits or the subprocess dies (in which case the next
+//! browser.proxy call respawns it).
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+#[derive(Debug)]
+pub enum SidecarState {
+    Stopped,
+    Running { pid: Option<u32>, port: u16 },
+}
+
+pub struct BrowserSidecar {
+    binary: PathBuf,
+    args: Vec<String>,
+    child: Arc<Mutex<Option<Child>>>,
+    port: Arc<Mutex<u16>>,
+}
+
+impl BrowserSidecar {
+    pub fn new_for_test(binary: PathBuf, args: Vec<String>) -> Self {
+        Self {
+            binary,
+            args,
+            child: Arc::new(Mutex::new(None)),
+            port: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub async fn start(&self) -> Result<(), String> {
+        let mut guard = self.child.lock().await;
+        if guard.is_some() {
+            return Ok(());
+        }
+        let mut child = Command::new(&self.binary)
+            .args(&self.args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| format!("spawn failed: {}", e))?;
+
+        // Pipe stdout: parse for "listening on 127.0.0.1:<port>" and
+        // forward every line to the file logger.
+        if let Some(out) = child.stdout.take() {
+            let port_slot = self.port.clone();
+            tokio::spawn(async move {
+                let reader = BufReader::new(out);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    crate::log(&format!("[browser-sidecar] {}", line));
+                    if let Some(port) = parse_listening_port(&line) {
+                        if let Ok(mut slot) = port_slot.try_lock() {
+                            *slot = port;
+                        }
+                    }
+                }
+            });
+        }
+        // Pipe stderr: forward to log with a prefix.
+        if let Some(err) = child.stderr.take() {
+            tokio::spawn(async move {
+                let reader = BufReader::new(err);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    crate::log(&format!("[browser-sidecar err] {}", line));
+                }
+            });
+        }
+
+        *guard = Some(child);
+        Ok(())
+    }
+
+    pub async fn stop(&self) {
+        let mut guard = self.child.lock().await;
+        if let Some(mut c) = guard.take() {
+            let _ = c.kill().await;
+        }
+        if let Ok(mut slot) = self.port.try_lock() {
+            *slot = 0;
+        }
+    }
+
+    pub fn state(&self) -> SidecarState {
+        let child_present = self
+            .child
+            .try_lock()
+            .map(|g| g.is_some())
+            .unwrap_or(false);
+        if child_present {
+            let port = self.port.try_lock().map(|g| *g).unwrap_or(0);
+            SidecarState::Running { pid: None, port }
+        } else {
+            SidecarState::Stopped
+        }
+    }
+
+    pub async fn port(&self) -> Option<u16> {
+        let p = *self.port.lock().await;
+        if p == 0 {
+            None
+        } else {
+            Some(p)
+        }
+    }
+}
+
+/// Parse "listening on 127.0.0.1:PORT" style lines. Accepts both
+/// "listening on 127.0.0.1:54321" and "…listening on http://127.0.0.1:54321/…"
+/// so minor log-format drift in the upstream service doesn't break us.
+fn parse_listening_port(line: &str) -> Option<u16> {
+    let needle = "127.0.0.1:";
+    let idx = line.find(needle)?;
+    let rest = &line[idx + needle.len()..];
+    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    rest[..end].parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_listening_port;
+
+    #[test]
+    fn parses_plain_form() {
+        assert_eq!(parse_listening_port("listening on 127.0.0.1:54321"), Some(54321));
+    }
+
+    #[test]
+    fn parses_url_form() {
+        assert_eq!(
+            parse_listening_port("[info] http://127.0.0.1:18791/ ready"),
+            Some(18791)
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_lines() {
+        assert_eq!(parse_listening_port("starting chrome-devtools-mcp"), None);
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd apps/desktop/src-tauri && cargo check --tests`
+Expected: compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/desktop/src-tauri/src/browser_sidecar.rs apps/desktop/src-tauri/tests/browser_sidecar_test.rs
+git commit -m "$(cat <<'EOF'
+feat(desktop): parse listening port + forward sidecar logs
+
+Stdout/stderr of the Node.js sidecar are teed to /tmp/isol8-desktop.log
+with [browser-sidecar] prefix so its diagnostics are visible alongside
+the rest of our Rust log. A cheap regex-free parser extracts the port
+from "listening on 127.0.0.1:PORT" lines so the browser.proxy handler
+knows where to dial.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `browser.proxy` RPC handler
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/node_invoke.rs`
+- Modify: `apps/desktop/src-tauri/src/node_client.rs` (advertise command)
+- Modify: `apps/desktop/src-tauri/src/lib.rs` (hold sidecar in state)
+
+Core feature of this plan. Handler takes the incoming `browser.proxy` invoke, lazily starts the sidecar, forwards the HTTP request to `127.0.0.1:<sidecar_port>`, and returns the response as the invoke payload.
+
+### Step-by-step
+
+- [ ] **Step 1: Hold a BrowserSidecar in shared state (lib.rs)**
+
+Add near the other `pub mod` declarations in `apps/desktop/src-tauri/src/lib.rs`:
+
+```rust
+pub mod browser_sidecar;
+```
+
+(If Task 5 already added it, skip.) Then in the Tauri `Builder::default()...` chain inside the `run()` function, add `.manage(Arc::new(tokio::sync::RwLock::new(browser_sidecar::BrowserSidecarHandle::production())))` — we need a production constructor on BrowserSidecar that resolves the bundled sidecar path from Tauri's resource dir.
+
+First extend `browser_sidecar.rs` with:
+
+```rust
+use tauri::Manager; // needed for resource_dir
+
+impl BrowserSidecar {
+    /// Production constructor: resolves the Tauri sidecar path at
+    /// runtime. Call from within a Tauri command where the AppHandle
+    /// is available.
+    pub fn for_app(app: &tauri::AppHandle) -> Result<Self, String> {
+        // Tauri externalBin resolves to this path inside the .app
+        // bundle after signing.
+        let sidecar = app
+            .path()
+            .resolve(
+                "isol8-browser-service",
+                tauri::path::BaseDirectory::Resource,
+            )
+            .map_err(|e| format!("resolve sidecar path: {}", e))?;
+        Ok(Self {
+            binary: sidecar,
+            args: vec![],
+            child: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+            port: std::sync::Arc::new(tokio::sync::Mutex::new(0)),
+        })
+    }
+}
+
+pub type BrowserSidecarHandle = std::sync::Arc<tokio::sync::RwLock<Option<BrowserSidecar>>>;
+```
+
+And in `lib.rs`'s `run()` function, add state registration (find the existing `.manage(...)` calls and add):
+
+```rust
+.manage::<browser_sidecar::BrowserSidecarHandle>(
+    std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+)
+```
+
+- [ ] **Step 2: Add `browser.proxy` dispatch case**
+
+In `node_invoke.rs`, find the existing `match command.as_str()` in `handle_invoke` and add a new case before the catch-all:
+
+```rust
+"browser.proxy" => handle_browser_proxy(&request, app).await,
+```
+
+`handle_invoke` needs access to the Tauri `AppHandle` to resolve state. If the signature doesn't already take one, add it as a parameter — propagate that change up the call chain (the spawning site in `lib.rs`'s `start_node_host` needs to pass `app.clone()` through).
+
+- [ ] **Step 3: Implement handle_browser_proxy**
+
+Add to `node_invoke.rs`:
+
+```rust
+#[derive(serde::Deserialize, Debug)]
+struct BrowserProxyParams {
+    // HTTP method (GET/POST/...) the agent's browser tool wants to
+    // invoke against the control service. See
+    // apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift:81-86
+    // for the canonical shape.
+    method: Option<String>,
+    path: Option<String>,
+    #[serde(default)]
+    query: Option<serde_json::Value>,
+    #[serde(default)]
+    body: Option<serde_json::Value>,
+    #[serde(default)]
+    auth: Option<BrowserProxyAuth>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct BrowserProxyAuth {
+    token: Option<String>,
+    password: Option<String>,
+}
+
+async fn handle_browser_proxy(
+    request: &NodeInvokeRequest,
+    app: tauri::AppHandle,
+) -> Result<NodeInvokeResult, Box<dyn std::error::Error + Send + Sync>> {
+    use tauri::Manager;
+
+    let params: BrowserProxyParams = parse_params(&request.params_json)?;
+    let method = params.method.unwrap_or_else(|| "GET".into());
+    let path = params.path.unwrap_or_else(|| "/".into());
+
+    // Lazily start the sidecar on first call. Later calls reuse it.
+    let handle = app.state::<crate::browser_sidecar::BrowserSidecarHandle>();
+    {
+        let guard = handle.read().await;
+        if guard.is_none() {
+            drop(guard);
+            let mut w = handle.write().await;
+            if w.is_none() {
+                let sc = crate::browser_sidecar::BrowserSidecar::for_app(&app)
+                    .map_err(|e| format!("sidecar init: {}", e))?;
+                sc.start().await.map_err(|e| format!("sidecar start: {}", e))?;
+                *w = Some(sc);
+            }
+        }
+    }
+
+    // Poll briefly for the port to appear. The sidecar prints its
+    // listening line within ~1s of start; bail with a helpful error
+    // if it takes longer than 10s.
+    let port = {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let guard = handle.read().await;
+            if let Some(sc) = guard.as_ref() {
+                if let Some(p) = sc.port().await {
+                    break p;
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Ok(error_result(
+                    request,
+                    "SIDECAR_STARTUP_TIMEOUT",
+                    "browser sidecar did not report a listening port within 10s",
+                ));
+            }
+            drop(guard);
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    };
+
+    // Build the outbound HTTP request. Query string is URL-encoded
+    // from the JSON map (flat string->string assumed, mirroring
+    // MacNodeBrowserProxy.swift's shape).
+    let url = build_proxy_url(port, &path, params.query.as_ref());
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("http client: {}", e))?;
+    let mut req = client.request(
+        method.parse().map_err(|e| format!("bad method {}: {}", method, e))?,
+        &url,
+    );
+    if let Some(auth) = params.auth {
+        if let Some(token) = auth.token {
+            req = req.bearer_auth(token);
+        } else if let Some(password) = auth.password {
+            req = req.basic_auth("", Some(password));
+        }
+    }
+    if let Some(body) = params.body {
+        req = req.json(&body);
+    }
+    let resp = req.send().await.map_err(|e| format!("http: {}", e))?;
+    let status = resp.status().as_u16();
+    let bytes = resp.bytes().await.map_err(|e| format!("body read: {}", e))?;
+
+    // Response is JSON most of the time; if it's not, wrap in a
+    // text envelope so the client can still read it.
+    let body: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(_) => serde_json::Value::String(String::from_utf8_lossy(&bytes).into_owned()),
+    };
+    let payload = serde_json::json!({
+        "status": status,
+        "body": body,
+    });
+    Ok(ok_payload(request, payload))
+}
+
+fn build_proxy_url(port: u16, path: &str, query: Option<&serde_json::Value>) -> String {
+    let mut url = format!("http://127.0.0.1:{}{}", port, path);
+    if let Some(serde_json::Value::Object(map)) = query {
+        let pairs: Vec<String> = map
+            .iter()
+            .filter_map(|(k, v)| match v {
+                serde_json::Value::String(s) => Some(format!(
+                    "{}={}",
+                    urlencoding::encode(k),
+                    urlencoding::encode(s)
+                )),
+                serde_json::Value::Number(n) => Some(format!(
+                    "{}={}",
+                    urlencoding::encode(k),
+                    n
+                )),
+                _ => None,
+            })
+            .collect();
+        if !pairs.is_empty() {
+            url.push('?');
+            url.push_str(&pairs.join("&"));
+        }
+    }
+    url
+}
+```
+
+Also add to `Cargo.toml` `[dependencies]`: `urlencoding = "2"`. (Keeps us off pulling `url` which is much heavier.)
+
+- [ ] **Step 4: Advertise `browser.proxy` in the commands list**
+
+In `apps/desktop/src-tauri/src/node_client.rs`, find the `commands:` array inside the connect params and append `"browser.proxy"`:
+
+```rust
+"commands": [
+    "system.run.prepare",
+    "system.run",
+    "system.which",
+    "system.execApprovals.get",
+    "system.execApprovals.set",
+    "system.notify",
+    "device.info",
+    "device.status",
+    "device.health",
+    "device.permissions",
+    "browser.proxy",
+],
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd apps/desktop/src-tauri && cargo check`
+Expected: compiles cleanly (warnings OK).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src-tauri/src/node_invoke.rs apps/desktop/src-tauri/src/node_client.rs apps/desktop/src-tauri/src/browser_sidecar.rs apps/desktop/src-tauri/src/lib.rs apps/desktop/src-tauri/Cargo.toml apps/desktop/src-tauri/Cargo.lock
+git commit -m "$(cat <<'EOF'
+feat(desktop): browser.proxy RPC handler + sidecar state
+
+handle_browser_proxy lazily starts the browser sidecar on first
+invocation, waits up to 10s for the sidecar to report its listening
+port, then forwards the HTTP request to 127.0.0.1:<port>. Response
+comes back as { status, body } in the invoke payload.
+
+Params mirror MacNodeBrowserProxy.swift (method/path/query/body/auth)
+so OpenClaw's container-side browser tool can talk to us unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Backend config — enable browser + node proxy
+
+**Files:**
+- Modify: `apps/backend/core/containers/config.py:537-548` (tools block) + `build_backend_policy_patch`
+- Modify: `apps/backend/tests/unit/containers/test_config.py`
+
+Container-side flag flip. Reuses the pattern from PR #306 (exec approval) — initial write sets the shape, `build_backend_policy_patch` backfills on reprovision.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `apps/backend/tests/unit/containers/test_config.py`:
+
+```python
+def test_config_browser_enabled_with_user_profile(self):
+    """Browser tool uses the user profile (attach to real Chrome)."""
+    config = json.loads(write_openclaw_config())
+    browser = config["browser"]
+    assert browser["enabled"] is True
+    assert browser["defaultProfile"] == "user"
+    assert browser["profiles"]["user"]["driver"] == "existing-session"
+
+def test_config_node_host_browser_proxy_enabled(self):
+    """Gateway auto-routes browser tool calls to the paired node."""
+    config = json.loads(write_openclaw_config())
+    assert config["nodeHost"]["browserProxy"]["enabled"] is True
+
+def test_build_backend_policy_patch_includes_browser(self):
+    """Refresh path carries the same browser + nodeHost scalars."""
+    from core.containers.config import build_backend_policy_patch
+    patch = build_backend_policy_patch("starter")
+    assert patch["browser"]["enabled"] is True
+    assert patch["browser"]["defaultProfile"] == "user"
+    assert patch["nodeHost"]["browserProxy"]["enabled"] is True
+```
+
+- [ ] **Step 2: Update `write_openclaw_config` in config.py**
+
+Find the top-level config dict (the one returned from `write_openclaw_config`). After the existing `"tools"` block (currently ending around line 548), add:
+
+```python
+        "browser": {
+            # Enables OpenClaw's browser tool. Default profile is `user`
+            # which attaches to the user's real signed-in Chrome 144+ via
+            # chrome-devtools-mcp + CDP. No Chromium bundled in the
+            # container image.
+            "enabled": True,
+            "defaultProfile": "user",
+            "profiles": {
+                "user": {
+                    "driver": "existing-session",
+                },
+            },
+        },
+        "nodeHost": {
+            "browserProxy": {
+                # Auto-route browser tool calls to the paired desktop
+                # node. The Isol8 Tauri app runs the sidecar
+                # (openclaw/extensions/browser + chrome-devtools-mcp)
+                # colocated with Chrome on the user's Mac.
+                "enabled": True,
+            },
+        },
+```
+
+- [ ] **Step 3: Update `build_backend_policy_patch`**
+
+Find `build_backend_policy_patch` in `config.py`. Add `browser` + `nodeHost` keys:
+
+```python
+def build_backend_policy_patch(tier: str, region: str = "us-east-1") -> dict:
+    ...existing...
+    return {
+        "models": {...},
+        "agents": {...},
+        "tools": _build_exec_policy(),
+        "browser": {
+            "enabled": True,
+            "defaultProfile": "user",
+        },
+        "nodeHost": {
+            "browserProxy": {
+                "enabled": True,
+            },
+        },
+    }
+```
+
+Scalars only — no arrays in this patch (deep-merge clobbers arrays). `browser.profiles.user` is a dict, so it merges fine, but the *initial write* covers it; we don't need to ship the full `profiles` map in the patch.
+
+- [ ] **Step 4: DO NOT run tests** (deferred to Task 10 end-of-plan verification).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/core/containers/config.py apps/backend/tests/unit/containers/test_config.py
+git commit -m "$(cat <<'EOF'
+feat(backend): enable browser tool + node proxy in openclaw.json
+
+Flips two backend-controlled config scalars:
+
+  browser.enabled = true
+  browser.defaultProfile = "user"
+  browser.profiles.user.driver = "existing-session"
+  nodeHost.browserProxy.enabled = true
+
+Together they tell OpenClaw: "enable the browser tool, route its
+calls to the paired desktop node, attach to the user's signed-in
+Chrome via chrome-devtools-mcp". The desktop node's sidecar (coming
+in this PR's earlier tasks) handles the actual Chrome driving.
+
+Mirrored in build_backend_policy_patch so PATCH /debug/provision
+backfills existing containers.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Optional macOS entitlements for child-process audio/camera access
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/entitlements.plist`
+
+chrome-devtools-mcp inherits our app's sandbox when spawned. If we later want screen recording / camera / notifications *through* the browser (e.g., agent lets the page request camera), we'd need entitlements. For Phase 1 we leave entitlements untouched — pure HTTP traffic to Chrome doesn't need special access.
+
+- [ ] **Step 1: Confirm current entitlements**
+
+Read `apps/desktop/src-tauri/entitlements.plist`. If it already has `com.apple.security.network.client`, no change. If missing, add it inside the top-level `<dict>`:
+
+```xml
+<key>com.apple.security.network.client</key>
+<true/>
+```
+
+Needed so our app can hit `127.0.0.1:<sidecar_port>`. If absent, `reqwest` calls will fail silently in hardened-runtime mode.
+
+- [ ] **Step 2: Commit if changed**
+
+```bash
+git add apps/desktop/src-tauri/entitlements.plist
+git commit -m "$(cat <<'EOF'
+chore(desktop): ensure network client entitlement for sidecar loopback
+
+reqwest calls to 127.0.0.1:<sidecar_port> need this entitlement in
+hardened-runtime mode. Already present in most Tauri templates but
+locking it in explicitly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If no change, skip this task.
+
+---
+
+## Task 10: End-of-plan verification
+
+**Files:** none modified. Final sanity check before PR.
+
+- [ ] **Step 1: Build the sidecars**
+
+Run: `bash apps/desktop/src-tauri/scripts/vendor-sidecars.sh`
+Expected: prints `==> Sidecars vendored at .../src-tauri/bin`. Takes ~2 min (Node.js download + npm install).
+
+- [ ] **Step 2: Run Rust tests**
+
+Run: `cd apps/desktop/src-tauri && cargo test`
+Expected: all green including the new browser_sidecar tests.
+
+- [ ] **Step 3: Build the Tauri debug bundle**
+
+Run: `cd apps/desktop && cargo tauri build --debug`
+Expected: builds + signs an `Isol8.app` with the sidecar bundled. ~3-5 min first time.
+
+- [ ] **Step 4: Run backend tests**
+
+Run: `cd apps/backend && CLERK_ISSUER=https://up-moth-55.clerk.accounts.dev uv run pytest tests/unit/containers/test_config.py -v --no-cov`
+Expected: 45+ tests pass, including the three new browser/nodeHost assertions.
+
+- [ ] **Step 5: Smoke-test the app locally**
+
+Install the built `.app` to `/Applications/`. Launch. Sign in. In the chat:
+
+> Use the browser tool to navigate to https://example.com and snapshot the page.
+
+Expected flow (readable in `/tmp/isol8-desktop.log`):
+- `[browser-sidecar] listening on 127.0.0.1:<PORT>` within a few seconds of the first invoke.
+- Container's browser tool calls flow as `browser.proxy` invokes to our node.
+- The sidecar handles them; chrome-devtools-mcp attaches to Chrome.
+- Chrome navigates; snapshot returns.
+- Agent replies with page content.
+
+If Chrome 144+ auto-connect prompts the user — approve it.
+
+- [ ] **Step 6: Commit any follow-up fixes**
+
+If the smoke test finds issues (port not parsed, sidecar dies, etc.), fix them and commit with messages referencing what the smoke test caught. Otherwise no further commits.
+
+---
+
+## Self-Review Checklist (author runs before handoff)
+
+- [ ] Spec coverage: every section in the spec maps to a task. (Sub-problem 1 — bundling → Tasks 1-3. Sub-problem 2 — supervisor → Tasks 5-6. Sub-problem 3 — proxy handler → Task 7. Sub-problem 4 — backend → Task 8.)
+- [ ] Phase 2 onboarding UI is explicitly out of scope — noted in the "Scope" line at the top.
+- [ ] No placeholders: grep for "TBD"/"TODO"/"fill in" — none.
+- [ ] Type consistency: `BrowserSidecar`, `BrowserSidecarHandle`, `SidecarState`, `BrowserProxyParams` defined in Task 5-7; used in Task 7. Names stable across tasks.
+- [ ] Test files deferred for execution per user preference; Task 10 runs them all at the end.
+- [ ] Commands are real: `cargo tauri build --debug`, `uv run pytest`, `bash scripts/vendor-sidecars.sh` — all valid for this repo.
+
+---
+
+## Execution Handoff
+
+Plan saved to `docs/superpowers/plans/2026-04-19-desktop-browser-node.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — I execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-04-19-desktop-browser-node.md
+++ b/docs/superpowers/plans/2026-04-19-desktop-browser-node.md
@@ -2,11 +2,17 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **2026-04-19 revision note (post-Task-10 verification):** Tasks 2, 5, 6, 7 were revised after discovering the original sparse-checkout + `dist/control-service.js` launcher was broken (that file doesn't exist; the vendored extensions/browser/ is TypeScript source with no build step, and even when built would require the `openclaw` npm package's plugin-sdk at runtime). The actual shape that works — confirmed against OpenClaw v2026.4.5 source:
+> - Vendor = `npm install openclaw@v2026.4.5` in a scratch project. Browser plugin is already bundled inside the tarball at `dist/extensions/browser/` and hydrated by `scripts/postinstall-bundled-plugins.mjs`. No separate sparse-checkout.
+> - Launcher = `node node_modules/openclaw/openclaw.mjs node run --port 18789`. This is what OpenClaw's own Mac Swift app points at (see `apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift`).
+> - Port = deterministic: `gatewayPort + 2` per `src/config/port-defaults.ts:deriveDefaultBrowserControlPort`. Gateway port pinned by `--port` flag → browser control port is `18791`. `browser_sidecar.rs` no longer parses stdout; `handle_browser_proxy` no longer polls.
+> - `chrome-devtools-mcp` — not needed as a separate dep. OpenClaw's bundled browser plugin includes its own CDP attach + Playwright session management; we just speak to its HTTP API.
+
 **Goal:** Let the container's agent drive the user's real, signed-in Chrome via OpenClaw's `browser.proxy` RPC — no bundled Chromium, no custom extension.
 
-**Architecture:** Bundle Node.js + OpenClaw's `extensions/browser/` TS + `chrome-devtools-mcp` as sidecars inside our Tauri desktop app. Our Rust code supervises the subprocess and relays `browser.proxy` RPCs from the container's WebSocket to the local HTTP control service, which drives chrome-devtools-mcp via CDP to Chrome 144+.
+**Architecture:** Bundle Node.js + the `openclaw` npm package (which ships its browser plugin inside) as a sidecar in our Tauri desktop app. Our Rust code supervises the Node subprocess (running `openclaw node run`) and relays `browser.proxy` RPCs from the container's WebSocket to the OpenClaw-hosted HTTP control service on `127.0.0.1:18791`, which drives the user's Chrome via CDP.
 
-**Tech Stack:** Tauri 2 (Rust), Node.js 20 LTS (bundled), OpenClaw `extensions/browser/` (vendored), `chrome-devtools-mcp` npm package, `reqwest` for HTTP relay, `tokio::process` for subprocess, FastAPI (Python) for backend config.
+**Tech Stack:** Tauri 2 (Rust), Node.js 20 LTS (bundled), `openclaw@v2026.4.5` npm package (vendored), `reqwest` for HTTP relay, `tokio::process` for subprocess, FastAPI (Python) for backend config.
 
 **Spec:** [`docs/superpowers/specs/2026-04-19-desktop-browser-node-design.md`](../specs/2026-04-19-desktop-browser-node-design.md)
 


### PR DESCRIPTION
## Summary
- Ships Node + pinned `openclaw@v2026.4.5` as a Tauri externalBin sidecar so the container's agent can drive the user's real Chrome via `browser.proxy` RPC
- Rust supervisor (`browser_sidecar.rs`) lazy-spawns the node-host on first `browser.proxy` invoke; reqwest relays the HTTP to `127.0.0.1:18791` (OpenClaw derives this from `gatewayPort + 2`)
- Backend (`containers/config.py`) opts the container into `browser` + `nodeHost.browserProxy` in `openclaw.json`
- Mirrors OpenClaw's own macOS Swift integration pattern (`MacNodeBrowserProxy.swift`); single vendored runtime gives us the full OpenClaw browser surface (35+ endpoints)

Note: initial design used a sparse-checkout of `extensions/browser/` + a custom `control-service.js` launcher. Task 10 verification caught that the TS is a plugin (requires `openclaw/plugin-sdk/*` at runtime) not a runnable service. Refactor commit `4df5679c` switched to `npm install openclaw` + `openclaw node run`, which is what the Mac app does. Port detection dropped — deterministic from config. Net -173/+87.

## Test plan
- [ ] CI check — `cargo test` on the desktop crate (25 unit + 3 browser_sidecar integration)
- [ ] CI check — backend `test_config.py` (45 tests)
- [ ] Manual smoke: `bash scripts/vendor-sidecars.sh`; `cargo tauri build --debug`; launch Isol8 desktop; sign in; from chat, ask agent to browse a URL; confirm Chrome opens on the user's Mac and returns a snapshot
- [ ] Run the launcher directly: `bin/isol8-browser-service-aarch64-apple-darwin` should print the OpenClaw banner and bind `127.0.0.1:18791`

🤖 Generated with [Claude Code](https://claude.com/claude-code)