### PR TITLE
fix(e2e): poll-loop in waitForChatReady (wizard appears late)

### DIFF
--- a/apps/frontend/tests/e2e/drivers/chat.ts
+++ b/apps/frontend/tests/e2e/drivers/chat.ts
@@ -1,32 +1,43 @@
 import { expect, type Page } from '@playwright/test';
 
 export async function waitForChatReady(page: Page): Promise<void> {
-  // After upgrading to a paid tier, the channel-onboarding wizard
-  // (Set up Telegram / Discord / WhatsApp) auto-opens and blocks the
-  // chat input — no send-button is rendered while the modal is up.
-  // Free tier never triggers this (channels are disabled). Dismiss it
-  // if present so the chat surface is reachable. Verified from PR #337
-  // e2e-dev artifact (run 24703932223, 2026-04-21) — Step 5 timed out
-  // at 10 min waiting for send-button while the Telegram wizard was
-  // covering it.
-  const wizardCancel = page.getByRole('button', { name: 'Cancel' });
-  if (await wizardCancel.isVisible({ timeout: 2_000 }).catch(() => false)) {
-    await wizardCancel.click().catch(() => {});
-  }
-
-  // The free-tier container can scale to zero in the gap between
+  // Poll for the send-button up to 10 min. While polling, dismiss any
+  // channel-onboarding wizard that appears (Set up Telegram / Discord /
+  // WhatsApp) — it auto-opens AFTER the WS reconnects post-upgrade, and
+  // it covers the chat input so send-button never renders.
+  //
+  // Why a loop instead of a one-shot probe: the wizard appears
+  // asynchronously after the page settles (verified from PR #339 e2e-dev
+  // artifact — at 10-min timeout, screenshot still showed the wizard
+  // covering the surface, meaning a single check at the start of
+  // waitForChatReady fires before the wizard is on-screen).
+  //
+  // Why we still need to handle the send-button being slow on free tier:
+  // the free-tier container can scale to zero in the gap between
   // containerHealthy returning (status:running) and the frontend gateway-WS
-  // handshake completing (the user is "idle" from scale-to-zero's
-  // perspective during this window). When that happens the page rebounds
-  // to "Container provisioning — waiting for ECS task" and the send-button
-  // disappears. We wait for the long-budget ECS-cold-start path: as long
-  // as either provisioning or the gateway WS handshake is making progress
-  // within the 10-minute outer budget, we keep waiting (Codex re-flag from
-  // PR #314 deploy 2026-04-20).
-  await page.getByTestId('send-button').waitFor({
-    state: 'visible',
-    timeout: 10 * 60_000,
-  });
+  // handshake completing — page rebounds to "Container provisioning —
+  // waiting for ECS task" and send-button disappears. The same loop covers
+  // that case (Codex re-flag from PR #314 deploy 2026-04-20).
+  const deadline = Date.now() + 10 * 60_000;
+  const sendButton = page.getByTestId('send-button');
+  const wizardCancel = page.getByRole('button', { name: 'Cancel' });
+
+  while (Date.now() < deadline) {
+    if (await sendButton.isVisible({ timeout: 500 }).catch(() => false)) {
+      return;
+    }
+    if (await wizardCancel.isVisible({ timeout: 500 }).catch(() => false)) {
+      await wizardCancel.click().catch(() => {});
+      // Loop again — wizard may have multiple steps or there may be a
+      // follow-up wizard for another channel.
+      continue;
+    }
+    await page.waitForTimeout(1_000);
+  }
+  throw new Error(
+    'waitForChatReady: send-button never appeared within 10 min ' +
+      '(wizard may keep reappearing or container is stuck provisioning)',
+  );
 }
 
 async function fillChatInput(page: Page, message: string): Promise<void> {


### PR DESCRIPTION
## Summary
- PR #339's one-shot Cancel probe fired before the wizard appeared. The wizard auto-opens *after* the WS reconnects post-upgrade — so by the time the probe ran, the wizard wasn't on screen, and the subsequent 10-min waitFor on send-button just sat there while the wizard then appeared and covered the surface.
- Replace with a poll loop (1s tick): return when send-button is visible, click Cancel + continue when wizard is up.
- Verified from PR #339 e2e-dev artifact (run 24704615472, 2026-04-21).

## Test plan
- [ ] `gh workflow run e2e-dev.yml --repo Isol8AI/isol8` — Step 5 completes on both flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)