### PR TITLE
fix(infra): inline family string (follow-up to #326 synth break)

### DIFF
--- a/apps/infra/lib/stacks/service-stack.ts
+++ b/apps/infra/lib/stacks/service-stack.ts
@@ -590,7 +590,7 @@ export class ServiceStack extends cdk.Stack {
         // longer recur under current code. If we later want the ARN-revision
         // pinning back, route it through an SSM parameter so the value isn't
         // tied to a consumer-imported export.
-        ECS_TASK_DEFINITION: props.container.openclawTaskDef.family,
+        ECS_TASK_DEFINITION: `isol8-${env}-openclaw`,
         ECS_SUBNETS: privateSubnetIds,
         ECS_SECURITY_GROUP_ID:
           props.container.containerSecurityGroup.securityGroupId,


### PR DESCRIPTION
## Summary

#326's deploy failed at the Synthesize step — `TS2339: Property 'family' does not exist on type 'ITaskDefinition'`. The prop type `ecs.ITaskDefinition` doesn't expose `.family`; only the concrete `TaskDefinition` / `FargateTaskDefinition` classes do.

Inline the family string directly. It's defined in `container-stack.ts:290` as a literal template (`\`isol8-\${env}-openclaw\``) — duplicating it here matches the source of truth with no cross-stack plumbing. Renames will surface at grep.

## Test plan

- [ ] Synth step passes.
- [ ] `isol8-prod-service` backend task-def env has `ECS_TASK_DEFINITION=isol8-prod-openclaw`.
- [ ] Export `isol8-prod-container:ExportsOutputRefOpenClawTaskDefDC1884BEC2B7400A` becomes unused (`list-imports` returns `[]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)