### PR TITLE
fix(e2e): three deploy-day fixes for personal + org flow

### DIFF
--- a/apps/frontend/tests/e2e/drivers/onboarding.ts
+++ b/apps/frontend/tests/e2e/drivers/onboarding.ts
@@ -34,6 +34,13 @@ export async function onboardOrganization(
   await page.getByRole('textbox', { name: /name/i }).fill(orgName);
   await page.getByRole('button', { name: /create|next/i }).first().click();
 
+  // Clerk's CreateOrganization shows an "Invite new members" screen after
+  // create — `skipInvitationScreen={false}` in onboarding/page.tsx. Click
+  // "Skip" so the flow can advance to /chat. Without this the page hangs
+  // on the invitation screen and the /chat URL wait below times out
+  // (verified from PR #309 deploy artifact, 2026-04-20).
+  await page.getByRole('button', { name: /^skip$/i }).click({ timeout: 30_000 });
+
   // Wait for Clerk to register the new org BEFORE waiting for any URL —
   // the org is the load-bearing teardown handle. Hand it to the caller
   // immediately so even a downstream throw still leaves cleanupUser able

--- a/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
+++ b/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
@@ -1,9 +1,8 @@
 import type { Page } from '@playwright/test';
 
 const TEST_CARD = {
-  // Stripe test card — always succeeds in test mode.
   number: '4242424242424242',
-  expiry: '1234', // MMYY, no separator (Stripe formats it)
+  expiry: '1234',
   cvc: '123',
   name: 'E2E Test',
 };
@@ -11,42 +10,47 @@ const TEST_CARD = {
 /**
  * Drive the Stripe-hosted Checkout page (`checkout.stripe.com/c/...`).
  *
- * Layout we're driving:
- *   - The `email` field is NOT filled here. The backend creates a Stripe
- *     customer with the user's email *before* opening Checkout (see
- *     `billing_service.create_checkout_session`), so Checkout is opened in
- *     `customer=...` mode and the email is pre-attached.
- *   - Card number / expiry / CVC each live inside their own iframe. Stripe
- *     sets a stable `title` attribute on these iframes that survives their
- *     UI revs better than the auto-generated `name=__privateStripeFrame…`
- *     attribute, so we locate by title.
- *   - Cardholder name and country/postal sometimes show, sometimes don't,
- *     depending on the Checkout config and detected geolocation. Both are
- *     treated as optional.
- *   - Submit button has a stable `data-testid="hosted-payment-submit-button"`.
+ * Layout (verified against the PR #309 deploy artifact, 2026-04-20):
+ *   - Top: Express Checkout iframes (Pay with Link, Amazon Pay) — ignore.
+ *   - Email field is required and NOT pre-filled — backend creates the
+ *     Stripe customer without email (separate bug). Fill it with the test
+ *     user's address.
+ *   - Payment method appears as a list of radios (Card / Cash App / Klarna
+ *     / Bank). The card NUMBER/EXPIRY/CVC iframes are NOT rendered until
+ *     the "Pay with card" button under the Card listitem is clicked.
+ *   - After expansion, fields live in iframes identified by stable `title`
+ *     attributes ("Secure card number input frame", etc).
+ *   - Submit button: stable `data-testid="hosted-payment-submit-button"`.
  */
-export async function completeStripeCheckout(page: Page): Promise<void> {
+export async function completeStripeCheckout(
+  page: Page,
+  email: string,
+): Promise<void> {
   await page.waitForURL(/checkout\.stripe\.com/, { timeout: 30_000 });
   await page.waitForLoadState('domcontentloaded');
+
+  // Email — required for new customers. Backend doesn't pre-fill (bug to
+  // fix separately). Fill it so Stripe can move on.
+  await page.getByRole('textbox', { name: /email/i }).fill(email);
+
+  // Expand the card form. The iframes don't render until this click.
+  await page.getByRole('button', { name: /pay with card/i }).click();
 
   const numberFrame = page.frameLocator('iframe[title="Secure card number input frame"]');
   const expiryFrame = page.frameLocator('iframe[title="Secure expiration date input frame"]');
   const cvcFrame = page.frameLocator('iframe[title="Secure CVC input frame"]');
 
+  // Wait for the card number iframe to actually exist before filling.
+  await numberFrame.locator('[name="cardnumber"]').waitFor({ state: 'visible', timeout: 30_000 });
   await numberFrame.locator('[name="cardnumber"]').fill(TEST_CARD.number);
   await expiryFrame.locator('[name="exp-date"]').fill(TEST_CARD.expiry);
   await cvcFrame.locator('[name="cvc"]').fill(TEST_CARD.cvc);
 
-  // Cardholder name — present on most Checkout configs but not all. Tolerate.
   const nameInput = page.locator('input[name="billingName"]');
   if (await nameInput.isVisible({ timeout: 1_000 }).catch(() => false)) {
     await nameInput.fill(TEST_CARD.name);
   }
 
   await page.getByTestId('hosted-payment-submit-button').click();
-
-  // Stripe redirects back to our success_url on success. Allow a generous
-  // window for the network round-trip (Stripe → 3DS-skip in test mode →
-  // success_url → Vercel → us).
   await page.waitForURL(/\/chat\?subscription=success/, { timeout: 60_000 });
 }

--- a/apps/frontend/tests/e2e/fixtures/stripe-admin.ts
+++ b/apps/frontend/tests/e2e/fixtures/stripe-admin.ts
@@ -18,6 +18,28 @@ export async function findCustomerByEmail(
   return list.data[0] ?? null;
 }
 
+/**
+ * Find every customer that the backend created for this owner_id,
+ * regardless of whether email was attached. The backend tags every
+ * Stripe customer with `metadata.owner_id` (verified billing_service.py),
+ * so this is the canonical way to find a test's customer for teardown.
+ *
+ * Email-based lookup misses customers whose email was never set —
+ * which happens whenever the Clerk JWT template doesn't include the
+ * email claim. Verified leak from PR #309 deploy: cus_UMsUjHET7fJ1NG.
+ */
+export async function findCustomersByOwnerId(
+  secretKey: string,
+  ownerId: string,
+): Promise<Stripe.Customer[]> {
+  const escaped = ownerId.replace(/'/g, "\\'");
+  const result = await client(secretKey).customers.search({
+    query: `metadata['owner_id']:'${escaped}'`,
+    limit: 100,
+  });
+  return result.data;
+}
+
 export async function setCustomerMetadata(
   secretKey: string,
   customerId: string,
@@ -29,9 +51,19 @@ export async function setCustomerMetadata(
 export async function cancelSubsAndDeleteCustomer(
   secretKey: string,
   email: string,
+  ownerId?: string,
 ): Promise<void> {
-  const customers = await client(secretKey).customers.list({ email, limit: 100 });
-  for (const customer of customers.data) {
+  // Collect candidates from both lookups — email-list (legacy path) AND
+  // metadata-search (catches the email=null case). Dedupe by id.
+  const seen = new Map<string, Stripe.Customer>();
+  const byEmail = await client(secretKey).customers.list({ email, limit: 100 });
+  for (const c of byEmail.data) seen.set(c.id, c);
+  if (ownerId) {
+    const byOwner = await findCustomersByOwnerId(secretKey, ownerId);
+    for (const c of byOwner) seen.set(c.id, c);
+  }
+
+  for (const customer of seen.values()) {
     const subs = await client(secretKey).subscriptions.list({
       customer: customer.id,
       status: 'all',

--- a/apps/frontend/tests/e2e/fixtures/user.ts
+++ b/apps/frontend/tests/e2e/fixtures/user.ts
@@ -16,7 +16,11 @@
 import { test as base, type Page } from '@playwright/test';
 import crypto from 'crypto';
 import { createUser, deleteUser, deleteOrg, findUserByEmail } from './clerk-admin';
-import { cancelSubsAndDeleteCustomer, findCustomerByEmail } from './stripe-admin';
+import {
+  cancelSubsAndDeleteCustomer,
+  findCustomerByEmail,
+  findCustomersByOwnerId,
+} from './stripe-admin';
 import { AuthedFetch, AuthedFetchError } from './api';
 import { DDBReader } from './ddb-reader';
 
@@ -76,8 +80,15 @@ export async function cleanupUser(user: E2EUser): Promise<void> {
   const failures: string[] = [];
 
   // 1. Stripe — cancels active subs then deletes the customer. Idempotent.
+  // Pass ownerId so we catch customers whose email field is null (the
+  // Clerk JWT template doesn't always include the email claim, so
+  // backend's create_customer_for_owner can produce email=null records
+  // that the email-based search would miss). The backend always tags the
+  // customer with metadata.owner_id, so that lookup is the canonical one.
+  // owner_id == clerkUserId in personal context, == orgId in org context.
+  const stripeOwnerId = user.orgId ?? user.clerkUserId;
   try {
-    await cancelSubsAndDeleteCustomer(stripeKey, user.email);
+    await cancelSubsAndDeleteCustomer(stripeKey, user.email, stripeOwnerId);
   } catch (err) {
     failures.push(`stripe: ${err}`);
   }
@@ -129,11 +140,16 @@ export async function cleanupUser(user: E2EUser): Promise<void> {
   //    side. 5s is enough in practice; a tighter poll would just add flakes.
   await new Promise((r) => setTimeout(r, 5000));
 
-  // 5. Hard-fail verification on external systems.
+  // 5. Hard-fail verification on external systems. Check by both email
+  // and owner_id — same defensive split as the cleanup call above.
   try {
     const stripeRemaining = await findCustomerByEmail(stripeKey, user.email);
     if (stripeRemaining) {
-      failures.push(`stripe leak: customer ${stripeRemaining.id} not deleted`);
+      failures.push(`stripe leak: customer ${stripeRemaining.id} (by-email) not deleted`);
+    }
+    const ownerRemaining = await findCustomersByOwnerId(stripeKey, stripeOwnerId);
+    for (const c of ownerRemaining) {
+      failures.push(`stripe leak: customer ${c.id} (by-owner_id) not deleted`);
     }
   } catch (err) {
     failures.push(`stripe verify: ${err}`);

--- a/apps/frontend/tests/e2e/org.spec.ts
+++ b/apps/frontend/tests/e2e/org.spec.ts
@@ -64,7 +64,7 @@ test.describe('E2E: Org happy path', () => {
     await user.page.goto('/settings');
     await user.page.getByRole('tab', { name: 'Billing' }).click();
     await user.page.getByRole('button', { name: 'Subscribe to Starter' }).click();
-    await completeStripeCheckout(user.page);
+    await completeStripeCheckout(user.page, user.email);
     await isSubscribed(user.api, true);
     await billingTier(user.api, 'starter');
   });

--- a/apps/frontend/tests/e2e/personal.spec.ts
+++ b/apps/frontend/tests/e2e/personal.spec.ts
@@ -60,7 +60,7 @@ test.describe('E2E: Personal happy path', () => {
     // Billing tab to render the plan cards.
     await user.page.getByRole('tab', { name: 'Billing' }).click();
     await user.page.getByRole('button', { name: 'Subscribe to Starter' }).click();
-    await completeStripeCheckout(user.page);
+    await completeStripeCheckout(user.page, user.email);
     await isSubscribed(user.api, true);
     await billingTier(user.api, 'starter');
   });

--- a/apps/frontend/tests/unit/e2e-helpers/cleanup.test.ts
+++ b/apps/frontend/tests/unit/e2e-helpers/cleanup.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../e2e/fixtures/clerk-admin', () => ({
 vi.mock('../../e2e/fixtures/stripe-admin', () => ({
   cancelSubsAndDeleteCustomer: vi.fn(),
   findCustomerByEmail: vi.fn(),
+  findCustomersByOwnerId: vi.fn(),
 }));
 
 import { cleanupUser, type E2EUser } from '../../e2e/fixtures/user';
@@ -22,6 +23,7 @@ import {
 import {
   cancelSubsAndDeleteCustomer,
   findCustomerByEmail,
+  findCustomersByOwnerId,
 } from '../../e2e/fixtures/stripe-admin';
 
 const ENV_KEYS = {
@@ -55,6 +57,7 @@ describe('cleanupUser', () => {
     vi.mocked(deleteUser).mockReset().mockResolvedValue();
     vi.mocked(deleteOrg).mockReset().mockResolvedValue();
     vi.mocked(findCustomerByEmail).mockReset().mockResolvedValue(null);
+    vi.mocked(findCustomersByOwnerId).mockReset().mockResolvedValue([]);
     vi.mocked(findUserByEmail).mockReset().mockResolvedValue(null);
   });
 
@@ -83,6 +86,7 @@ describe('cleanupUser', () => {
     expect(cancelSubsAndDeleteCustomer).toHaveBeenCalledWith(
       ENV_KEYS.STRIPE_SECRET_KEY,
       user.email,
+      user.clerkUserId, // owner_id == clerkUserId in personal context
     );
     expect(user.api.delete).toHaveBeenCalledWith('/debug/user-data');
     expect(deleteUser).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
First post-merge deploy of the new E2E gate (PR #309) failed on three concrete issues. All reproduced from playwright artifacts.

(Reopened from #314 — that branch was based on pre-merge `feat/e2e-rewrite` which conflicts with main after the squash merge.)

## Failures + fixes

### 1. Org Step 2 — `waitForURL('/chat')` 60s timeout
Clerk's `CreateOrganization` widget renders an "Invite new members" screen after create (`skipInvitationScreen={false}` in `apps/frontend/src/app/onboarding/page.tsx`). Test never dismissed it → page stuck on `/onboarding`. Fix: click `Skip` before `waitForURL`.

### 2. Personal Step 4 — `locator.fill: Test ended` (15-min timeout)
Stripe Checkout's card iframes don't render until the "Pay with card" button under the Card listitem is explicitly clicked — the form starts collapsed. Driver now: fills email (required, not pre-filled — see #3), clicks "Pay with card", waits for the card-number iframe, then fills card fields.

### 3. Stripe customer leak (`cus_UMsUjHET7fJ1NG`, `email=null`)
Backend creates the Stripe customer with `email=auth.email`, but the Clerk JWT template doesn't always include the `email` claim. Resulting customer has `email=null` → email-based search misses it → leak. Added `findCustomersByOwnerId` (Stripe `customers.search` by `metadata['owner_id']`); wired `cleanupUser` and the leak-verification step to use both lookups. Backend always tags `metadata.owner_id`, so that's the canonical handle.

## Pre-merge orphan sweep
Cleaned out ~7 leftover ECS services + EFS access points + DDB rows + Clerk users + the leaked Stripe customer from local debug runs before this PR.

## Test plan
- [x] 33/33 frontend e2e-helper unit tests pass
- [ ] CI lint + build + vitest
- [ ] First post-merge deploy: both `personal.spec.ts` and `org.spec.ts` reach Step 5 with zero leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)