### PR TITLE
fix(containers): add browser.profiles.user.color to openclaw config

### DIFF
--- a/apps/backend/core/containers/config.py
+++ b/apps/backend/core/containers/config.py
@@ -420,6 +420,10 @@ def build_backend_policy_patch(tier: str, region: str = "us-east-1") -> dict:
             "profiles": {
                 "user": {
                     "driver": "existing-session",
+                    # Required since OpenClaw bumped its config schema —
+                    # `browser.profiles.*.color` is now a required string.
+                    # Surfaces in the OpenClaw UI as the profile chip.
+                    "color": "#0066FF",
                 },
             },
         },
@@ -699,6 +703,10 @@ def write_openclaw_config(
             "profiles": {
                 "user": {
                     "driver": "existing-session",
+                    # Required since OpenClaw bumped its config schema —
+                    # `browser.profiles.*.color` is now a required string.
+                    # Surfaces in the OpenClaw UI as the profile chip.
+                    "color": "#0066FF",
                 },
             },
         },

--- a/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
+++ b/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
@@ -33,11 +33,19 @@ export async function completeStripeCheckout(
   // fix separately). Fill it so Stripe can move on.
   await page.getByRole('textbox', { name: /email/i }).fill(email);
 
-  // Select the Card payment method. Stripe Checkout in this account config
-  // shows Card / Cash App / Klarna / Bank as a radio list with NO default
-  // selection — the card iframes only render once Card is selected.
-  // Verified from PR #314 deploy artifact (2026-04-20).
-  await page.getByRole('radio', { name: 'Card' }).check();
+  // Select the Card payment method. The card iframes only render once
+  // Card is selected (verified from PR #314 deploy artifact 2026-04-20).
+  //
+  // Stripe styles the radios as visually-hidden inputs with a custom
+  // div wrapper that handles the click — playwright's .check() rejects
+  // because the underlying <input type="radio"> isn't visible/actionable
+  // and the call hangs to per-test timeout. Click the listitem (the
+  // wrapper Stripe wires the click handler onto) instead.
+  // Verified from PR #318 deploy artifact (2026-04-20).
+  await page
+    .getByRole('listitem')
+    .filter({ has: page.getByRole('radio', { name: 'Card' }) })
+    .click();
 
   const numberFrame = page.frameLocator('iframe[title="Secure card number input frame"]');
   const expiryFrame = page.frameLocator('iframe[title="Secure expiration date input frame"]');


### PR DESCRIPTION
Caught by the E2E gate (PR #319 deploy): OpenClaw is rejecting every freshly-generated openclaw.json with:

```
Config invalid
Problem:
  - browser.profiles.user.color: Invalid input: expected string, received undefined
```

Container exits immediately → backend health checks get `[Errno 111] Connect call failed` → `containerHealthy` times out at 10 min → both personal + org Step 3 fail.

Fix: add `color: "#0066FF"` to both `browser.profiles.user` blocks in `config.py` (initial-write + patch-template, both must stay in lock-step since the patch is deep-merged into existing configs on upgrade).

276/276 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)