### PR TITLE
fix(posthog): reverse-proxy through /ingest + add chunk arrival tracer

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -9,6 +9,32 @@ const nextConfig: NextConfig = {
     root: path.resolve(__dirname, '../../'),
   },
 
+  // Reverse-proxy PostHog through our own domain so ad-blockers /
+  // privacy extensions (uBlock, Brave shields, NextDNS, etc.) don't
+  // block telemetry. Requests go to isol8.co/ingest/* which Vercel
+  // rewrites to the PostHog ingestion + asset origins. Per PostHog's
+  // documented pattern: https://posthog.com/docs/advanced/proxy/nextjs
+  // Order matters: /ingest/static/* must come before the catch-all.
+  // skipTrailingSlashRedirect is required so PostHog's `decide`
+  // endpoint is reached without a 307.
+  skipTrailingSlashRedirect: true,
+  async rewrites() {
+    return [
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://us-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://us.i.posthog.com/:path*",
+      },
+      {
+        source: "/ingest/decide",
+        destination: "https://us.i.posthog.com/decide",
+      },
+    ];
+  },
+
   // Exclude heavy ML packages from Vercel's output file tracing
   // We do CLIENT-SIDE inference only, so we don't need onnxruntime-node at all
   // See: https://github.com/huggingface/transformers.js/issues/1164

--- a/apps/frontend/src/components/PostHogProvider.tsx
+++ b/apps/frontend/src/components/PostHogProvider.tsx
@@ -7,11 +7,19 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+// Route PostHog through our own domain via the Next rewrite in
+// next.config.ts ("/ingest/*" → us.i.posthog.com). Same-origin requests
+// bypass ad-blockers / privacy extensions that otherwise drop every
+// posthog call with ERR_BLOCKED_BY_CLIENT and flood the console with
+// retries. `ui_host` keeps links in the PostHog dashboard pointed at
+// the real PostHog UI.
+const POSTHOG_API_HOST = "/ingest";
+const POSTHOG_UI_HOST = "https://us.posthog.com";
 
 if (typeof window !== "undefined" && POSTHOG_KEY) {
   posthog.init(POSTHOG_KEY, {
-    api_host: POSTHOG_HOST,
+    api_host: POSTHOG_API_HOST,
+    ui_host: POSTHOG_UI_HOST,
     person_profiles: "identified_only",
     capture_pageview: false,
     capture_pageleave: true,

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -302,10 +302,34 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         });
       }
 
+      // Chunk arrival tracer (console-only — NEVER posthog, NEVER content).
+      // We need to know WHEN chunks arrive relative to approval events to
+      // decide whether the post-approval chunk-routing bug is a same-bubble
+      // or cross-bubble misrouting. Logs length only (shape, not content).
+      // Skips posthog entirely to avoid per-token volume.
+      if (msg.type === "chunk" && isChatDebugEnabled()) {
+        // eslint-disable-next-line no-console
+        console.log("[chat-debug]", "chunk_rx", {
+          ts: Date.now(),
+          content_length: msg.content?.length ?? 0,
+          msg_agent_id: msg.agent_id,
+          my_agent_id: agentIdRef.current,
+          ref: currentAssistantIdRef.current,
+          streaming: isStreamingRef.current,
+        });
+      }
+
       // Only process if we're currently streaming
       if (!currentAssistantIdRef.current) {
         if (msg.type !== "chunk" && msg.type !== "heartbeat") {
           chatDebug("chat_msg_dropped_no_ref", { msg_type: msg.type });
+        } else if (msg.type === "chunk" && isChatDebugEnabled()) {
+          // Dropped chunk — critical signal for the post-approval bug.
+          // eslint-disable-next-line no-console
+          console.log("[chat-debug]", "chunk_dropped_no_ref", {
+            ts: Date.now(),
+            content_length: msg.content?.length ?? 0,
+          });
         }
         return;
       }


### PR DESCRIPTION
## Summary — two changes

### 1. Reverse-proxy PostHog through our own domain
Ad-blockers and privacy extensions (uBlock, Brave shields, NextDNS, etc.) drop every request to `us.i.posthog.com` with `ERR_BLOCKED_BY_CLIENT`. `posthog-js` retries each event with exponential backoff, which floods the console so hard that actual debug logs become unreadable.

This is PostHog's canonical fix (https://posthog.com/docs/advanced/proxy/nextjs):
- `next.config.ts` rewrites `/ingest/*` → `us.i.posthog.com/*` and `/ingest/static/*` → `us-assets.i.posthog.com/static/*`
- `PostHogProvider.tsx` points `api_host` at `/ingest` (same-origin), keeps `ui_host` at `us.posthog.com` so dashboard links work.
- `skipTrailingSlashRedirect: true` so PostHog's `decide` endpoint isn't 307'd away.

Same-origin requests aren't blocked by URL-based ad rules, so telemetry goes through cleanly.

### 2. Chunk arrival tracer
Previously chunks were filtered from all debug logs (per-token volume). But they're the specific signal we need to diagnose the post-approval chunk-routing bug — whether chunks land during the 21.5s silent window (and get silently dropped by the null-ref gate) OR after the user's next message arrives (and displace its response).

- Logs length only (shape, no content).
- Console-only (skips posthog to avoid per-token volume).
- Gated on the existing `localStorage.chat_debug = "1"` flag — off by default.
- Also logs `chunk_dropped_no_ref` — the critical-path signal that was invisible before.

## Test plan
- [ ] Deploy lands; ad-blocker users stop seeing `ERR_BLOCKED_BY_CLIENT` retry spam.
- [ ] With `chat_debug=1`, reproduce the bug; the new `chunk_rx` / `chunk_dropped_no_ref` lines appear in the console alongside the existing trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)