### PR TITLE
debug(gateway): log raw runId/seq/clientRunId on chat-terminal + approvalId on exec.approval.*

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -649,13 +649,27 @@ class GatewayConnection:
                 return
             if event_name != "agent":
                 state = payload.get("state", "") if isinstance(payload, dict) else ""
+                # Temporary extra fields for the post-approval chunk-routing
+                # investigation. `runId`/`seq`/`clientRunId` show up on chat
+                # events; `id` shows up on exec.approval.{requested,resolved}.
+                # Remove after the bug is diagnosed.
+                extras = ""
+                if isinstance(payload, dict):
+                    approval_id = payload.get("id", "-") if event_name.startswith("exec.approval") else "-"
+                    extras = (
+                        f" runId={payload.get('runId', '-')}"
+                        f" seq={payload.get('seq', '-')}"
+                        f" clientRunId={payload.get('clientRunId', '-')}"
+                        f" approvalId={approval_id}"
+                    )
                 logger.info(
-                    "[%s] gateway event=%s state=%s sessionKey=%s target=%s",
+                    "[%s] gateway event=%s state=%s sessionKey=%s target=%s%s",
                     self.user_id,
                     event_name,
                     state,
                     session_key[:60] if session_key else "-",
                     target_member or "broadcast",
+                    extras,
                 )
 
             if event_name == "agent":
@@ -708,12 +722,25 @@ class GatewayConnection:
                 # Delta states are skipped; agent events handle streaming.
                 state = payload.get("state", "")
                 if state in ("final", "error", "aborted"):
+                    # Temporary debug logging: dump identifying fields
+                    # (runId, seq, clientRunId) so we can tell whether
+                    # OpenClaw assigns a new runId per LLM turn or reuses
+                    # one across the whole chat.send — needed to
+                    # disambiguate the "mid-run chat.final fires before
+                    # user approves" case from a true end-of-run.
+                    # Remove once the post-approval chunk-routing bug
+                    # is diagnosed.
                     logger.info(
-                        "[%s] chat %s sessionKey=%s target=%s",
+                        "[%s] chat %s sessionKey=%s target=%s runId=%s seq=%s clientRunId=%s parentRunId=%s stopReason=%s",
                         self.user_id,
                         state,
                         session_key[:60] if session_key else "-",
                         target_member or "broadcast",
+                        payload.get("runId", "-"),
+                        payload.get("seq", "-"),
+                        payload.get("clientRunId", "-"),
+                        payload.get("parentRunId", "-"),
+                        payload.get("stopReason", "-"),
                     )
                 # Tag all chat messages with agent_id so the frontend can
                 # route responses to the correct agent conversation.


### PR DESCRIPTION
## Summary

Temporary backend instrumentation to answer the open question from the post-approval chunk-routing investigation.

Frontend instrumentation caught the bug's *effect*: `{type:"done"}` arrives at the client ~3s after `exec.approval.requested` but ~45s BEFORE the user actually clicks Allow-once. Our backend only emits that `done` on OpenClaw `chat.state==="final"`, so OpenClaw is firing `final` mid-run. We don't yet know whether it uses the same `runId` for the pre- and post-approval segments of the same user turn.

This log change captures `runId` / `seq` / `clientRunId` / `parentRunId` / `stopReason` on every terminal chat event, plus the approval `id` on `exec.approval.{requested,resolved}`, so the next CloudWatch query can chain the sequence end-to-end with the frontend's chat-debug trace.

## No behavioral change
Just log format. Rip the extras out once the bug is diagnosed.

## How we'll use it
After this deploys, repro the bug once more. I'll pull the backend logs filtered on `[<user-id>] chat` and `exec.approval` for that timeframe, match runIds between pre- and post-approval final events, and that tells us whether a runId-based or approval-set-based gate is the right fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)