### PR TITLE
fix(e2e): dismiss post-upgrade channel wizard before chat-ready wait

### DIFF
--- a/apps/frontend/tests/e2e/drivers/chat.ts
+++ b/apps/frontend/tests/e2e/drivers/chat.ts
@@ -1,6 +1,19 @@
 import { expect, type Page } from '@playwright/test';
 
 export async function waitForChatReady(page: Page): Promise<void> {
+  // After upgrading to a paid tier, the channel-onboarding wizard
+  // (Set up Telegram / Discord / WhatsApp) auto-opens and blocks the
+  // chat input — no send-button is rendered while the modal is up.
+  // Free tier never triggers this (channels are disabled). Dismiss it
+  // if present so the chat surface is reachable. Verified from PR #337
+  // e2e-dev artifact (run 24703932223, 2026-04-21) — Step 5 timed out
+  // at 10 min waiting for send-button while the Telegram wizard was
+  // covering it.
+  const wizardCancel = page.getByRole('button', { name: 'Cancel' });
+  if (await wizardCancel.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await wizardCancel.click().catch(() => {});
+  }
+
   // The free-tier container can scale to zero in the gap between
   // containerHealthy returning (status:running) and the frontend gateway-WS
   // handshake completing (the user is "idle" from scale-to-zero's


### PR DESCRIPTION
## Summary
- After Step 4 (upgrade to Starter), the channel-onboarding wizard (Set up Telegram) auto-opens and covers the chat input — no send-button is rendered while it's up. Step 5 timed out 10 min waiting for the button.
- Free tier never triggers the wizard (channels disabled), so Step 3 doesn't hit this.
- Click Cancel (tolerant — short 2s probe) at the start of `waitForChatReady`.

## Status
PRs in this chase that already landed:
- #321 (iframe enumeration) — wrong layout assumption
- #334 (native on-page inputs) — card form fills ✅
- #335 (uncheck Stripe Link) — submit accepted ✅
- #337 (wait for Clerk after redirect) — `isSubscribed` succeeds ✅

After this lands, Steps 1-4 already pass on both flows; Step 5 should now too.

## Test plan
- [ ] `gh workflow run e2e-dev.yml --repo Isol8AI/isol8` — both flows reach Step 5 completion + model assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)