### PR TITLE
feat(gateway): forward runId on chat stream events (backend half of multi-bubble fix)

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -294,56 +294,59 @@ class GatewayConnection:
         - ``stream: "assistant"`` events with text are forwarded as chunks.
         - ``stream: "reasoning"`` / ``"thinking"`` events are forwarded for real-time thinking.
         - ``stream: "tool"`` events are forwarded as tool_start/tool_end/tool_error.
+
+        The OpenClaw ``runId`` on the source payload is propagated onto every
+        transformed event so the frontend can route chunks/tools to the
+        correct per-run assistant bubble (multi-bubble rendering).
         """
         stream = payload.get("stream")
         data = payload.get("data")
         if not isinstance(data, dict):
             return None
 
+        transformed: dict | None = None
+
         if stream == "assistant":
             text = data.get("text", "")
             if text:
-                return {"type": "chunk", "content": text}
-            return None
+                transformed = {"type": "chunk", "content": text}
 
-        if stream in ("reasoning", "thinking"):
+        elif stream in ("reasoning", "thinking"):
             text = data.get("text", "")
             if text:
-                return {"type": "thinking", "content": text}
-            return None
+                transformed = {"type": "thinking", "content": text}
 
-        if stream == "tool":
+        elif stream == "tool":
             phase = data.get("phase", "")
             name = data.get("name", "")
-            if not name:
-                return None
-            tool_call_id = data.get("toolCallId", "")
-            if phase == "start":
-                # OpenClaw never strips `args` — it's safe to forward at any
-                # verboseLevel. Shows the user what the tool was called with.
-                msg: dict = {"type": "tool_start", "tool": name}
-                if tool_call_id:
-                    msg["toolCallId"] = tool_call_id
-                if "args" in data:
-                    msg["args"] = data["args"]
-                return msg
-            if phase == "result":
-                # OpenClaw signals tool errors via isError flag on the result
-                # phase, not a separate "error" phase. `result` and `meta`
-                # are only populated when verboseLevel is "full" (set in
-                # agents.defaults.verboseDefault).
-                is_error = bool(data.get("isError"))
-                msg = {"type": "tool_error" if is_error else "tool_end", "tool": name}
-                if tool_call_id:
-                    msg["toolCallId"] = tool_call_id
-                if "result" in data:
-                    msg["result"] = data["result"]
-                if data.get("meta"):
-                    msg["meta"] = data["meta"]
-                return msg
+            if name:
+                tool_call_id = data.get("toolCallId", "")
+                if phase == "start":
+                    transformed = {"type": "tool_start", "tool": name}
+                    if tool_call_id:
+                        transformed["toolCallId"] = tool_call_id
+                    if "args" in data:
+                        transformed["args"] = data["args"]
+                elif phase == "result":
+                    is_error = bool(data.get("isError"))
+                    transformed = {
+                        "type": "tool_error" if is_error else "tool_end",
+                        "tool": name,
+                    }
+                    if tool_call_id:
+                        transformed["toolCallId"] = tool_call_id
+                    if "result" in data:
+                        transformed["result"] = data["result"]
+                    if data.get("meta"):
+                        transformed["meta"] = data["meta"]
+
+        if transformed is None:
             return None
 
-        return None
+        run_id = payload.get("runId")
+        if run_id:
+            transformed["runId"] = run_id
+        return transformed
 
     @staticmethod
     def _extract_thinking_text(payload: dict) -> str | None:

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -748,6 +748,8 @@ class GatewayConnection:
                 # Tag all chat messages with agent_id so the frontend can
                 # route responses to the correct agent conversation.
                 event_agent_id = parsed_key.get("agent_id")
+                # runId lets the frontend route to a per-run assistant bubble.
+                run_id = payload.get("runId") if isinstance(payload, dict) else None
                 if state == "final":
                     put_metric("chat.message.count")
                     # Deliver thinking from content blocks for models that
@@ -760,6 +762,8 @@ class GatewayConnection:
                         fwd: dict = {"type": "thinking", "content": thinking_text}
                         if event_agent_id:
                             fwd["agent_id"] = event_agent_id
+                        if run_id:
+                            fwd["runId"] = run_id
                         self._forward_to_frontends(fwd, target_member)
                     # OpenClaw guarantees the full text reached us via agent
                     # stream="assistant" events (with flushBufferedChatDeltaIfNeeded
@@ -767,6 +771,8 @@ class GatewayConnection:
                     fwd = {"type": "done"}
                     if event_agent_id:
                         fwd["agent_id"] = event_agent_id
+                    if run_id:
+                        fwd["runId"] = run_id
                     self._forward_to_frontends(fwd, target_member)
                 elif state == "error":
                     put_metric("chat.error", dimensions={"reason": "agent_error"})
@@ -779,12 +785,16 @@ class GatewayConnection:
                     fwd = {"type": "error", "message": err_msg}
                     if event_agent_id:
                         fwd["agent_id"] = event_agent_id
+                    if run_id:
+                        fwd["runId"] = run_id
                     self._forward_to_frontends(fwd, target_member)
                 elif state == "aborted":
                     put_metric("chat.error", dimensions={"reason": "aborted"})
                     fwd = {"type": "error", "message": "Agent run was cancelled"}
                     if event_agent_id:
                         fwd["agent_id"] = event_agent_id
+                    if run_id:
+                        fwd["runId"] = run_id
                     self._forward_to_frontends(fwd, target_member)
 
             else:

--- a/apps/backend/tests/unit/core/test_connection_pool.py
+++ b/apps/backend/tests/unit/core/test_connection_pool.py
@@ -389,6 +389,67 @@ class TestTransformAgentEvent:
         payload = {"stream": "assistant"}
         assert GatewayConnection._transform_agent_event(payload) is None
 
+    def test_forwards_run_id_on_chunk(self):
+        payload = {
+            "stream": "assistant",
+            "runId": "run-abc-123",
+            "data": {"text": "Hello"},
+        }
+        result = GatewayConnection._transform_agent_event(payload)
+        assert result == {
+            "type": "chunk",
+            "content": "Hello",
+            "runId": "run-abc-123",
+        }
+
+    def test_forwards_run_id_on_thinking(self):
+        payload = {
+            "stream": "thinking",
+            "runId": "run-xyz",
+            "data": {"text": "let me think"},
+        }
+        result = GatewayConnection._transform_agent_event(payload)
+        assert result == {
+            "type": "thinking",
+            "content": "let me think",
+            "runId": "run-xyz",
+        }
+
+    def test_forwards_run_id_on_tool_start(self):
+        payload = {
+            "stream": "tool",
+            "runId": "run-tool-1",
+            "data": {"phase": "start", "name": "exec", "toolCallId": "tc-1"},
+        }
+        result = GatewayConnection._transform_agent_event(payload)
+        assert result == {
+            "type": "tool_start",
+            "tool": "exec",
+            "toolCallId": "tc-1",
+            "runId": "run-tool-1",
+        }
+
+    def test_forwards_run_id_on_tool_end(self):
+        payload = {
+            "stream": "tool",
+            "runId": "run-tool-2",
+            "data": {"phase": "result", "name": "exec", "toolCallId": "tc-2"},
+        }
+        result = GatewayConnection._transform_agent_event(payload)
+        assert result == {
+            "type": "tool_end",
+            "tool": "exec",
+            "toolCallId": "tc-2",
+            "runId": "run-tool-2",
+        }
+
+    def test_omits_run_id_when_not_in_payload(self):
+        """Transform should not add runId key when source payload lacks it."""
+        payload = {"stream": "assistant", "data": {"text": "Hello"}}
+        result = GatewayConnection._transform_agent_event(payload)
+        assert result == {"type": "chunk", "content": "Hello"}
+        assert "runId" not in result
+
 
 class TestHandleMessageChatEvents:
     """Test _handle_message routing for chat event states."""

--- a/apps/backend/tests/unit/core/test_connection_pool.py
+++ b/apps/backend/tests/unit/core/test_connection_pool.py
@@ -443,6 +443,25 @@ class TestTransformAgentEvent:
             "runId": "run-tool-2",
         }
 
+    def test_forwards_run_id_on_tool_error(self):
+        payload = {
+            "stream": "tool",
+            "runId": "run-tool-err",
+            "data": {
+                "phase": "result",
+                "name": "exec",
+                "toolCallId": "tc-err",
+                "isError": True,
+            },
+        }
+        result = GatewayConnection._transform_agent_event(payload)
+        assert result == {
+            "type": "tool_error",
+            "tool": "exec",
+            "toolCallId": "tc-err",
+            "runId": "run-tool-err",
+        }
+
     def test_omits_run_id_when_not_in_payload(self):
         """Transform should not add runId key when source payload lacks it."""
         payload = {"stream": "assistant", "data": {"text": "Hello"}}

--- a/apps/backend/tests/unit/core/test_connection_pool.py
+++ b/apps/backend/tests/unit/core/test_connection_pool.py
@@ -720,3 +720,99 @@ class TestStatusChangeEvents:
         conn._emit_status_change("HEALTHY", "Gateway connected")
 
         mock_mgmt.send_message.assert_not_called()
+
+
+class TestChatEventForwarding:
+    """_handle_message forwards runId on chat terminal events (done/error)."""
+
+    @pytest.fixture
+    def mock_management_api(self):
+        client = MagicMock()
+        client.send_message = MagicMock(return_value=True)
+        return client
+
+    @pytest.fixture
+    def connection(self, mock_management_api):
+        c = GatewayConnection(
+            frontend_connections={"conn-1"},
+            conn_member_map={"conn-1": "user-1"},
+            user_id="user-1",
+            ip="10.0.0.1",
+            token="t",
+            management_api=mock_management_api,
+        )
+        return c
+
+    def test_done_event_carries_run_id(self, connection, mock_management_api):
+        connection._handle_message(
+            {
+                "type": "event",
+                "event": "chat",
+                "payload": {
+                    "state": "final",
+                    "sessionKey": "agent:main:user-1",
+                    "runId": "run-done-1",
+                },
+            }
+        )
+        done_msgs = [
+            c.args[1] for c in mock_management_api.send_message.call_args_list if c.args[1].get("type") == "done"
+        ]
+        assert len(done_msgs) == 1
+        assert done_msgs[0]["runId"] == "run-done-1"
+
+    def test_error_event_carries_run_id(self, connection, mock_management_api):
+        connection._handle_message(
+            {
+                "type": "event",
+                "event": "chat",
+                "payload": {
+                    "state": "error",
+                    "sessionKey": "agent:main:user-1",
+                    "runId": "run-err-1",
+                    "error": {"message": "model unavailable"},
+                },
+            }
+        )
+        error_msgs = [
+            c.args[1] for c in mock_management_api.send_message.call_args_list if c.args[1].get("type") == "error"
+        ]
+        assert len(error_msgs) == 1
+        assert error_msgs[0]["runId"] == "run-err-1"
+        assert error_msgs[0]["message"] == "model unavailable"
+
+    def test_aborted_event_carries_run_id(self, connection, mock_management_api):
+        connection._handle_message(
+            {
+                "type": "event",
+                "event": "chat",
+                "payload": {
+                    "state": "aborted",
+                    "sessionKey": "agent:main:user-1",
+                    "runId": "run-abort-1",
+                },
+            }
+        )
+        error_msgs = [
+            c.args[1] for c in mock_management_api.send_message.call_args_list if c.args[1].get("type") == "error"
+        ]
+        assert len(error_msgs) == 1
+        assert error_msgs[0]["runId"] == "run-abort-1"
+
+    def test_done_without_run_id_still_forwarded(self, connection, mock_management_api):
+        """When OpenClaw omits runId, the forwarded done has no runId key (not None)."""
+        connection._handle_message(
+            {
+                "type": "event",
+                "event": "chat",
+                "payload": {
+                    "state": "final",
+                    "sessionKey": "agent:main:user-1",
+                },
+            }
+        )
+        done_msgs = [
+            c.args[1] for c in mock_management_api.send_message.call_args_list if c.args[1].get("type") == "done"
+        ]
+        assert len(done_msgs) == 1
+        assert "runId" not in done_msgs[0]


### PR DESCRIPTION
## Summary

Backend half of the multi-bubble chat rendering refactor.

Every chat event forwarded from OpenClaw to the frontend now carries its source \`runId\`:
- \`chunk\` / \`thinking\` / \`tool_start\` / \`tool_end\` / \`tool_error\` — via \`_transform_agent_event\`
- \`done\` / \`error\` (emitted from \`chat.state: final|error|aborted\`)

**Spec:** `docs/superpowers/specs/2026-04-21-multi-bubble-chat-design.md`
**Plan:** `docs/superpowers/plans/2026-04-21-multi-bubble-chat.md` (Tasks 1-2)

## Why

Root cause diagnosis from the 2026-04-21 post-tool-approval streaming bug investigation: OpenClaw assigns a new \`runId\` per LLM turn within a single \`chat.send\` and fires \`chat.state:"final"\` per turn. The frontend currently treats each \`final\` as terminal and misroutes subsequent turns' chunks into the next user message's bubble.

The fix is on the frontend (multi-bubble rendering, follow-up PR). This PR is the prerequisite: without \`runId\` on the relayed events, the frontend has nothing to key per-run state on.

## Rollout safety

No frontend changes here. Old frontend ignores the extra field. Zero runtime difference until the frontend multi-bubble PR lands. Safe to ship independently.

## Test plan

- [x] \`test_connection_pool.py::TestTransformAgentEvent\` — 12 tests (7 existing + 5 new runId cases: chunk / thinking / tool_start / tool_end / tool_error / absence guard).
- [x] New \`test_connection_pool.py::TestChatEventForwarding\` class — 4 tests covering \`done\` / \`error\` / \`aborted\` runId propagation + absence guard.
- [x] Full regression across \`test_connection_pool.py\` + \`test_connection_pool_org.py\` + \`gateway/test_connection_pool.py\` — 63/63 passing.
- [ ] After prod deploy, CloudWatch logs on \`/ecs/isol8-prod\` show \`runId=<uuid>\` on forwarded events (PR #336's debug logging already surfaces this — this PR makes \`runId\` also present on the messages the frontend receives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)