### PR TITLE
fix(e2e): tolerate provider prefix in modelUsed + log last-seen

### DIFF
--- a/apps/frontend/tests/e2e/assertions/chat.ts
+++ b/apps/frontend/tests/e2e/assertions/chat.ts
@@ -17,6 +17,7 @@ export async function modelUsed(
   // 24725288866, 2026-04-21) hit this — 502 on modelUsed ~12s after
   // Step 4 completed.
   const deadline = Date.now() + (opts.timeoutMs ?? 5 * 60_000);
+  let lastSeen: string[] = [];
   while (Date.now() < deadline) {
     try {
       const data = await api.post<SessionsListResponse>('/container/rpc', {
@@ -25,7 +26,18 @@ export async function modelUsed(
       });
       const sessions = data.sessions ?? [];
       const used = sessions.flatMap((s) => (s.usage?.model ? [s.usage.model] : []));
-      if (used.some((m) => m === expectedModel)) return;
+      lastSeen = used;
+      // Tolerate provider prefix — the backend config stores
+      // "amazon-bedrock/qwen.qwen3-vl-235b-a22b" while some session
+      // usage records strip the "amazon-bedrock/" prefix
+      // (bedrock_pricing.py uses the bare id; apps/backend/core/config.py
+      // uses the prefixed form). Match either (PR #345 e2e-dev artifact
+      // run 24729067287, 2026-04-21: modelUsed never matched the bare-id
+      // expected value).
+      const suffix = expectedModel.replace(/^.*\//, '');
+      if (used.some((m) => m === expectedModel || m === suffix || m.endsWith(`/${suffix}`))) {
+        return;
+      }
     } catch (err) {
       // Swallow transient 5xx — the gateway is temporarily disconnected
       // from the reconfiguring container. Let any other error propagate
@@ -37,6 +49,7 @@ export async function modelUsed(
     await new Promise((r) => setTimeout(r, 2000));
   }
   throw new Error(
-    `modelUsed: expected ${expectedModel}, never observed within 5 min`,
+    `modelUsed: expected ${expectedModel}, never observed within 5 min. ` +
+      `Last seen models across sessions: [${lastSeen.join(', ')}]`,
   );
 }


### PR DESCRIPTION
## Summary
Backend stores \`amazon-bedrock/qwen.qwen3-vl-235b-a22b\` in agent config but session usage may report the bare id depending on pipeline path. Test exact-match fails either way.

- Match expected model by equals, bare-suffix, or \`/<suffix>\` endsWith
- Log last-seen session models on timeout (so next failure tells us the real string)

## Status
After PR #345, Steps 1-4 pass both flows. Step 5 fails only on the model-name comparison. If backend HAS swapped the model, this PR makes the test recognize it. If backend HASN'T swapped, the new log message will tell us what model sessions are recording.

## Test plan
- [ ] \`gh workflow run e2e-dev.yml --repo Isol8AI/isol8\` — either green, or fails with an informative "Last seen models" list

🤖 Generated with [Claude Code](https://claude.com/claude-code)