### PR TITLE
debug(chat): use console.log so entries are visible at default level

### DIFF
--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -58,8 +58,12 @@ function isChatDebugEnabled(): boolean {
 }
 function chatDebug(event: string, payload: Record<string, unknown> = {}) {
   if (!isChatDebugEnabled()) return;
+  // Using console.log rather than console.debug so entries show up at
+  // the Chrome default log level (debug is a Verbose-only level, hidden
+  // by default and a common source of "I see nothing in the console"
+  // confusion).
   // eslint-disable-next-line no-console
-  console.debug("[chat-debug]", event, { ts: Date.now(), ...payload });
+  console.log("[chat-debug]", event, { ts: Date.now(), ...payload });
   try {
     posthog?.capture?.("chat_debug", { event, ...payload });
   } catch {


### PR DESCRIPTION
## Summary

`console.debug` is filtered out in Chrome devtools unless the "Verbose" log level is explicitly enabled — a hidden setting users wouldn't know to toggle. `console.log` shows up at the default level.

Follow-up to PR #332. Same payload-scrubbing + localStorage gate, just switches the emitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)