### PR TITLE
fix(e2e): modelUsed swallows transient 5xx + 3-min budget

### DIFF
--- a/apps/frontend/tests/e2e/assertions/chat.ts
+++ b/apps/frontend/tests/e2e/assertions/chat.ts
@@ -1,4 +1,4 @@
-import type { AuthedFetch } from '../fixtures/api';
+import { AuthedFetchError, type AuthedFetch } from '../fixtures/api';
 
 type Session = { sessionKey?: string; usage?: { model?: string } };
 type SessionsListResponse = { sessions?: Session[] };
@@ -8,18 +8,35 @@ export async function modelUsed(
   expectedModel: string,
   opts: { timeoutMs?: number } = {},
 ): Promise<void> {
-  const deadline = Date.now() + (opts.timeoutMs ?? 30_000);
+  // 3-minute budget — after a free→starter upgrade, the gateway RPC path
+  // briefly returns 502 "Gateway RPC call failed" while the OpenClaw
+  // container reconfigures (model swap + config watcher reload). That
+  // window can exceed the AuthedFetch internal retry (5 × 2s = 10s), so
+  // we wrap the whole poll in a longer budget and explicitly swallow
+  // transient 5xx to keep trying. PR #343 e2e-dev artifact (run
+  // 24725288866, 2026-04-21) hit this — 502 on modelUsed ~12s after
+  // Step 4 completed.
+  const deadline = Date.now() + (opts.timeoutMs ?? 3 * 60_000);
   while (Date.now() < deadline) {
-    const data = await api.post<SessionsListResponse>('/container/rpc', {
-      method: 'sessions.list',
-      params: {},
-    });
-    const sessions = data.sessions ?? [];
-    const used = sessions.flatMap((s) => (s.usage?.model ? [s.usage.model] : []));
-    if (used.some((m) => m === expectedModel)) return;
+    try {
+      const data = await api.post<SessionsListResponse>('/container/rpc', {
+        method: 'sessions.list',
+        params: {},
+      });
+      const sessions = data.sessions ?? [];
+      const used = sessions.flatMap((s) => (s.usage?.model ? [s.usage.model] : []));
+      if (used.some((m) => m === expectedModel)) return;
+    } catch (err) {
+      // Swallow transient 5xx — the gateway is temporarily disconnected
+      // from the reconfiguring container. Let any other error propagate
+      // so real bugs surface fast.
+      if (!(err instanceof AuthedFetchError) || err.status < 500 || err.status >= 600) {
+        throw err;
+      }
+    }
     await new Promise((r) => setTimeout(r, 2000));
   }
   throw new Error(
-    `modelUsed: expected ${expectedModel}, none of the recent sessions matched`,
+    `modelUsed: expected ${expectedModel}, never observed within 3 min`,
   );
 }


### PR DESCRIPTION
## Summary
PR #341 retries 5xx inside `AuthedFetch.send` (5 × 2s = 10s). But `modelUsed`'s 30s outer budget bails on the first AuthedFetchError — so one persistent 502 at start of polling ends the assertion before the container finishes its post-upgrade reconfig.

Bump the outer budget to 3 min and catch `AuthedFetchError` with 5xx explicitly.

## Status (from PR #343 run 24725288866)
Steps 1-4 pass on both flows. Step 5 chat succeeds. Only `modelUsed` RPC errors with 502 ~12s into Step 5 — gateway recovers shortly after but the test already bailed.

## Test plan
- [ ] `gh workflow run e2e-dev.yml --repo Isol8AI/isol8` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)