### PR TITLE
fix(chat): drop per-message agent_id filter — post-approval streaming

### DIFF
--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -230,18 +230,33 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
   useEffect(() => {
     return onChatMessage((msg: ChatIncomingMessage) => {
-      // Only process if we're currently streaming
+      // Gate on "am I in an active stream" — mirrors OpenClaw control-ui's
+      // own pattern, which holds a single `chatStream` string and treats
+      // "non-null chatStream" as the implicit active bubble. Only `done` /
+      // `error` / `aborted` (all tied to `chat:"final"` on the server)
+      // tear this down.
       if (!currentAssistantIdRef.current) return;
 
-      // Drop messages meant for a different agent. Heartbeat and
-      // update_available aren't tied to a specific run. Errors are
-      // allowed through even without agent_id as a safety valve —
-      // some failure paths (client-side validation, etc.) have no
-      // agent context but still need to clear the streaming state.
-      const isUntaggedBroadcast =
-        msg.type === "heartbeat" || msg.type === "update_available";
-      const isUntaggedError = msg.type === "error" && msg.agent_id === undefined;
-      if (!isUntaggedBroadcast && !isUntaggedError && msg.agent_id !== agentIdRef.current) return;
+      // NOTE: deliberately NOT filtering by msg.agent_id. OpenClaw's
+      // reference control-ui gates at the SESSION level (sessionKey equality)
+      // and then trusts the pipe; it never per-message filters by agent id.
+      // Our prior `msg.agent_id !== agentIdRef.current` drop broke the
+      // post-approval stream: OpenClaw can emit chunks without a sessionKey
+      // attached (notably after an exec approval resolves), those reach the
+      // frontend untagged, and `undefined !== "agent-xyz"` dropped them —
+      // producing the "one message behind" glitch (next sendMessage
+      // re-rendered the assistant bubble with the accumulated-but-unflushed
+      // content).
+      //
+      // Safety invariants this relies on:
+      //   - The backend already filters channel/cron-originated events
+      //     (`is_channel_session || is_cron_session` early-return in
+      //     connection_pool.py), so frontend only sees the user's own
+      //     webchat stream.
+      //   - Only one `useAgentChat` is mounted at a time (see the file-
+      //     level comment). Agent switch clears state via unmount/remount.
+      // See feedback_no_speculative_event_filtering: never add untested
+      // filters to the event pipeline.
 
       if (msg.type === "chunk") {
         // OpenClaw sends cumulative text (full response so far) in each


### PR DESCRIPTION
## Summary

Fixes the "one message behind" chat bug: after approving an exec tool, the agent's post-approval response doesn't appear until the NEXT user message lands.

## Root cause

Traced against OpenClaw's own control-ui reference (bundled at `node_modules/openclaw/dist/control-ui/assets/index-DWX0XMYb.js`). OpenClaw's client gates chat events at the OUTERMOST dispatcher with ONE check — `event.sessionKey === ui.sessionKey` — and then trusts the pipe. It never per-message filters by agent id. Approvals live in a separate `execApprovalQueue` that doesn't touch the assistant-stream state; the bubble is implicit (`chatStream != null`), torn down only on `final`/`error`/`aborted`.

Our `useAgentChat.ts:244` was doing a strict per-message filter:
```ts
if (!isUntaggedBroadcast && !isUntaggedError && msg.agent_id !== agentIdRef.current) return;
```
`undefined !== "agent-xyz"` is `true`, so any chunk without an `agent_id` tag was dropped. OpenClaw emits some events (notably around post-approval resume) without a `sessionKey` on the payload, and our backend `_transform_agent_event` only tags `agent_id` when the source event has a sessionKey — so those chunks reached the frontend untagged and vanished.

The "one message behind" was the subsequent `setMessages` call re-rendering the bubble with whatever text *did* accumulate (on the next turn's chunks, which carry a sessionKey).

## Fix

Drop the per-message `agent_id` filter. Match OpenClaw's model. Safety invariants we already depend on:
- Backend filters out channel/cron events before forwarding to the frontend (`connection_pool.py`, `is_channel_session || is_cron_session` early return).
- Only one `useAgentChat` is mounted at a time (documented in the hook). Agent switch clears state via unmount/remount.

This is the class of bug the `feedback_no_speculative_event_filtering` memory warns about — speculative filters on the event pipeline silently drop responses.

## Test plan
- [ ] Approve an exec tool mid-chat. Verify the post-approval agent output streams into the same bubble immediately, without needing to send another message.
- [ ] Confirm other agent flows (plain chat, tool_end without approval, error) are unaffected.
- [ ] No regressions on agent switch (state clears via unmount as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)