### PR TITLE
chore(infra): unstick prod pipeline — .family cross-stack, revert prod.tag, drop nonce

### DIFF
--- a/apps/infra/lib/stacks/service-stack.ts
+++ b/apps/infra/lib/stacks/service-stack.ts
@@ -580,12 +580,17 @@ export class ServiceStack extends cdk.Stack {
         CONTAINER_EXECUTION_ROLE_ARN:
           props.container.taskExecutionRole.roleArn,
         ECS_CLUSTER_ARN: props.container.cluster.clusterArn,
-        // Pin to the full ARN (with revision) so the backend cloner always
-        // reads the CDK-managed base, never a per-user clone. Per-user clones
-        // register into the same family, so the family name resolves to
-        // family-latest — which can be a poisoned per-user revision and was
-        // the root cause of the CLAWHUB_WORKDIR drift incident on 2026-04-17.
-        ECS_TASK_DEFINITION: props.container.openclawTaskDef.taskDefinitionArn,
+        // Use the family name (inlined static string) rather than the full
+        // revision ARN so we don't create a cross-stack Fn::ImportValue that
+        // CFN locks on every task-def bump. The backend's cloner resolves
+        // latest-in-family at runtime; per-user clones register into the same
+        // family, but access points are always overridden in the clone so no
+        // cross-user leakage, and per-user clones inherit the CDK base's env
+        // vars so the CLAWHUB_WORKDIR drift PR #299 was reacting to can no
+        // longer recur under current code. If we later want the ARN-revision
+        // pinning back, route it through an SSM parameter so the value isn't
+        // tied to a consumer-imported export.
+        ECS_TASK_DEFINITION: props.container.openclawTaskDef.family,
         ECS_SUBNETS: privateSubnetIds,
         ECS_SECURITY_GROUP_ID:
           props.container.containerSecurityGroup.securityGroupId,
@@ -595,14 +600,6 @@ export class ServiceStack extends cdk.Stack {
         CLOUD_MAP_SERVICE_ARN: props.container.cloudMapService.serviceArn,
         DYNAMODB_TABLE_PREFIX: `isol8-${env}-`,
         AGENT_CATALOG_BUCKET: agentCatalogBucket.bucketName,
-        // One-off nonce to force a service-stack template diff. The prod-container
-        // stack could not update ExportsOutputRefOpenClawTaskDefDC1884BEC2B7400A
-        // while prod-service had no pending template changes (CFN blocks export
-        // updates when a consumer is still importing the old value and has no
-        // in-flight diff to resequence). Giving the consumer a trivial change
-        // lets CDK's stack ordering reorchestrate the export refresh. Unrelated
-        // to runtime behavior; can be deleted once PR #323's prod deploy lands.
-        DEPLOY_NONCE: "2026-04-20-unlock-openclaw-taskdef-export",
         // Observability: page topic ARN for backend-initiated SNS alerts.
         // Populated after first deploy via Fn.importValue from ObservabilityStack.
         ...(props.alertPageTopicArn

--- a/openclaw-version.json
+++ b/openclaw-version.json
@@ -6,6 +6,6 @@
   "full": "alpine/openclaw:2026.4.5",
   "extendedImage": "877352799272.dkr.ecr.us-east-1.amazonaws.com/isol8/openclaw-extended",
   "dev":  { "tag": "2026.4.5-bf9f699" },
-  "prod": { "tag": "2026.4.5-bf9f699" },
+  "prod": { "tag": "bootstrap" },
   "notes": "Two image references coexist during the migration to the extended image. The legacy `image`/`tag`/`full` fields point at the upstream alpine/openclaw image used by current container-stack.ts (Task 1-8 of the plan). The new `extendedImage` + per-env `dev.tag`/`prod.tag` fields point at our custom ECR image used after Task 9 lands. The 'bootstrap' tag is a placeholder until the first CI build completes — it intentionally won't resolve, so any deploy referencing it before the first build will fail loudly."
 }


### PR DESCRIPTION
## Summary

PR #324's nonce theory was wrong — today's deploy failed again with the same `Cannot update export ... as it is in use` error. CFN checks the consumer's **live** template, not pending changes queued in the same run, so giving service-stack a nonce diff doesn't help.

This is the **PR-A half** of a two-PR plan to roll the extended image out to everyone:

1. **Revert `openclaw-version.json` `prod.tag` → `"bootstrap"`.** Container-stack will have no task-def diff this deploy, so it can't hit the lock. Prod stays on `alpine/openclaw:2026.4.5` (upstream) — where every running task-def revision is now. Zero runtime regression.
2. **Swap `service-stack.ts:588` from `.taskDefinitionArn` → `.family`.** That's an inlined static string (`"isol8-prod-openclaw"`), not a cross-stack `Fn::ImportValue`. The coupling is gone: after deploy, `isol8-prod-container:ExportsOutputRefOpenClawTaskDef...` has no consumers.
3. **Drop `DEPLOY_NONCE`** (PR #324 leftover).

## Trade-off

`.family` reintroduces the "latest-in-family" lookup PR #299 moved away from. Currently safe:
- `CLAWHUB_WORKDIR` is on every clone now (added in PR #277, inherited by every subsequent per-user clone).
- Access point is always overridden in `_build_register_kwargs_from_base`, so no cross-user leakage even if the backend clones from a per-user revision.

Durable fix (put the revision ARN behind an SSM parameter so it's not a CFN-import) is worth doing later — filed as follow-up.

## Follow-up PR

`PR-B`: re-bump `prod.tag` → `"2026.4.5-bf9f699"`. With no consumer importing the export, container-stack updates the task-def freely. New provisions land on the extended image (clawhub baked in). Then `POST /container/updates` with `owner_id:"all"` rolls banners to every existing owner.

## Test plan

- [ ] `isol8-prod-container` deploys (no-op on task-def, expected).
- [ ] `isol8-prod-service` deploys (template diff for `ECS_TASK_DEFINITION` env, and `DEPLOY_NONCE` removal).
- [ ] After deploy, `aws cloudformation list-imports --export-name isol8-prod-container:ExportsOutputRefOpenClawTaskDefDC1884BEC2B7400A` returns empty.
- [ ] Backend reads `ECS_TASK_DEFINITION=isol8-prod-openclaw` (family), `describe_task_definition` still works on the family name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)