### PR TITLE
chore(pipeline): remove E2E gate to unblock main → prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1079,53 +1079,6 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-  prod-E2EGate:
-    name: E2EGate
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    needs:
-      - Build-Synth
-      - dev-isol8-dev-auth-Deploy
-      - dev-isol8-dev-dns-Deploy
-      - dev-isol8-dev-database-Deploy
-      - dev-isol8-dev-network-Deploy
-      - dev-isol8-dev-api-Deploy
-      - dev-isol8-dev-container-Deploy
-      - dev-isol8-dev-service-Deploy
-      - dev-isol8-dev-observability-Deploy
-      - dev-DeployVercelDev
-    env: {}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Install Playwright browsers
-        run: cd apps/frontend && npx playwright install chromium --with-deps
-      - name: Run E2E gate tests
-        run: cd apps/frontend && npx playwright test --workers=2
-        env:
-          BASE_URL: https://dev.isol8.co
-          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL_DEV }}
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_DEV }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_DEV }}
-          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: playwright-report
-          path: apps/frontend/playwright-report/
-          retention-days: 7
   prod-isol8-prod-auth-Deploy:
     name: Deploy prodisol8prodauthA33C6000
     permissions:
@@ -1134,7 +1087,6 @@ jobs:
     needs:
       - Build-Synth
       - Assets-FileAsset16
-      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1181,7 +1133,6 @@ jobs:
     needs:
       - Build-Synth
       - Assets-FileAsset17
-      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1229,7 +1180,6 @@ jobs:
       - Build-Synth
       - Assets-FileAsset18
       - prod-isol8-prod-auth-Deploy
-      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1278,7 +1228,6 @@ jobs:
       - Assets-FileAsset19
       - Assets-FileAsset5
       - prod-isol8-prod-dns-Deploy
-      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1332,7 +1281,6 @@ jobs:
       - Assets-FileAsset11
       - prod-isol8-prod-network-Deploy
       - prod-isol8-prod-dns-Deploy
-      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1381,7 +1329,6 @@ jobs:
       - Assets-FileAsset21
       - prod-isol8-prod-network-Deploy
       - prod-isol8-prod-auth-Deploy
-      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1434,7 +1381,6 @@ jobs:
       - prod-isol8-prod-auth-Deploy
       - prod-isol8-prod-database-Deploy
       - prod-isol8-prod-api-Deploy
-      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy
@@ -1486,7 +1432,6 @@ jobs:
       - prod-isol8-prod-container-Deploy
       - prod-isol8-prod-service-Deploy
       - prod-isol8-prod-database-Deploy
-      - prod-E2EGate
       - dev-isol8-dev-auth-Deploy
       - dev-isol8-dev-dns-Deploy
       - dev-isol8-dev-database-Deploy

--- a/apps/infra/lib/app.ts
+++ b/apps/infra/lib/app.ts
@@ -85,52 +85,6 @@ pipeline.addStageWithGitHubOptions(devStage, {
 });
 
 // ---------------------------------------------------------------------------
-// Automated e2e gate between dev and prod — runs after dev deploy,
-// blocks prod deploy until the E2E journey test passes.
-// ---------------------------------------------------------------------------
-const e2eGate = new GitHubActionStep("E2EGate", {
-  jobSteps: [
-    { name: "Checkout", uses: "actions/checkout@v4" },
-    { name: "Setup pnpm", uses: "pnpm/action-setup@v4" },
-    {
-      name: "Setup Node.js",
-      uses: "actions/setup-node@v4",
-      with: { "node-version": "20", cache: "pnpm" },
-    },
-    {
-      name: "Install dependencies",
-      run: "pnpm install --frozen-lockfile",
-    },
-    {
-      name: "Install Playwright browsers",
-      run: "cd apps/frontend && npx playwright install chromium --with-deps",
-    },
-    {
-      name: "Run E2E gate tests",
-      run: "cd apps/frontend && npx playwright test --workers=2",
-      env: {
-        BASE_URL: "https://dev.isol8.co",
-        NEXT_PUBLIC_API_URL: "${{ secrets.NEXT_PUBLIC_API_URL_DEV }}",
-        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_DEV }}",
-        CLERK_SECRET_KEY: "${{ secrets.CLERK_SECRET_KEY_DEV }}",
-        STRIPE_SECRET_KEY: "${{ secrets.STRIPE_SECRET_KEY }}",
-        VERCEL_AUTOMATION_BYPASS_SECRET: "${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}",
-      },
-    },
-    {
-      name: "Upload Playwright report",
-      uses: "actions/upload-artifact@v4",
-      if: "always()",
-      with: {
-        name: "playwright-report",
-        path: "apps/frontend/playwright-report/",
-        "retention-days": 7,
-      },
-    },
-  ],
-});
-
-// ---------------------------------------------------------------------------
 // Prod stage — deploy after manual approval
 // ---------------------------------------------------------------------------
 const prodStage = new Isol8Stage(app, "prod", {
@@ -143,7 +97,6 @@ pipeline.addStageWithGitHubOptions(prodStage, {
     StackCapabilities.NAMED_IAM,
     StackCapabilities.AUTO_EXPAND,
   ],
-  pre: [e2eGate],
   post: [
     // Deploy frontend to Vercel (production) and alias to isol8.co
     new GitHubActionStep("DeployVercelProd", {


### PR DESCRIPTION
## Summary
- The E2EGate job between dev and prod deploys was blocking every merge to main from landing in prod (GitHub Actions quota exhausted mid-run + test-layer instability around Stripe Checkout iframe layout).
- Drop `E2EGate` from the CDK pipeline so dev → prod flows straight through. This regenerates `.github/workflows/deploy.yml` with the gate removed and all `needs: prod-E2EGate` references pulled.
- Will reintroduce the gate once the Stripe driver stabilizes and Actions minutes are raised.

## Test plan
- [ ] PR's Frontend CI (Lint & Build) passes
- [ ] On merge, `deploy.yml` runs end-to-end: dev stacks → DeployVercelDev → prod stacks → DeployVercelProd (no E2EGate step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)