### PR TITLE
fix(e2e): select Card radio + tolerate scale-to-zero in waitForChatReady

### DIFF
--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: 0, // journey tests have destructive side effects — no retries
   workers: 2,
-  globalTimeout: 30 * 60 * 1000, // 30 min — Step 3 alone can hit 10 min on cold-start, then Stripe Checkout + starter chat add another 5-7 min per flow
+  globalTimeout: 45 * 60 * 1000, // 45 min — Step 3 alone can hit 20 min when scale-to-zero races the gateway WS handshake on a cold start; Stripe Checkout + starter chat add another 5-7 min per flow. Both flows run in parallel (workers=2) so the gate clock is dominated by the slower flow.
   reporter: [
     ['html', { open: 'never' }],
     ['list'],

--- a/apps/frontend/tests/e2e/drivers/chat.ts
+++ b/apps/frontend/tests/e2e/drivers/chat.ts
@@ -1,19 +1,19 @@
 import { expect, type Page } from '@playwright/test';
 
 export async function waitForChatReady(page: Page): Promise<void> {
-  // Two readiness signals:
-  //   1. "Connected" — API WebSocket up (frontend ↔ backend)
-  //   2. "Ask anything" placeholder — per-agent gateway WS handshake done
-  // The agent gateway can take 1-3 min on a freshly-provisioned container
-  // because the OpenClaw process boots, opens its WS, the backend pool
-  // attaches, then the frontend reconnects through it.
-  await page.getByText('Connected').waitFor({ state: 'visible', timeout: 60_000 });
-  // The chat input's placeholder rotates ("Ask anything", suggested bootstrap
-  // text, etc.) so don't pin to placeholder text. Wait for the Send button to
-  // be present + the textbox to be enabled.
-  await page
-    .getByTestId('send-button')
-    .waitFor({ state: 'visible', timeout: 5 * 60_000 });
+  // The free-tier container can scale to zero in the gap between
+  // containerHealthy returning (status:running) and the frontend gateway-WS
+  // handshake completing (the user is "idle" from scale-to-zero's
+  // perspective during this window). When that happens the page rebounds
+  // to "Container provisioning — waiting for ECS task" and the send-button
+  // disappears. We wait for the long-budget ECS-cold-start path: as long
+  // as either provisioning or the gateway WS handshake is making progress
+  // within the 10-minute outer budget, we keep waiting (Codex re-flag from
+  // PR #314 deploy 2026-04-20).
+  await page.getByTestId('send-button').waitFor({
+    state: 'visible',
+    timeout: 10 * 60_000,
+  });
 }
 
 async function fillChatInput(page: Page, message: string): Promise<void> {

--- a/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
+++ b/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
@@ -33,8 +33,11 @@ export async function completeStripeCheckout(
   // fix separately). Fill it so Stripe can move on.
   await page.getByRole('textbox', { name: /email/i }).fill(email);
 
-  // Expand the card form. The iframes don't render until this click.
-  await page.getByRole('button', { name: /pay with card/i }).click();
+  // Select the Card payment method. Stripe Checkout in this account config
+  // shows Card / Cash App / Klarna / Bank as a radio list with NO default
+  // selection — the card iframes only render once Card is selected.
+  // Verified from PR #314 deploy artifact (2026-04-20).
+  await page.getByRole('radio', { name: 'Card' }).check();
 
   const numberFrame = page.frameLocator('iframe[title="Secure card number input frame"]');
   const expiryFrame = page.frameLocator('iframe[title="Secure expiration date input frame"]');

--- a/apps/frontend/tests/e2e/org.spec.ts
+++ b/apps/frontend/tests/e2e/org.spec.ts
@@ -14,7 +14,9 @@ import { modelUsed } from './assertions/chat';
 
 test.describe('E2E: Org happy path', () => {
   test.describe.configure({ mode: 'serial' });
-  test.setTimeout(15 * 60_000);
+  // Same as personal.spec — Step 3 cold-start can hit 20 min when scale-to-zero
+  // races the gateway WS handshake.
+  test.setTimeout(25 * 60_000);
 
   let user: E2EUser;
 

--- a/apps/frontend/tests/e2e/personal.spec.ts
+++ b/apps/frontend/tests/e2e/personal.spec.ts
@@ -14,7 +14,11 @@ import { modelUsed } from './assertions/chat';
 
 test.describe('E2E: Personal happy path', () => {
   test.describe.configure({ mode: 'serial' });
-  test.setTimeout(15 * 60_000);
+  // Per-test cap. Step 3 alone can hit 20 min on a free-tier cold start
+  // that scale-to-zeros mid-handshake (containerHealthy 10m + waitForChatReady
+  // 10m + chat round-trip 90s). 25 min gives headroom; the slow path
+  // dominates in practice.
+  test.setTimeout(25 * 60_000);
 
   let user: E2EUser;
 


### PR DESCRIPTION
Reopened from #317 (rebased onto current main).

## Failures + fixes (from PR #315 deploy)

### 1. Stripe Checkout — Card radio not selected by default
Card iframes only render once Card is selected. Driver was clicking a hidden `Pay with card` button → hung. Fix: `getByRole('radio', {name:'Card'}).check()`.

### 2. Personal Step 3 — scale-to-zero race
`containerHealthy` returned running, then scale-to-zero fired before frontend gateway-WS handshake finished. Page rebounded to "Container provisioning…". Fix: single 10-min budget on send-button (was split 60s + 5min). Per-test 15→25 min, globalTimeout 30→45 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)