### PR TITLE
ci: add manual-trigger e2e workflow (replaces removed gate)

### DIFF
--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -1,0 +1,51 @@
+name: E2E (dev) — manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'BASE_URL to test against'
+        required: false
+        default: 'https://dev.isol8.co'
+
+jobs:
+  e2e:
+    name: Playwright E2E vs dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: cd apps/frontend && npx playwright install chromium --with-deps
+
+      - name: Run E2E suite
+        run: cd apps/frontend && npx playwright test --project=chromium --grep-invert='Chat Smoke'
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL_DEV }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY_DEV }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_DEV }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/frontend/playwright-report/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/e2e-dev.yml` — a `workflow_dispatch`-only Playwright suite that runs against dev (default `https://dev.isol8.co`).
- Replaces the deploy-pipeline E2E gate (removed in #322 to unblock prod) with an on-demand verifier so we can confirm fixes (e.g. PR #321's Stripe iframe fix) without blocking the deploy path.

## Usage
```bash
gh workflow run e2e-dev.yml --repo Isol8AI/isol8
# or override BASE_URL:
gh workflow run e2e-dev.yml --repo Isol8AI/isol8 -f base_url=https://dev.isol8.co
```
Or via GitHub UI: Actions → "E2E (dev) — manual" → Run workflow.

## Test plan
- [ ] Workflow shows up under Actions tab after merge
- [ ] Manual trigger succeeds (or fails with actionable artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)