### PR TITLE
fix(e2e): retry transient 5xx RPCs + handle empty agent sidebar

### DIFF
--- a/apps/frontend/tests/e2e/drivers/chat.ts
+++ b/apps/frontend/tests/e2e/drivers/chat.ts
@@ -21,22 +21,47 @@ export async function waitForChatReady(page: Page): Promise<void> {
   const deadline = Date.now() + 10 * 60_000;
   const sendButton = page.getByTestId('send-button');
   const wizardCancel = page.getByRole('button', { name: 'Cancel' });
+  const emptyState = page.getByText('Select an agent', { exact: false });
+  let lastRefresh = Date.now();
 
   while (Date.now() < deadline) {
-    if (await sendButton.isVisible({ timeout: 500 }).catch(() => false)) {
+    // Ready: send-button visible AND enabled. Playwright's click waits
+    // for actionability, but we've seen it hang 25 min on a disabled
+    // send-button (no agent selected because agents.list returned empty).
+    if (
+      (await sendButton.isVisible({ timeout: 500 }).catch(() => false)) &&
+      (await sendButton.isEnabled({ timeout: 500 }).catch(() => false))
+    ) {
       return;
     }
+
+    // Dismiss the channel-onboarding wizard if it's up — it covers the
+    // chat input so send-button never renders.
     if (await wizardCancel.isVisible({ timeout: 500 }).catch(() => false)) {
       await wizardCancel.click().catch(() => {});
-      // Loop again — wizard may have multiple steps or there may be a
-      // follow-up wizard for another channel.
       continue;
     }
+
+    // "Select an agent" empty state = agents.list returned empty even
+    // though the container is healthy. Refresh the page every 60s to
+    // re-run agents.list; if a stale cached result is the issue, a fresh
+    // fetch will pick up the newly-created agent. Verified from PR #340
+    // e2e-dev artifact (run 24705367375) — personal Step 3 screenshot
+    // showed empty sidebar + disabled send.
+    if (
+      (await emptyState.isVisible({ timeout: 500 }).catch(() => false)) &&
+      Date.now() - lastRefresh > 60_000
+    ) {
+      await page.reload().catch(() => {});
+      lastRefresh = Date.now();
+      continue;
+    }
+
     await page.waitForTimeout(1_000);
   }
   throw new Error(
-    'waitForChatReady: send-button never appeared within 10 min ' +
-      '(wizard may keep reappearing or container is stuck provisioning)',
+    'waitForChatReady: send-button never enabled within 10 min ' +
+      '(wizard persisting, empty agent list, or container stuck provisioning)',
   );
 }
 

--- a/apps/frontend/tests/e2e/fixtures/api.ts
+++ b/apps/frontend/tests/e2e/fixtures/api.ts
@@ -56,16 +56,27 @@ export class AuthedFetch {
   }
 
   private async send(method: string, path: string, body?: unknown): Promise<Response> {
-    const token = await this.token();
-    return fetch(`${this.apiUrl}${path}`, {
-      method,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        'X-E2E-Run-Id': this.runId,
-      },
-      body: body ? JSON.stringify(body) : undefined,
-    });
+    // Retry on transient 502/503/504 — the gateway proxies RPC to the
+    // user's OpenClaw container over WebSocket, and during an upgrade
+    // (free→starter) the container is reconfigured (model swap) and the
+    // gateway briefly returns "Gateway RPC call failed" (502). Up to 5
+    // attempts with 2s backoff covers typical reconfig windows. Non-5xx
+    // errors return immediately.
+    for (let attempt = 0; ; attempt++) {
+      const token = await this.token();
+      const res = await fetch(`${this.apiUrl}${path}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'X-E2E-Run-Id': this.runId,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      const transient = res.status === 502 || res.status === 503 || res.status === 504;
+      if (!transient || attempt >= 4) return res;
+      await new Promise((r) => setTimeout(r, 2_000));
+    }
   }
 
   private async unwrap<T>(method: string, path: string, res: Response): Promise<T> {


### PR DESCRIPTION
## Summary
Two flaky issues surfaced by PR #340 e2e-dev run (24705367375):

1. **Org Step 5** — chat worked (screenshot shows agent 'Thinking…' after `Say \"hi\"` sent), but the follow-up `modelUsed()` RPC returned `POST /container/rpc 502: Gateway RPC call failed`. Gateway briefly 502s during the free→starter container reconfig (model swap).
   → Retry transient 5xx (502/503/504) in `AuthedFetch.send`: up to 5 attempts with 2s backoff.

2. **Personal Step 3** — container healthy + 'Connected', but sidebar empty ('Select an agent'). Send-button disabled; `click()` hung 25 min on actionability.
   → `waitForChatReady` requires send-button visible **and enabled**, and reloads every 60s if the empty state is showing.

## Stripe checkout chain landed in previous PRs
Steps 1-4 are passing on both flows. This PR targets the Step 5 RPC flakiness and the Step 3 empty-agent flake.

## Test plan
- [ ] `gh workflow run e2e-dev.yml --repo Isol8AI/isol8` — entire suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)