### PR TITLE
fix(e2e): uncheck Stripe Link opt-in (phone required if checked)

### DIFF
--- a/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
+++ b/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
@@ -70,6 +70,17 @@ export async function completeStripeCheckout(
   await fillIfVisible(page.getByRole('textbox', { name: 'Cardholder name' }), TEST_CARD.name);
   await fillIfVisible(page.getByRole('textbox', { name: 'ZIP' }), TEST_CARD.zip);
 
+  // Uncheck "Save my information for faster checkout" — it's checked by
+  // default and enrolls the customer in Stripe Link, which makes Phone
+  // number a required field. Test card has no phone; submit gets rejected
+  // with a red border on Phone (verified from PR #334 e2e-dev artifact).
+  const linkOptIn = page.getByRole('checkbox', {
+    name: /save my information for faster checkout/i,
+  });
+  if (await linkOptIn.isChecked({ timeout: 2_000 }).catch(() => false)) {
+    await linkOptIn.uncheck();
+  }
+
   await page.getByTestId('hosted-payment-submit-button').click();
   await page.waitForURL(/\/chat\?subscription=success/, { timeout: 60_000 });
 }


### PR DESCRIPTION
## Summary
- PR #334 fix worked — the card form filled correctly. But submit was rejected because the default-checked **Save my information for faster checkout** (Link opt-in) makes Phone number required, and the test card has no phone.
- Uncheck the Link opt-in before clicking Subscribe.
- Verified from PR #334 e2e-dev artifact (run 24702793517): post-submit screenshot shows empty Phone with red border.

## Test plan
- [ ] Run `gh workflow run e2e-dev.yml --repo Isol8AI/isol8` after merge — both flows reach `/chat?subscription=success` and Step 5 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)