### PR TITLE
chore(infra): bump prod.tag to extended image (re-apply PR #323)

### DIFF
--- a/openclaw-version.json
+++ b/openclaw-version.json
@@ -6,6 +6,6 @@
   "full": "alpine/openclaw:2026.4.5",
   "extendedImage": "877352799272.dkr.ecr.us-east-1.amazonaws.com/isol8/openclaw-extended",
   "dev":  { "tag": "2026.4.5-bf9f699" },
-  "prod": { "tag": "bootstrap" },
+  "prod": { "tag": "2026.4.5-bf9f699" },
   "notes": "Two image references coexist during the migration to the extended image. The legacy `image`/`tag`/`full` fields point at the upstream alpine/openclaw image used by current container-stack.ts (Task 1-8 of the plan). The new `extendedImage` + per-env `dev.tag`/`prod.tag` fields point at our custom ECR image used after Task 9 lands. The 'bootstrap' tag is a placeholder until the first CI build completes — it intentionally won't resolve, so any deploy referencing it before the first build will fail loudly."
 }


### PR DESCRIPTION
## Summary

Re-applies PR #323's `prod.tag` bump now that PR #329 decoupled the task-def ARN from a cross-stack `Fn::ImportValue` via SSM. `container-stack` can freely register a new task-def revision with the extended OpenClaw image — the SSM param value tracks the new ARN automatically, and no consumer imports the revision-embedded export.

## Expected deploy behavior

- `isol8-prod-container`: task-def resource updates → new revision (e.g. `:22`) → SSM param value updates → clean, no lock.
- `isol8-prod-service`: no diff (still reads SSM). Backend tasks keep running on the OLD SSM value until restarted; `--force-new-deployment` on the backend service picks up the new ARN.

## Follow-ups (post-deploy)

- Force a backend restart so new provisions see the new SSM value.
- Fleet rollout for existing containers via `POST /container/updates` with `owner_id:"all"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)