### PR TITLE
fix(e2e): click Refresh when provisioning stuck + longer model budget

### DIFF
--- a/apps/frontend/tests/e2e/assertions/chat.ts
+++ b/apps/frontend/tests/e2e/assertions/chat.ts
@@ -16,7 +16,7 @@ export async function modelUsed(
   // transient 5xx to keep trying. PR #343 e2e-dev artifact (run
   // 24725288866, 2026-04-21) hit this — 502 on modelUsed ~12s after
   // Step 4 completed.
-  const deadline = Date.now() + (opts.timeoutMs ?? 3 * 60_000);
+  const deadline = Date.now() + (opts.timeoutMs ?? 5 * 60_000);
   while (Date.now() < deadline) {
     try {
       const data = await api.post<SessionsListResponse>('/container/rpc', {
@@ -37,6 +37,6 @@ export async function modelUsed(
     await new Promise((r) => setTimeout(r, 2000));
   }
   throw new Error(
-    `modelUsed: expected ${expectedModel}, never observed within 3 min`,
+    `modelUsed: expected ${expectedModel}, never observed within 5 min`,
   );
 }

--- a/apps/frontend/tests/e2e/drivers/chat.ts
+++ b/apps/frontend/tests/e2e/drivers/chat.ts
@@ -20,11 +20,13 @@ export async function waitForChatReady(page: Page): Promise<void> {
   // agents.list sometimes returns empty during container cold-start
   // (PR #340 run 24705367375: empty sidebar + disabled send, click hung
   // 25 min).
-  const deadline = Date.now() + 10 * 60_000;
+  const deadline = Date.now() + 15 * 60_000;
   const sendButton = page.getByTestId('send-button');
   const wizardCancel = page.getByRole('button', { name: 'Cancel' });
   const emptyState = page.getByText('Select an agent', { exact: false });
+  const refreshButton = page.getByRole('button', { name: 'Refresh' });
   let lastRefresh = Date.now();
+  let lastRefreshClick = 0;
 
   while (Date.now() < deadline) {
     if (await sendButton.isVisible({ timeout: 500 }).catch(() => false)) {
@@ -32,6 +34,19 @@ export async function waitForChatReady(page: Page): Promise<void> {
     }
     if (await wizardCancel.isVisible({ timeout: 500 }).catch(() => false)) {
       await wizardCancel.click().catch(() => {});
+      continue;
+    }
+    // "Connecting to AI gateway…" + "Taking longer than expected" +
+    // a Refresh button appears when the container is slow to provision.
+    // Click Refresh to kick the gateway handshake along. Verified from
+    // PR #344 e2e-dev artifact (run 24727433942, 2026-04-21) — org Step
+    // 3 screenshot showed this state after 17 min.
+    if (
+      (await refreshButton.isVisible({ timeout: 500 }).catch(() => false)) &&
+      Date.now() - lastRefreshClick > 30_000
+    ) {
+      await refreshButton.click().catch(() => {});
+      lastRefreshClick = Date.now();
       continue;
     }
     if (
@@ -45,7 +60,7 @@ export async function waitForChatReady(page: Page): Promise<void> {
     await page.waitForTimeout(1_000);
   }
   throw new Error(
-    'waitForChatReady: send-button never became visible within 10 min ' +
+    'waitForChatReady: send-button never became visible within 15 min ' +
       '(wizard persisting, empty agent list, or container stuck provisioning)',
   );
 }

--- a/apps/frontend/tests/e2e/org.spec.ts
+++ b/apps/frontend/tests/e2e/org.spec.ts
@@ -16,7 +16,7 @@ test.describe('E2E: Org happy path', () => {
   test.describe.configure({ mode: 'serial' });
   // Same as personal.spec — Step 3 cold-start can hit 20 min when scale-to-zero
   // races the gateway WS handshake.
-  test.setTimeout(25 * 60_000);
+  test.setTimeout(35 * 60_000);
 
   let user: E2EUser;
 

--- a/apps/frontend/tests/e2e/personal.spec.ts
+++ b/apps/frontend/tests/e2e/personal.spec.ts
@@ -18,7 +18,7 @@ test.describe('E2E: Personal happy path', () => {
   // that scale-to-zeros mid-handshake (containerHealthy 10m + waitForChatReady
   // 10m + chat round-trip 90s). 25 min gives headroom; the slow path
   // dominates in practice.
-  test.setTimeout(25 * 60_000);
+  test.setTimeout(35 * 60_000);
 
   let user: E2EUser;
 


### PR DESCRIPTION
## Summary
Findings from PR #344 e2e-dev artifact (run 24727433942):

1. **Org Step 3**: screenshot showed 17+ min in 'Connecting to AI gateway… / Preparing workspace / Taking longer than expected' with a Refresh button.
   → waitForChatReady clicks Refresh (throttled to once per 30s).
   → Bump waitForChatReady budget 10→15 min.

2. **Personal Step 5**: modelUsed 3-min budget exhausted — config patch (minimax→qwen3-vl-235b) hasn't propagated through chokidar EFS polling in time.
   → Bump to 5 min.

3. Per-test setTimeout 25→35 min to absorb the extended budgets.

## Test plan
- [ ] `gh workflow run e2e-dev.yml --repo Isol8AI/isol8` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)