### PR TITLE
fix(e2e): ready signal is send-button visible (not 'Start a conversation')

### DIFF
--- a/apps/frontend/tests/e2e/drivers/chat.ts
+++ b/apps/frontend/tests/e2e/drivers/chat.ts
@@ -1,33 +1,33 @@
 import { expect, type Page } from '@playwright/test';
 
 export async function waitForChatReady(page: Page): Promise<void> {
-  // Ready signal: the "Start a conversation with your agent" paragraph is
-  // visible. That paragraph only renders when an agent is selected and
-  // loaded — so it differentiates "agent loaded, input empty (send
-  // disabled — normal)" from "no agent selected, send disabled (broken
-  // state)". Previous attempts waited for the send-button to be
-  // visible+enabled, which fails on the legitimate "empty input" state
-  // (verified from PR #341 e2e-dev artifact run 24714987157 — send-button
-  // was correctly disabled because the textbox had no user text yet; the
-  // agent was fully loaded).
+  // Ready signal: the send-button is VISIBLE. It may be disabled (empty
+  // input, no agent selected, or container provisioning) — that's fine
+  // for readiness; sendMessageAndWaitForResponse fills the input first
+  // which enables it. What we're checking is that the chat surface has
+  // rendered at all.
+  //
+  // History from PR #342 (run 24721205698): tried "Start a conversation"
+  // paragraph as the ready signal — but that only renders on a fresh
+  // agent with no history. Step 5 reuses Step 3's chat history so the
+  // paragraph is absent; waitForChatReady timed out while the chat
+  // surface was in fact fully ready.
   //
   // While polling, also dismiss the channel-onboarding wizard (Set up
   // Telegram / Discord / WhatsApp) if it appears — it auto-opens after
   // the WS reconnects post-upgrade and covers the chat input. And reload
   // the page every 60s if the "Select an agent" empty state is stuck —
-  // agents.list sometimes returns empty during the container cold-start
-  // race (verified from PR #340 artifact run 24705367375 — personal Step
-  // 3 showed empty sidebar + disabled send, click hung 25 min).
+  // agents.list sometimes returns empty during container cold-start
+  // (PR #340 run 24705367375: empty sidebar + disabled send, click hung
+  // 25 min).
   const deadline = Date.now() + 10 * 60_000;
-  const readyHeading = page.getByText('Start a conversation with', {
-    exact: false,
-  });
+  const sendButton = page.getByTestId('send-button');
   const wizardCancel = page.getByRole('button', { name: 'Cancel' });
   const emptyState = page.getByText('Select an agent', { exact: false });
   let lastRefresh = Date.now();
 
   while (Date.now() < deadline) {
-    if (await readyHeading.isVisible({ timeout: 500 }).catch(() => false)) {
+    if (await sendButton.isVisible({ timeout: 500 }).catch(() => false)) {
       return;
     }
     if (await wizardCancel.isVisible({ timeout: 500 }).catch(() => false)) {
@@ -45,9 +45,8 @@ export async function waitForChatReady(page: Page): Promise<void> {
     await page.waitForTimeout(1_000);
   }
   throw new Error(
-    'waitForChatReady: chat-ready signal ("Start a conversation") never ' +
-      'appeared within 10 min (wizard persisting, empty agent list, or ' +
-      'container stuck provisioning)',
+    'waitForChatReady: send-button never became visible within 10 min ' +
+      '(wizard persisting, empty agent list, or container stuck provisioning)',
   );
 }
 
@@ -72,8 +71,8 @@ export async function sendMessageAndWaitForResponse(
 
   await fillChatInput(page, message);
   // Click with a short explicit timeout — if actionability fails fast,
-  // the test budget won't be consumed by a 25-min retry loop. Falls back
-  // to standard click if the element is actionable.
+  // the test budget won't be consumed by a 25-min retry loop (PR #340
+  // run 24704615472: click() hung full test budget on disabled button).
   await page.getByTestId('send-button').click({ timeout: 30_000 });
 
   // Wait for a strictly-newer assistant message to appear and contain text.


### PR DESCRIPTION
## Summary
PR #342's 'Start a conversation with your agent' signal only renders on a fresh agent with no history. Step 5 reuses Step 3's history on the same agent — the paragraph is absent, so waitForChatReady timed out 10 min while the chat was in fact ready.

Back to **send-button visibility** as the signal. DOM snapshot from PR #342 run confirmed `button 'Send message' [disabled]` was present and visible — just disabled because input was empty. sendMessageAndWaitForResponse fills the input first which enables the button.

Keep wizard-dismiss + reload-on-empty-state from PR #341.

## Status (from PR #342 run)
Steps 1-4 pass on both flows. Step 5 should now too.

## Test plan
- [ ] `gh workflow run e2e-dev.yml --repo Isol8AI/isol8` — entire suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)