### PR TITLE
fix(e2e): pass includeGlobal/includeUnknown to sessions.list

### DIFF
--- a/apps/frontend/tests/e2e/assertions/chat.ts
+++ b/apps/frontend/tests/e2e/assertions/chat.ts
@@ -22,7 +22,14 @@ export async function modelUsed(
     try {
       const data = await api.post<SessionsListResponse>('/container/rpc', {
         method: 'sessions.list',
-        params: {},
+        params: {
+          // Match SessionsPanel defaults — without these, sessions.list
+          // returns a narrow scope and the agent's chat session isn't
+          // included (verified from PR #346 e2e-dev artifact run
+          // 24734250785, 2026-04-21: "Last seen models: []").
+          includeGlobal: true,
+          includeUnknown: true,
+        },
       });
       const sessions = data.sessions ?? [];
       const used = sessions.flatMap((s) => (s.usage?.model ? [s.usage.model] : []));


### PR DESCRIPTION
## Summary
PR #346's diagnostic 'Last seen models: []' revealed the real problem — sessions.list was returning zero sessions even though the chat completed successfully. Frontend's SessionsPanel passes \`includeGlobal:true\` + \`includeUnknown:true\` by default — without these the RPC returns a narrow scope that excludes the agent's chat sessions.

## Test plan
- [ ] \`gh workflow run e2e-dev.yml --repo Isol8AI/isol8\` — Step 5 recognizes the session and modelUsed matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)