### PR TITLE
fix(e2e): wait for Clerk session after Stripe redirect

### DIFF
--- a/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
+++ b/apps/frontend/tests/e2e/drivers/stripe-checkout.ts
@@ -83,6 +83,18 @@ export async function completeStripeCheckout(
 
   await page.getByTestId('hosted-payment-submit-button').click();
   await page.waitForURL(/\/chat\?subscription=success/, { timeout: 60_000 });
+
+  // After redirect, Clerk hasn't finished hydrating on the fresh /chat
+  // page yet — the very next AuthedFetch call would throw "no Clerk
+  // session on current page" (verified from PR #335 e2e-dev artifact).
+  // Wait for Clerk.session to be available before returning.
+  await page.waitForFunction(
+    () => {
+      const w = window as Window & { Clerk?: { session?: unknown } };
+      return Boolean(w.Clerk?.session);
+    },
+    { timeout: 30_000 },
+  );
 }
 
 async function fillIfVisible(locator: Locator, value: string): Promise<void> {


### PR DESCRIPTION
## Summary
- PR #335 fixed the submit (uncheck Link). Both flows now reach `/chat?subscription=success`. New error: `AuthedFetch.token: no Clerk session on current page` — Clerk hasn't hydrated yet on the fresh post-redirect page when isSubscribed fires.
- Wait for `window.Clerk.session` to be defined (max 30s) before returning from `completeStripeCheckout`.

## Test plan
- [ ] After merge, `gh workflow run e2e-dev.yml --repo Isol8AI/isol8` reaches Step 5 (starter-tier chat) on both flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)