### PR TITLE
chore(infra): remove DEPLOY_NONCE from service-stack

### DIFF
--- a/apps/infra/lib/stacks/service-stack.ts
+++ b/apps/infra/lib/stacks/service-stack.ts
@@ -595,14 +595,6 @@ export class ServiceStack extends cdk.Stack {
         CLOUD_MAP_SERVICE_ARN: props.container.cloudMapService.serviceArn,
         DYNAMODB_TABLE_PREFIX: `isol8-${env}-`,
         AGENT_CATALOG_BUCKET: agentCatalogBucket.bucketName,
-        // One-off nonce to force a service-stack template diff. The prod-container
-        // stack could not update ExportsOutputRefOpenClawTaskDefDC1884BEC2B7400A
-        // while prod-service had no pending template changes (CFN blocks export
-        // updates when a consumer is still importing the old value and has no
-        // in-flight diff to resequence). Giving the consumer a trivial change
-        // lets CDK's stack ordering reorchestrate the export refresh. Unrelated
-        // to runtime behavior; can be deleted once PR #323's prod deploy lands.
-        DEPLOY_NONCE: "2026-04-20-unlock-openclaw-taskdef-export",
         // Observability: page topic ARN for backend-initiated SNS alerts.
         // Populated after first deploy via Fn.importValue from ObservabilityStack.
         ...(props.alertPageTopicArn


### PR DESCRIPTION
## Summary

- Follow-up to #324 — drops the one-off `DEPLOY_NONCE` env var now that prod is on the extended image.
- **Merge order:** wait for PR #324's prod deploy to land successfully (confirm `isol8-prod-container` is `UPDATE_COMPLETE` and at a fresh task-def revision). Merging this before that deploy completes would just recreate the same deadlock.

## Follow-up

The durable fix — SSM-parameter indirection on the cross-stack `openclawTaskDef.taskDefinitionArn` reference — is a separate PR so image bumps never need this dance again.

## Test plan
- [ ] PR #324's prod deploy has landed; prod is on `openclaw-extended:2026.4.5-bf9f699`.
- [ ] After this merges, prod deploy succeeds (the backend task def loses `DEPLOY_NONCE` but nothing breaks — it was never read by application code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)