### PR TITLE
refactor(infra): route backend ECS_TASK_DEFINITION through SSM (fix cross-stack lock)

### DIFF
--- a/apps/infra/lib/isol8-stage.ts
+++ b/apps/infra/lib/isol8-stage.ts
@@ -96,6 +96,7 @@ export class Isol8Stage extends cdk.Stage {
         taskExecutionRole: container.taskExecutionRole,
         taskRole: container.taskRole,
         openclawTaskDef: container.openclawTaskDef,
+        openclawTaskDefArnParam: container.openclawTaskDefArnParam,
       },
       managementApiUrl: api.managementApiUrl,
       connectionsTableName: api.connectionsTableName,

--- a/apps/infra/lib/local-stage.ts
+++ b/apps/infra/lib/local-stage.ts
@@ -99,6 +99,7 @@ export class LocalStage extends cdk.Stage {
         taskExecutionRole: container.taskExecutionRole,
         taskRole: container.taskRole,
         openclawTaskDef: container.openclawTaskDef,
+        openclawTaskDefArnParam: container.openclawTaskDefArnParam,
       },
       managementApiUrl: api.managementApiUrl,
       connectionsTableName: api.connectionsTableName,

--- a/apps/infra/lib/stacks/container-stack.ts
+++ b/apps/infra/lib/stacks/container-stack.ts
@@ -8,6 +8,7 @@ import * as efs from "aws-cdk-lib/aws-efs";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as kms from "aws-cdk-lib/aws-kms";
 import * as servicediscovery from "aws-cdk-lib/aws-servicediscovery";
+import * as ssm from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 
 // Single source of truth for the pinned OpenClaw container image.
@@ -56,6 +57,11 @@ export class ContainerStack extends cdk.Stack {
   // reads this ARN to build per-user task defs; pinning prevents per-user
   // clones (which register into the same family) from poisoning family-latest.
   public readonly openclawTaskDef: ecs.FargateTaskDefinition;
+  // SSM parameter carrying the current task-def ARN. Consumed by service-stack
+  // via ecs.Secret.fromSsmParameter so the value travels through SSM rather
+  // than a cross-stack Fn::ImportValue — the Fn::ImportValue path made every
+  // task-def bump hit CFN's "export is in use" lock (2026-04-20 incident).
+  public readonly openclawTaskDefArnParam: ssm.StringParameter;
 
   constructor(scope: Construct, id: string, props: ContainerStackProps) {
     super(scope, id, props);
@@ -293,6 +299,33 @@ export class ContainerStack extends cdk.Stack {
       taskRole: this.taskRole,
       executionRole: this.taskExecutionRole,
     });
+
+    // Carry the revision ARN over to service-stack via SSM rather than
+    // Fn::ImportValue. A cross-stack ImportValue on a value that changes
+    // per task-def revision trips CFN's "export is in use" lock on every
+    // image bump (see 2026-04-20 incident). SSM parameters don't have that
+    // constraint, and ecs.Secret.fromSsmParameter on the consumer side
+    // resolves the value at container start — so the backend always boots
+    // pointing at the latest CDK-managed base.
+    this.openclawTaskDefArnParam = new ssm.StringParameter(
+      this,
+      "OpenClawTaskDefArnParam",
+      {
+        parameterName: `/isol8/${env}/openclaw-task-def-arn`,
+        stringValue: this.openclawTaskDef.taskDefinitionArn,
+        description:
+          "Current CDK-managed OpenClaw task-def ARN. Read by the backend (via ECS secrets valueFrom) instead of cross-stack import.",
+      },
+    );
+
+    // Keep the previously auto-generated CFN export alive across the
+    // transition. Service-stack's LIVE template still holds an
+    // Fn::ImportValue on this export; without exportValue(), CDK emits a
+    // delete for it in the new synth and CFN rejects the delete while the
+    // live consumer still imports it. Leaving this call in is harmless
+    // after the transition (no consumers, value updates freely) — remove it
+    // in a follow-up cleanup PR once both envs have deployed past the drop.
+    this.exportValue(this.openclawTaskDef.taskDefinitionArn);
 
     // Startup command — almost everything (apt packages, pip, npm globals,
     // gh, uv) is now baked into the extended OpenClaw image. We only:

--- a/apps/infra/lib/stacks/service-stack.ts
+++ b/apps/infra/lib/stacks/service-stack.ts
@@ -12,6 +12,7 @@ import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import * as servicediscovery from "aws-cdk-lib/aws-servicediscovery";
+import * as ssm from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 
 /**
@@ -55,6 +56,7 @@ export interface ServiceStackProps extends cdk.StackProps {
     taskExecutionRole: iam.IRole;
     taskRole: iam.IRole;
     openclawTaskDef: ecs.ITaskDefinition;
+    openclawTaskDefArnParam: ssm.IStringParameter;
   };
   managementApiUrl: string;
   connectionsTableName: string;
@@ -580,17 +582,8 @@ export class ServiceStack extends cdk.Stack {
         CONTAINER_EXECUTION_ROLE_ARN:
           props.container.taskExecutionRole.roleArn,
         ECS_CLUSTER_ARN: props.container.cluster.clusterArn,
-        // Use the family name (inlined static string) rather than the full
-        // revision ARN so we don't create a cross-stack Fn::ImportValue that
-        // CFN locks on every task-def bump. The backend's cloner resolves
-        // latest-in-family at runtime; per-user clones register into the same
-        // family, but access points are always overridden in the clone so no
-        // cross-user leakage, and per-user clones inherit the CDK base's env
-        // vars so the CLAWHUB_WORKDIR drift PR #299 was reacting to can no
-        // longer recur under current code. If we later want the ARN-revision
-        // pinning back, route it through an SSM parameter so the value isn't
-        // tied to a consumer-imported export.
-        ECS_TASK_DEFINITION: `isol8-${env}-openclaw`,
+        // ECS_TASK_DEFINITION is injected via `secrets` below (SSM-backed).
+        // Resolves at container start to the current CDK-managed task-def ARN.
         ECS_SUBNETS: privateSubnetIds,
         ECS_SECURITY_GROUP_ID:
           props.container.containerSecurityGroup.securityGroupId,
@@ -625,6 +618,14 @@ export class ServiceStack extends cdk.Stack {
         ),
         ENCRYPTION_KEY: ecs.Secret.fromSecretsManager(
           secretsmanager.Secret.fromSecretNameV2(this, "ImportEncryptionKey", props.secretNames.encryptionKey),
+        ),
+        // Task-def ARN comes from SSM rather than a cross-stack Fn::ImportValue.
+        // The backend reads this env var and uses it as the base to clone per-user
+        // task defs. Resolved by ECS at task start — new backend deploys always see
+        // the current CDK-managed revision. Grants ssm:GetParameters on the param's
+        // ARN to the execution role automatically.
+        ECS_TASK_DEFINITION: ecs.Secret.fromSsmParameter(
+          props.container.openclawTaskDefArnParam,
         ),
       },
       healthCheck: {


### PR DESCRIPTION
## Summary

Replaces the cross-stack `Fn::ImportValue` on the task-def revision ARN with an SSM parameter read via `ecs.Secret.fromSsmParameter`. Durable fix for the 2026-04-20 "export is in use" deploy lock.

### The core problem
`service-stack.ts` imported `container.openclawTaskDef.taskDefinitionArn` — a value that includes the task-def revision and changes on every image bump. CFN blocked the producer stack from updating or deleting an export while a consumer stack still referenced it via `Fn::ImportValue`. Every prod `prod.tag` bump attempt rolled back.

### New design
- **Producer (`container-stack.ts`):** writes the ARN into SSM at `/isol8/{env}/openclaw-task-def-arn`. Exposes the param (not the ARN) to consumers.
- **Consumer (`service-stack.ts`):** moves `ECS_TASK_DEFINITION` from `environment` → `secrets` via `ecs.Secret.fromSsmParameter(param)`. ECS resolves at task start, so a backend task refresh always sees the current revision. CDK auto-grants `ssm:GetParameters` to the execution role.
- **What the cross-stack import references now:** the SSM parameter *name* — a stable string (`/isol8/{env}/openclaw-task-def-arn`). That doesn't change per task-def revision, so the lock can't recur.

### Transitional exportValue
Prod-service's LIVE template still holds `Fn::ImportValue` on the old auto-generated export (previous deploys skipped the service-stack update). Without a workaround, CDK would emit a DELETE on that export in the new synth and CFN would reject it. I added `this.exportValue(this.openclawTaskDef.taskDefinitionArn)` in container-stack so the old export name persists through this transition. Remove in a cleanup PR once both envs have deployed past the drop.

### Deploy flow expected
- `isol8-{env}-container` deploys: keeps old export alive, adds SSM param + new auto-export for the param name.
- `isol8-{env}-service` deploys: drops old `Fn::ImportValue` on the task-def ARN, adds new `Fn::ImportValue` on the SSM param name (stable string, immune to re-lock), puts `ECS_TASK_DEFINITION` in `secrets.ValueFrom`.

### Follow-ups
- **PR-B (small):** bump `openclaw-version.json` `prod.tag` back to `"2026.4.5-bf9f699"`. With no consumer importing the task-def-revision export, container-stack can update the task-def freely and the SSM param value tracks the new ARN. New provisions land on the extended image with `clawhub`.
- **Cleanup PR:** remove `this.exportValue(...)` once both envs have settled.
- **Fleet rollout:** `POST /container/updates` with `owner_id:"all"` to queue banners for existing users.

## Test plan

- [ ] Local `npx cdk synth` is clean (verified; SSM param resource + new auto-export visible in `cdk.out/assembly-prod/prodisol8prodcontainer*.template.json`).
- [ ] `isol8-prod-container` deploys — no `UPDATE_ROLLBACK`.
- [ ] `isol8-prod-service` deploys — backend task-def env becomes `secrets.ECS_TASK_DEFINITION.ValueFrom` → SSM ARN.
- [ ] Backend restart reads SSM; `describe_task_definition` with the ARN still resolves.
- [ ] `aws ssm get-parameter --name /isol8/prod/openclaw-task-def-arn` returns the current task-def ARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)