### PR TITLE
chore(infra): unblock prod task-def export bump via DEPLOY_NONCE

### DIFF
--- a/apps/infra/lib/stacks/service-stack.ts
+++ b/apps/infra/lib/stacks/service-stack.ts
@@ -595,6 +595,14 @@ export class ServiceStack extends cdk.Stack {
         CLOUD_MAP_SERVICE_ARN: props.container.cloudMapService.serviceArn,
         DYNAMODB_TABLE_PREFIX: `isol8-${env}-`,
         AGENT_CATALOG_BUCKET: agentCatalogBucket.bucketName,
+        // One-off nonce to force a service-stack template diff. The prod-container
+        // stack could not update ExportsOutputRefOpenClawTaskDefDC1884BEC2B7400A
+        // while prod-service had no pending template changes (CFN blocks export
+        // updates when a consumer is still importing the old value and has no
+        // in-flight diff to resequence). Giving the consumer a trivial change
+        // lets CDK's stack ordering reorchestrate the export refresh. Unrelated
+        // to runtime behavior; can be deleted once PR #323's prod deploy lands.
+        DEPLOY_NONCE: "2026-04-20-unlock-openclaw-taskdef-export",
         // Observability: page topic ARN for backend-initiated SNS alerts.
         // Populated after first deploy via Fn.importValue from ObservabilityStack.
         ...(props.alertPageTopicArn


### PR DESCRIPTION
## Summary

- PR #323's prod deploy rolled back because `isol8-prod-container` tried to bump the `OpenClawTaskDef` export to a new revision ARN while `isol8-prod-service` was still importing the old value with no pending template changes. CFN blocks export updates in that state.
- `isol8-dev` escaped this today because `dev.tag` was unchanged in PR #323 — no task-def update, no export change. Previous successful dev task-def bumps coincided with service-stack having pending changes that let CDK/CFN resequence the export.
- Adding a trivial `DEPLOY_NONCE` env var on the backend container forces a `service-stack` diff this run so CFN handles the export refresh correctly.

## Follow-up

Revert this env var (or replace with the planned SSM-parameter indirection) once PR #323's prod deploy lands.

## Test plan
- [ ] `isol8-prod-container` reaches `UPDATE_COMPLETE` (previously rolled back on PR #323).
- [ ] `isol8-prod-service` redeploys with the new env var on the backend container.
- [ ] Export `isol8-prod-container:ExportsOutputRefOpenClawTaskDefDC1884BEC2B7400A` is at a new revision (e.g. `:22`).
- [ ] Backend reads the new `ECS_TASK_DEFINITION` ARN; new provisions launch on the extended image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)