### PR TITLE
chore(infra): bump prod.tag to 2026.4.5-bf9f699 — flip prod to extended image

### DIFF
--- a/openclaw-version.json
+++ b/openclaw-version.json
@@ -6,6 +6,6 @@
   "full": "alpine/openclaw:2026.4.5",
   "extendedImage": "877352799272.dkr.ecr.us-east-1.amazonaws.com/isol8/openclaw-extended",
   "dev":  { "tag": "2026.4.5-bf9f699" },
-  "prod": { "tag": "bootstrap" },
+  "prod": { "tag": "2026.4.5-bf9f699" },
   "notes": "Two image references coexist during the migration to the extended image. The legacy `image`/`tag`/`full` fields point at the upstream alpine/openclaw image used by current container-stack.ts (Task 1-8 of the plan). The new `extendedImage` + per-env `dev.tag`/`prod.tag` fields point at our custom ECR image used after Task 9 lands. The 'bootstrap' tag is a placeholder until the first CI build completes — it intentionally won't resolve, so any deploy referencing it before the first build will fail loudly."
 }


### PR DESCRIPTION
## Summary

- Prod's `prod.tag` was `"bootstrap"`, so `container-stack.ts:318-322` fell through to the legacy upstream `alpine/openclaw:2026.4.5` — no `clawhub` / `gh` / `uv` baked in.
- Flipping to `2026.4.5-bf9f699` (same tag dev has been running) so the extended multi-stage image rolls out to prod.
- Env var `CLAWHUB_WORKDIR=/home/node/.openclaw` was already set on the base task def; it just couldn't help until the CLI was actually present.

## Rollout behavior

- Deploy registers a new base task def revision and re-pins the backend's `ECS_TASK_DEFINITION` env to it.
- **Existing per-user services** keep launching from whatever revision they were registered against at provision time, so they will NOT automatically pick up the new image. To get existing users onto the extended image after deploy, trigger a re-register (no-op `resize_user_container` or delete+recreate service) per user.
- New provisions created after deploy use the new base.

## Test plan
- [ ] Prod deploy succeeds (isol8-prod-container + isol8-prod-service stacks).
- [ ] After deploy, a freshly-provisioned prod container has `which clawhub` return a path and `echo $CLAWHUB_WORKDIR` return `/home/node/.openclaw`.
- [ ] `clawhub install <slug>` lands at `/home/node/.openclaw/skills/<slug>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)