### PR TITLE
feat(chat): multi-bubble rendering per LLM turn (runId-keyed)

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
@@ -66,8 +66,77 @@ describe("useAgentChat — multi-bubble", () => {
     sendChat.mockReset();
   });
 
-  it("is a scaffold", () => {
-    // Placeholder test - real assertions come in later tasks.
-    expect(true).toBe(true);
+  it("creates one bubble per runId and mirrors cumulative chunk content", async () => {
+    const useAgentChat = await importHook();
+    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+
+    // Send a user message
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    // First chunk for runId=R1 creates the bubble.
+    emit({ type: "chunk", content: "Hi", agent_id: "agent-A", runId: "R1" });
+
+    // Find the assistant message
+    const assistants = result.current.messages.filter((m) => m.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0].content).toBe("Hi");
+    expect(result.current.isStreaming).toBe(true);
+
+    // Second chunk — cumulative text for R1
+    emit({ type: "chunk", content: "Hi there", agent_id: "agent-A", runId: "R1" });
+    expect(result.current.messages.filter((m) => m.role === "assistant")[0].content).toBe("Hi there");
+
+    // done finalizes
+    emit({ type: "done", agent_id: "agent-A", runId: "R1" });
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("renders two assistant bubbles when two runIds stream within one chat.send", async () => {
+    const useAgentChat = await importHook();
+    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+
+    await act(async () => {
+      await result.current.sendMessage("do it");
+    });
+
+    // Run 1
+    emit({ type: "chunk", content: "Let me try", agent_id: "agent-A", runId: "R1" });
+    emit({ type: "done", agent_id: "agent-A", runId: "R1" });
+
+    // Run 2 — different runId, should create a new bubble
+    emit({ type: "chunk", content: "Done.", agent_id: "agent-A", runId: "R2" });
+    emit({ type: "done", agent_id: "agent-A", runId: "R2" });
+
+    const assistants = result.current.messages.filter((m) => m.role === "assistant");
+    expect(assistants).toHaveLength(2);
+    expect(assistants[0].content).toBe("Let me try");
+    expect(assistants[1].content).toBe("Done.");
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("isStreaming stays true while any run is active (union of runs)", async () => {
+    const useAgentChat = await importHook();
+    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+
+    await act(async () => {
+      await result.current.sendMessage("work");
+    });
+
+    emit({ type: "chunk", content: "a", agent_id: "agent-A", runId: "R1" });
+    expect(result.current.isStreaming).toBe(true);
+
+    // Second run starts before first finishes (interleaved deltas)
+    emit({ type: "chunk", content: "b", agent_id: "agent-A", runId: "R2" });
+    expect(result.current.isStreaming).toBe(true);
+
+    emit({ type: "done", agent_id: "agent-A", runId: "R1" });
+    // Still streaming — R2 still active
+    expect(result.current.isStreaming).toBe(true);
+
+    emit({ type: "done", agent_id: "agent-A", runId: "R2" });
+    // All runs done — streaming false
+    expect(result.current.isStreaming).toBe(false);
   });
 });

--- a/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
@@ -59,16 +59,30 @@ async function importHook() {
 }
 
 describe("useAgentChat — multi-bubble", () => {
+  // Unique agent id per test: the hook has a module-level `_messageCache`
+  // keyed by `${agentId}:${sessionName}` that persists across tests. Even
+  // with `vi.resetModules()`, using a fresh id per test is a belt-and-braces
+  // guarantee that no state leaks between cases.
+  const nextAgent = (() => {
+    let i = 0;
+    return () => `agent-${++i}`;
+  })();
+
   beforeEach(() => {
     chatHandlers = [];
     eventHandlers = [];
     sendReq.mockReset().mockResolvedValue({});
     sendChat.mockReset();
+    // Reset modules between tests so the module-level `_messageCache`
+    // and `_needsBootstrap` inside useAgentChat don't leak state.
+    // vi.mock() for useGateway hoists and is re-applied per module load.
+    vi.resetModules();
   });
 
   it("creates one bubble per runId and mirrors cumulative chunk content", async () => {
     const useAgentChat = await importHook();
-    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
 
     // Send a user message
     await act(async () => {
@@ -76,7 +90,7 @@ describe("useAgentChat — multi-bubble", () => {
     });
 
     // First chunk for runId=R1 creates the bubble.
-    emit({ type: "chunk", content: "Hi", agent_id: "agent-A", runId: "R1" });
+    emit({ type: "chunk", content: "Hi", agent_id: agentId, runId: "R1" });
 
     // Find the assistant message
     const assistants = result.current.messages.filter((m) => m.role === "assistant");
@@ -85,29 +99,30 @@ describe("useAgentChat — multi-bubble", () => {
     expect(result.current.isStreaming).toBe(true);
 
     // Second chunk — cumulative text for R1
-    emit({ type: "chunk", content: "Hi there", agent_id: "agent-A", runId: "R1" });
+    emit({ type: "chunk", content: "Hi there", agent_id: agentId, runId: "R1" });
     expect(result.current.messages.filter((m) => m.role === "assistant")[0].content).toBe("Hi there");
 
     // done finalizes
-    emit({ type: "done", agent_id: "agent-A", runId: "R1" });
+    emit({ type: "done", agent_id: agentId, runId: "R1" });
     expect(result.current.isStreaming).toBe(false);
   });
 
   it("renders two assistant bubbles when two runIds stream within one chat.send", async () => {
     const useAgentChat = await importHook();
-    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
 
     await act(async () => {
       await result.current.sendMessage("do it");
     });
 
     // Run 1
-    emit({ type: "chunk", content: "Let me try", agent_id: "agent-A", runId: "R1" });
-    emit({ type: "done", agent_id: "agent-A", runId: "R1" });
+    emit({ type: "chunk", content: "Let me try", agent_id: agentId, runId: "R1" });
+    emit({ type: "done", agent_id: agentId, runId: "R1" });
 
     // Run 2 — different runId, should create a new bubble
-    emit({ type: "chunk", content: "Done.", agent_id: "agent-A", runId: "R2" });
-    emit({ type: "done", agent_id: "agent-A", runId: "R2" });
+    emit({ type: "chunk", content: "Done.", agent_id: agentId, runId: "R2" });
+    emit({ type: "done", agent_id: agentId, runId: "R2" });
 
     const assistants = result.current.messages.filter((m) => m.role === "assistant");
     expect(assistants).toHaveLength(2);
@@ -118,25 +133,68 @@ describe("useAgentChat — multi-bubble", () => {
 
   it("isStreaming stays true while any run is active (union of runs)", async () => {
     const useAgentChat = await importHook();
-    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
 
     await act(async () => {
       await result.current.sendMessage("work");
     });
 
-    emit({ type: "chunk", content: "a", agent_id: "agent-A", runId: "R1" });
+    emit({ type: "chunk", content: "a", agent_id: agentId, runId: "R1" });
     expect(result.current.isStreaming).toBe(true);
 
     // Second run starts before first finishes (interleaved deltas)
-    emit({ type: "chunk", content: "b", agent_id: "agent-A", runId: "R2" });
+    emit({ type: "chunk", content: "b", agent_id: agentId, runId: "R2" });
     expect(result.current.isStreaming).toBe(true);
 
-    emit({ type: "done", agent_id: "agent-A", runId: "R1" });
+    emit({ type: "done", agent_id: agentId, runId: "R1" });
     // Still streaming — R2 still active
     expect(result.current.isStreaming).toBe(true);
 
-    emit({ type: "done", agent_id: "agent-A", runId: "R2" });
+    emit({ type: "done", agent_id: agentId, runId: "R2" });
     // All runs done — streaming false
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("error with runId finalizes only that bubble; other runs continue", async () => {
+    const useAgentChat = await importHook();
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
+
+    await act(async () => {
+      await result.current.sendMessage("dual");
+    });
+
+    emit({ type: "chunk", content: "a", agent_id: agentId, runId: "R1" });
+    emit({ type: "chunk", content: "b", agent_id: agentId, runId: "R2" });
+
+    // Error on R1
+    emit({ type: "error", message: "oh no", agent_id: agentId, runId: "R1" });
+
+    const assistants = result.current.messages.filter((m) => m.role === "assistant");
+    const r1 = assistants.find((m) => m.content.includes("Error:"));
+    expect(r1).toBeTruthy();
+    expect(result.current.isStreaming).toBe(true); // R2 still active
+
+    emit({ type: "done", agent_id: agentId, runId: "R2" });
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("error without runId clears all active runs", async () => {
+    const useAgentChat = await importHook();
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
+
+    await act(async () => {
+      await result.current.sendMessage("multi");
+    });
+
+    emit({ type: "chunk", content: "x", agent_id: agentId, runId: "R1" });
+    emit({ type: "chunk", content: "y", agent_id: agentId, runId: "R2" });
+
+    // Global error (no runId)
+    emit({ type: "error", message: "global fail", agent_id: undefined });
+
     expect(result.current.isStreaming).toBe(false);
   });
 });

--- a/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
@@ -200,40 +200,45 @@ describe("useAgentChat — multi-bubble", () => {
 
   it("sendMessage does NOT create an assistant placeholder before first event", async () => {
     const useAgentChat = await importHook();
-    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
 
     await act(async () => {
       await result.current.sendMessage("hi");
     });
 
-    // Only a user message exists; no assistant placeholder yet.
-    const assistants = result.current.messages.filter((m) => m.role === "assistant");
-    expect(assistants).toHaveLength(0);
-    // No runs yet
+    // Only a user message exists; no assistant placeholder yet. `runsRef` is
+    // hook-internal, so we assert on the observable outcome: after
+    // sendMessage resolves but before any chunk arrives, there should be
+    // zero assistant messages.
+    expect(
+      result.current.messages.filter((m) => m.role === "assistant"),
+    ).toHaveLength(0);
     expect(result.current.isStreaming).toBe(true); // sendMessage sets isStreaming = true early
   });
 
   it("approval.requested event matches toolCallId across any assistant bubble", async () => {
     const useAgentChat = await importHook();
-    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
 
     await act(async () => {
       await result.current.sendMessage("install");
     });
 
     // Chunk + tool_start into R1
-    emit({ type: "chunk", content: "Running", agent_id: "agent-A", runId: "R1" });
+    emit({ type: "chunk", content: "Running", agent_id: agentId, runId: "R1" });
     emit({
       type: "tool_start",
       tool: "exec",
       toolCallId: "tc-1",
-      agent_id: "agent-A",
+      agent_id: agentId,
       runId: "R1",
     });
 
     // First run finishes with tool_use; second run starts
-    emit({ type: "done", agent_id: "agent-A", runId: "R1" });
-    emit({ type: "chunk", content: "More", agent_id: "agent-A", runId: "R2" });
+    emit({ type: "done", agent_id: agentId, runId: "R1" });
+    emit({ type: "chunk", content: "More", agent_id: agentId, runId: "R2" });
 
     // Approval event arrives for the tool in R1's bubble (not the active R2).
     emitEvent("exec.approval.requested", {
@@ -241,7 +246,7 @@ describe("useAgentChat — multi-bubble", () => {
       request: {
         command: "rm -rf /tmp/foo",
         host: "gateway" as const,
-        agentId: "agent-A",
+        agentId: agentId,
         toolCallId: "tc-1",
         allowedDecisions: ["allow-once", "deny"],
       },

--- a/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
@@ -197,4 +197,62 @@ describe("useAgentChat — multi-bubble", () => {
 
     expect(result.current.isStreaming).toBe(false);
   });
+
+  it("sendMessage does NOT create an assistant placeholder before first event", async () => {
+    const useAgentChat = await importHook();
+    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+
+    await act(async () => {
+      await result.current.sendMessage("hi");
+    });
+
+    // Only a user message exists; no assistant placeholder yet.
+    const assistants = result.current.messages.filter((m) => m.role === "assistant");
+    expect(assistants).toHaveLength(0);
+    // No runs yet
+    expect(result.current.isStreaming).toBe(true); // sendMessage sets isStreaming = true early
+  });
+
+  it("approval.requested event matches toolCallId across any assistant bubble", async () => {
+    const useAgentChat = await importHook();
+    const { result } = renderHook(() => useAgentChat("agent-A", "main"));
+
+    await act(async () => {
+      await result.current.sendMessage("install");
+    });
+
+    // Chunk + tool_start into R1
+    emit({ type: "chunk", content: "Running", agent_id: "agent-A", runId: "R1" });
+    emit({
+      type: "tool_start",
+      tool: "exec",
+      toolCallId: "tc-1",
+      agent_id: "agent-A",
+      runId: "R1",
+    });
+
+    // First run finishes with tool_use; second run starts
+    emit({ type: "done", agent_id: "agent-A", runId: "R1" });
+    emit({ type: "chunk", content: "More", agent_id: "agent-A", runId: "R2" });
+
+    // Approval event arrives for the tool in R1's bubble (not the active R2).
+    emitEvent("exec.approval.requested", {
+      id: "appr-1",
+      request: {
+        command: "rm -rf /tmp/foo",
+        host: "gateway" as const,
+        agentId: "agent-A",
+        toolCallId: "tc-1",
+        allowedDecisions: ["allow-once", "deny"],
+      },
+    });
+
+    // Expect R1's bubble to have the tool in pending-approval status.
+    const r1 = result.current.messages.find((m) =>
+      m.toolUses?.some((t) => t.toolCallId === "tc-1"),
+    );
+    expect(r1).toBeDefined();
+    const tool = r1!.toolUses!.find((t) => t.toolCallId === "tc-1")!;
+    expect(tool.status).toBe("pending-approval");
+  });
 });

--- a/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
@@ -473,4 +473,83 @@ describe("useAgentChat — multi-bubble", () => {
     expect(assistantCountAfterLate).toBe(assistantCountAfterCancel);
     expect(result.current.isStreaming).toBe(false);
   });
+
+  it("late events after cancel-before-first-event are tombstoned as ghost bubbles", async () => {
+    // Regression test for Codex (useAgentChat line ~281): if the user hits
+    // Stop BEFORE any chunk/thinking/tool_start for the in-flight turn has
+    // arrived, runsRef is empty at cancel time — so finalizeAllActiveRuns
+    // has no runIds to tombstone. A late first event then fell through to
+    // getOrCreateBubble's bubble-creation path, spawning a ghost bubble and
+    // flipping isStreaming back to true (silently undoing the cancel). The
+    // pendingCancelRef flag closes that window.
+    const useAgentChat = await importHook();
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
+
+    // User sends a message; sendMessage flips isStreaming=true but we never
+    // emit any chunk/thinking/tool_start before cancel fires.
+    await act(async () => {
+      await result.current.sendMessage("go");
+    });
+    expect(result.current.isStreaming).toBe(true);
+    expect(
+      result.current.messages.filter((m) => m.role === "assistant"),
+    ).toHaveLength(0);
+
+    // User hits Stop before any event arrives — runsRef is empty here.
+    await act(async () => {
+      await result.current.cancelMessage();
+    });
+    expect(result.current.isStreaming).toBe(false);
+
+    // Late first chunk arrives for a runId we've never seen. Must be dropped.
+    emit({
+      type: "chunk",
+      content: "late straggler",
+      agent_id: agentId,
+      runId: "R-late",
+    });
+
+    expect(
+      result.current.messages.filter((m) => m.role === "assistant"),
+    ).toHaveLength(0);
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("pendingCancelRef is cleared on new sendMessage so new runs are not dropped", async () => {
+    // Companion test: verify the pendingCancelRef flag does not persist
+    // past the next sendMessage. A new turn must allow events for its
+    // new runId through normally.
+    const useAgentChat = await importHook();
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
+
+    // Turn 1: send + cancel before any event arrives.
+    await act(async () => {
+      await result.current.sendMessage("first");
+    });
+    await act(async () => {
+      await result.current.cancelMessage();
+    });
+    expect(result.current.isStreaming).toBe(false);
+
+    // Turn 2: new sendMessage must reset pendingCancelRef so a normal chunk
+    // for the new turn creates a bubble and flips isStreaming back on.
+    await act(async () => {
+      await result.current.sendMessage("second");
+    });
+    emit({
+      type: "chunk",
+      content: "normal reply",
+      agent_id: agentId,
+      runId: "R-fresh",
+    });
+
+    const assistants = result.current.messages.filter(
+      (m) => m.role === "assistant",
+    );
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0].content).toBe("normal reply");
+    expect(result.current.isStreaming).toBe(true);
+  });
 });

--- a/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { ChatIncomingMessage } from "../useGateway";
+
+// --- Mocks ---------------------------------------------------------------
+
+// Chat-message handlers registered by useAgentChat.
+let chatHandlers: Array<(msg: ChatIncomingMessage) => void> = [];
+let eventHandlers: Array<(name: string, data: unknown) => void> = [];
+
+const sendReq = vi.fn().mockResolvedValue({});
+const sendChat = vi.fn();
+
+vi.mock("../useGateway", () => ({
+  useGateway: () => ({
+    isConnected: true,
+    nodeConnected: false,
+    error: null,
+    reconnectAttempt: 0,
+    send: vi.fn(),
+    sendReq,
+    sendChat,
+    onEvent: (h: (name: string, data: unknown) => void) => {
+      eventHandlers.push(h);
+      return () => {
+        eventHandlers = eventHandlers.filter((x) => x !== h);
+      };
+    },
+    onChatMessage: (h: (msg: ChatIncomingMessage) => void) => {
+      chatHandlers.push(h);
+      return () => {
+        chatHandlers = chatHandlers.filter((x) => x !== h);
+      };
+    },
+    reconnect: vi.fn(),
+  }),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
+// Helpers to drive the hook from tests.
+function emit(msg: ChatIncomingMessage) {
+  act(() => {
+    chatHandlers.forEach((h) => h(msg));
+  });
+}
+
+function emitEvent(name: string, data: unknown) {
+  act(() => {
+    eventHandlers.forEach((h) => h(name, data));
+  });
+}
+
+async function importHook() {
+  const mod = await import("../useAgentChat");
+  return mod.useAgentChat;
+}
+
+describe("useAgentChat — multi-bubble", () => {
+  beforeEach(() => {
+    chatHandlers = [];
+    eventHandlers = [];
+    sendReq.mockReset().mockResolvedValue({});
+    sendChat.mockReset();
+  });
+
+  it("is a scaffold", () => {
+    // Placeholder test - real assertions come in later tasks.
+    expect(true).toBe(true);
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
@@ -217,6 +217,166 @@ describe("useAgentChat — multi-bubble", () => {
     expect(result.current.isStreaming).toBe(true); // sendMessage sets isStreaming = true early
   });
 
+  it("post-approval chunks with new runId create a new bubble, not displace next user message's turn", async () => {
+    // Regression test for the original bug this PR fixes: post-approval
+    // stream chunks arriving after exec.approval.resolved were landing in
+    // the NEXT user message's assistant bubble. With multi-bubble routing,
+    // a distinct runId per turn should create a distinct assistant bubble.
+    const useAgentChat = await importHook();
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
+
+    // --- Turn 1: user sends message #1, agent starts exec that needs approval
+    await act(async () => {
+      await result.current.sendMessage("install something");
+    });
+
+    // tool_start with runId "R1" — creates first assistant bubble
+    emit({
+      type: "tool_start",
+      tool: "exec",
+      toolCallId: "tc-1",
+      agent_id: agentId,
+      runId: "R1",
+    });
+
+    // Approval requested for the tool. R1 is still active (no done yet;
+    // OpenClaw stalls the run until the approval resolves).
+    emitEvent("exec.approval.requested", {
+      id: "appr-1",
+      request: {
+        command: "rm -rf /tmp/foo",
+        host: "gateway" as const,
+        agentId: agentId,
+        toolCallId: "tc-1",
+        allowedDecisions: ["allow-once", "deny"],
+      },
+    });
+
+    // Simulate approval resolution (does not finalize R1; the run continues).
+    emitEvent("exec.approval.resolved", { id: "appr-1", decision: "allow-once" });
+
+    // R1 finishes with a done
+    emit({ type: "tool_end", tool: "exec", toolCallId: "tc-1", agent_id: agentId, runId: "R1" });
+    emit({ type: "done", agent_id: agentId, runId: "R1" });
+
+    // --- Turn 2: post-approval followup. OpenClaw assigns a NEW runId for
+    // the follow-up stream (e.g. "exec-approval-followup:..."). Under the
+    // fix this should create a SECOND assistant bubble, not reuse R1's.
+    emit({
+      type: "chunk",
+      content: "Followup output",
+      agent_id: agentId,
+      runId: "exec-approval-followup:1",
+    });
+    emit({ type: "done", agent_id: agentId, runId: "exec-approval-followup:1" });
+
+    const afterTurn2 = result.current.messages.filter((m) => m.role === "assistant");
+    expect(afterTurn2).toHaveLength(2);
+    // Turn 2 content is isolated to the second bubble.
+    expect(afterTurn2[0].content).not.toContain("Followup output");
+    expect(afterTurn2[1].content).toBe("Followup output");
+
+    // --- Turn 3: user sends message #2 → new chat.send with runId "R3".
+    await act(async () => {
+      await result.current.sendMessage("next");
+    });
+    emit({ type: "chunk", content: "Third turn reply", agent_id: agentId, runId: "R3" });
+    emit({ type: "done", agent_id: agentId, runId: "R3" });
+
+    const finalAssistants = result.current.messages.filter((m) => m.role === "assistant");
+    expect(finalAssistants).toHaveLength(3);
+
+    // Critical assertion: turn 2's content did NOT get displaced into turn 3's bubble.
+    expect(finalAssistants[2].content).toBe("Third turn reply");
+    expect(finalAssistants[2].content).not.toContain("Followup output");
+    // Each bubble has a distinct identity.
+    const assistantIdsInternal = new Set(
+      result.current.messages
+        .filter((m) => m.role === "assistant")
+        .map((m) => m.content),
+    );
+    expect(assistantIdsInternal.size).toBe(3);
+  });
+
+  it("late chunk after done does not create a ghost bubble or re-enable streaming", async () => {
+    // Regression test for M1: after finalizeBubble(runId) deletes the run,
+    // a trailing chunk for the same runId used to re-create a fresh empty
+    // bubble and flip isStreaming back to true. The finalizedRunsRef guard
+    // should silently drop such late events.
+    const useAgentChat = await importHook();
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
+
+    await act(async () => {
+      await result.current.sendMessage("hi");
+    });
+
+    emit({ type: "chunk", content: "Hello", agent_id: agentId, runId: "R1" });
+    emit({ type: "done", agent_id: agentId, runId: "R1" });
+
+    // After done: 1 assistant bubble, not streaming.
+    expect(result.current.messages.filter((m) => m.role === "assistant")).toHaveLength(1);
+    expect(result.current.isStreaming).toBe(false);
+
+    // Late straggler chunk for the same finalized runId.
+    emit({ type: "chunk", content: "Late content", agent_id: agentId, runId: "R1" });
+
+    // Should NOT create a ghost bubble, NOT re-enable streaming, and should
+    // NOT mutate the existing bubble's content.
+    const assistants = result.current.messages.filter((m) => m.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0].content).toBe("Hello");
+    expect(result.current.isStreaming).toBe(false);
+
+    // Also verify late thinking + tool_start are dropped.
+    emit({ type: "thinking", content: "late thought", agent_id: agentId, runId: "R1" });
+    emit({
+      type: "tool_start",
+      tool: "exec",
+      toolCallId: "tc-late",
+      agent_id: agentId,
+      runId: "R1",
+    });
+    expect(result.current.messages.filter((m) => m.role === "assistant")).toHaveLength(1);
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("scoped error with unknown runId clears isStreaming", async () => {
+    // Regression test for Codex P1 / S3: sendMessage sets isStreaming=true
+    // before any bubble exists. If a run errors before any chunk/thinking/
+    // tool_start arrives, runsRef.get(runId) is undefined and the old
+    // scoped-error branch only called setError() — leaving isStreaming
+    // stuck at true and the input in "Stop" mode.
+    const useAgentChat = await importHook();
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
+
+    await act(async () => {
+      await result.current.sendMessage("boom");
+    });
+
+    // sendMessage flipped isStreaming=true, no bubble yet.
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+
+    // Scoped error for a runId that was never bubbled.
+    emit({
+      type: "error",
+      message: "provider failed",
+      agent_id: agentId,
+      runId: "R-never-bubbled",
+    });
+
+    // isStreaming must be cleared (otherwise input stays stuck).
+    expect(result.current.isStreaming).toBe(false);
+    // An error-marked assistant message was appended so the failure is visible.
+    const assistants = result.current.messages.filter((m) => m.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0].content).toContain("Error:");
+    expect(result.current.error).toBeTruthy();
+  });
+
   it("approval.requested event matches toolCallId across any assistant bubble", async () => {
     const useAgentChat = await importHook();
     const agentId = nextAgent();

--- a/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useAgentChat.test.ts
@@ -420,4 +420,57 @@ describe("useAgentChat — multi-bubble", () => {
     const tool = r1!.toolUses!.find((t) => t.toolCallId === "tc-1")!;
     expect(tool.status).toBe("pending-approval");
   });
+
+  it("late events after cancelMessage do not resurrect a ghost bubble", async () => {
+    // Regression test for Codex P2 (useAgentChat line ~912/930): cancelMessage
+    // and clearMessages used to do `runsRef.clear(); finalizedRunsRef.clear()`,
+    // which wiped the ghost-bubble guard for runs that were just aborted. A
+    // late in-flight chunk/thinking/tool_start for one of those runIds would
+    // then miss BOTH refs inside getOrCreateBubble, spawn a fresh empty
+    // assistant bubble, and flip isStreaming back to true — silently undoing
+    // the cancel. The fix migrates active runIds into finalizedRunsRef before
+    // clearing runsRef so late stragglers are dropped.
+    const useAgentChat = await importHook();
+    const agentId = nextAgent();
+    const { result } = renderHook(() => useAgentChat(agentId, "main"));
+
+    await act(async () => {
+      await result.current.sendMessage("go");
+    });
+
+    // First chunk for R1 creates the bubble and keeps isStreaming=true.
+    emit({ type: "chunk", content: "partial", agent_id: agentId, runId: "R1" });
+    expect(result.current.isStreaming).toBe(true);
+    expect(
+      result.current.messages.filter((m) => m.role === "assistant"),
+    ).toHaveLength(1);
+
+    // User hits Stop.
+    await act(async () => {
+      await result.current.cancelMessage();
+    });
+    expect(result.current.isStreaming).toBe(false);
+    const assistantCountAfterCancel = result.current.messages.filter(
+      (m) => m.role === "assistant",
+    ).length;
+
+    // Late stragglers for R1 arrive after cancel (WebSocket reorder / OpenClaw
+    // still flushing). These must NOT create a new bubble and must NOT flip
+    // isStreaming back on.
+    emit({ type: "chunk", content: "late chunk", agent_id: agentId, runId: "R1" });
+    emit({ type: "thinking", content: "late thinking", agent_id: agentId, runId: "R1" });
+    emit({
+      type: "tool_start",
+      tool: "exec",
+      toolCallId: "tc-late",
+      agent_id: agentId,
+      runId: "R1",
+    });
+
+    const assistantCountAfterLate = result.current.messages.filter(
+      (m) => m.role === "assistant",
+    ).length;
+    expect(assistantCountAfterLate).toBe(assistantCountAfterCancel);
+    expect(result.current.isStreaming).toBe(false);
+  });
 });

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -268,6 +268,25 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     }
   }, [setIsStreaming]);
 
+  // Mark every currently-active run as finalized, then clear runsRef. Used by
+  // cancel / clear / global-error branches: wiping runsRef without also
+  // populating finalizedRunsRef would let a late in-flight chunk/thinking/
+  // tool_start event slip past getOrCreateBubble (it wouldn't find the runId
+  // in either ref) and spawn a ghost assistant bubble that re-enables
+  // isStreaming — silently undoing the cancel/clear. Never clear
+  // finalizedRunsRef for the same reason; rely on the 100-entry FIFO cap in
+  // finalizeBubble to bound growth.
+  const finalizeAllActiveRuns = useCallback(() => {
+    for (const runId of runsRef.current.keys()) {
+      finalizedRunsRef.current.add(runId);
+      if (finalizedRunsRef.current.size > 100) {
+        const first = finalizedRunsRef.current.values().next().value;
+        if (first) finalizedRunsRef.current.delete(first);
+      }
+    }
+    runsRef.current.clear();
+  }, []);
+
   const agentIdRef = useRef(agentId);
   useEffect(() => {
     agentIdRef.current = agentId;
@@ -439,8 +458,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
             Array.from(runsRef.current.values()).map((r) => r.messageId),
           );
           setMessages((prev) => prev.filter((m) => !activeMessageIds.has(m.id)));
-          runsRef.current.clear();
-          finalizedRunsRef.current.clear();
+          finalizeAllActiveRuns();
           setIsStreaming(false, "error-budget");
           return;
         }
@@ -498,8 +516,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
           ),
         );
         setError(displayError);
-        runsRef.current.clear();
-        finalizedRunsRef.current.clear();
+        finalizeAllActiveRuns();
         setIsStreaming(false, "error-generic");
         return;
       }
@@ -909,9 +926,8 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
     // Immediately update local state so the UI feels responsive
     setIsStreaming(false, "cancelMessage");
-    runsRef.current.clear();
-    finalizedRunsRef.current.clear();
-  }, [isStreaming, sendReq, sessionName]);
+    finalizeAllActiveRuns();
+  }, [isStreaming, sendReq, sessionName, finalizeAllActiveRuns]);
 
   // ---- Clear messages ----
 
@@ -927,9 +943,8 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     }
     setError(null);
     setIsStreaming(false, "clearMessages");
-    runsRef.current.clear();
-    finalizedRunsRef.current.clear();
-  }, [sessionName]);
+    finalizeAllActiveRuns();
+  }, [sessionName, finalizeAllActiveRuns]);
 
   // ---- Resolve approval (allow-once / allow-always / deny) ----
 

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -679,6 +679,11 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         // Nothing matched — attach to the newest assistant message as a new
         // tool entry (preserves old behavior for correlationless cases
         // where no tool has started yet).
+        // Protocol invariant: OpenClaw emits `tool_start` (which creates the
+        // bubble and the toolCall entry) before `exec.approval.requested` for
+        // that toolCall, so at least one assistant bubble exists by the time
+        // we get here. The `lastAssistantIdx < 0` guard is a safety net for
+        // protocol violations, not a normal code path.
         const lastAssistantIdx = (() => {
           for (let i = prev.length - 1; i >= 0; i--) {
             if (prev[i].role === "assistant") return i;

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -207,6 +207,41 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
   const currentAssistantIdRef = useRef<string | null>(null);
   const streamContentRef = useRef<string>("");
+
+  // Multi-bubble: one assistant message per OpenClaw runId. This replaces
+  // currentAssistantIdRef + streamContentRef. OpenClaw assigns a new runId
+  // per LLM turn within a single chat.send; each turn gets its own bubble.
+  // See docs/superpowers/specs/2026-04-21-multi-bubble-chat-design.md.
+  type RunState = {
+    messageId: string;
+    streamContent: string;
+    thinking: string;
+  };
+  const runsRef = useRef<Map<string, RunState>>(new Map());
+
+  const getOrCreateBubble = useCallback((runId: string): string => {
+    const existing = runsRef.current.get(runId);
+    if (existing) return existing.messageId;
+
+    const messageId = `assistant-${crypto.randomUUID()}`;
+    runsRef.current.set(runId, { messageId, streamContent: "", thinking: "" });
+    setMessages((prev) => [
+      ...prev,
+      { id: messageId, role: "assistant", content: "" },
+    ]);
+    if (!isStreamingRef.current) {
+      setIsStreaming(true, `run-${runId.slice(0, 12)}-start`);
+    }
+    return messageId;
+  }, [setIsStreaming]);
+
+  const finalizeBubble = useCallback((runId: string) => {
+    runsRef.current.delete(runId);
+    if (runsRef.current.size === 0) {
+      setIsStreaming(false, `run-${runId.slice(0, 12)}-done`);
+    }
+  }, [setIsStreaming]);
+
   const agentIdRef = useRef(agentId);
   useEffect(() => {
     agentIdRef.current = agentId;
@@ -354,16 +389,14 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "chunk") {
-        // OpenClaw sends cumulative text (full response so far) in each
-        // chunk, so we replace rather than append — matching how OpenClaw's
-        // own frontend handles streaming.
-        streamContentRef.current = msg.content;
-        const updatedContent = streamContentRef.current;
+        const runId = msg.runId ?? "_default";
+        const messageId = getOrCreateBubble(runId);
+        const run = runsRef.current.get(runId)!;
+        run.streamContent = msg.content;
+        const updatedContent = run.streamContent;
         setMessages((prev) =>
           prev.map((m) =>
-            m.id === currentAssistantIdRef.current
-              ? { ...m, content: updatedContent }
-              : m,
+            m.id === messageId ? { ...m, content: updatedContent } : m,
           ),
         );
         return;
@@ -419,92 +452,90 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "thinking") {
-        // Streamed thinking events carry the cumulative thinking text, so
-        // replace rather than append. The chat.final batch sends a single
-        // event with the full text — replace works for that too.
-        if (currentAssistantIdRef.current) {
-          setMessages((prev) =>
-            prev.map((m) =>
-              m.id === currentAssistantIdRef.current
-                ? { ...m, thinking: msg.content }
-                : m,
-            ),
-          );
-        }
+        const runId = msg.runId ?? "_default";
+        const messageId = getOrCreateBubble(runId);
+        const run = runsRef.current.get(runId)!;
+        run.thinking = msg.content;
+        const updatedThinking = run.thinking;
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === messageId ? { ...m, thinking: updatedThinking } : m,
+          ),
+        );
         return;
       }
 
       if (msg.type === "tool_start") {
-        if (currentAssistantIdRef.current) {
-          setMessages((prev) =>
-            prev.map((m) => {
-              if (m.id !== currentAssistantIdRef.current) return m;
-              const existing = m.toolUses ?? [];
-              // If an approval request already created a ToolUse for this call
-              // (race where exec.approval.requested lands before tool_start),
-              // merge into that entry rather than appending a duplicate.
-              const existingIdx =
-                msg.toolCallId !== undefined
-                  ? existing.findIndex((t) => t.toolCallId === msg.toolCallId)
-                  : -1;
-              if (existingIdx >= 0) {
-                const next = existing.slice();
-                const prior = next[existingIdx];
-                next[existingIdx] = {
-                  ...prior,
-                  tool: msg.tool,
-                  // Keep pending-approval/denied if approval already landed;
-                  // only default to "running" when we had no prior status.
-                  status: prior.status ?? ("running" as const),
-                  ...(msg.args ? { args: msg.args } : {}),
-                };
-                return { ...m, toolUses: next };
-              }
-              return {
-                ...m,
-                toolUses: [
-                  ...existing,
-                  {
-                    tool: msg.tool,
-                    toolCallId: msg.toolCallId,
-                    status: "running" as const,
-                    ...(msg.args ? { args: msg.args } : {}),
-                  },
-                ],
+        const runId = msg.runId ?? "_default";
+        const messageId = getOrCreateBubble(runId);
+        setMessages((prev) =>
+          prev.map((m) => {
+            if (m.id !== messageId) return m;
+            const existing = m.toolUses ?? [];
+            const existingIdx =
+              msg.toolCallId !== undefined
+                ? existing.findIndex((t) => t.toolCallId === msg.toolCallId)
+                : -1;
+            if (existingIdx >= 0) {
+              const next = existing.slice();
+              const prior = next[existingIdx];
+              next[existingIdx] = {
+                ...prior,
+                tool: msg.tool,
+                status: prior.status ?? ("running" as const),
+                ...(msg.args ? { args: msg.args } : {}),
               };
-            }),
-          );
-        }
+              return { ...m, toolUses: next };
+            }
+            return {
+              ...m,
+              toolUses: [
+                ...existing,
+                {
+                  tool: msg.tool,
+                  toolCallId: msg.toolCallId,
+                  status: "running" as const,
+                  ...(msg.args ? { args: msg.args } : {}),
+                },
+              ],
+            };
+          }),
+        );
         return;
       }
 
       if (msg.type === "tool_end" || msg.type === "tool_error") {
-        const nextStatus = msg.type === "tool_end" ? "done" : "error";
-        if (currentAssistantIdRef.current) {
-          setMessages((prev) =>
-            prev.map((m) => {
-              if (m.id !== currentAssistantIdRef.current) return m;
-              const toolUses = (m.toolUses || []).map((t) => {
-                const matchesCallId =
-                  msg.toolCallId !== undefined &&
-                  t.toolCallId === msg.toolCallId;
-                const matchesName =
-                  msg.toolCallId === undefined && t.tool === msg.tool;
-                const isRunning = t.status === "running";
-                if (isRunning && (matchesCallId || matchesName)) {
-                  return {
-                    ...t,
-                    status: nextStatus as "done" | "error",
-                    ...(msg.result ? { result: msg.result } : {}),
-                    ...(msg.meta ? { meta: msg.meta } : {}),
-                  };
-                }
-                return t;
-              });
-              return { ...m, toolUses };
-            }),
-          );
+        const runId = msg.runId ?? "_default";
+        const run = runsRef.current.get(runId);
+        const messageId = run?.messageId;
+        if (!messageId) {
+          // No bubble for this run (unknown runId) — nothing to update.
+          return;
         }
+        const nextStatus = msg.type === "tool_end" ? "done" : "error";
+        setMessages((prev) =>
+          prev.map((m) => {
+            if (m.id !== messageId) return m;
+            const toolUses = (m.toolUses || []).map((t) => {
+              const matchesCallId =
+                msg.toolCallId !== undefined &&
+                t.toolCallId === msg.toolCallId;
+              const matchesName =
+                msg.toolCallId === undefined && t.tool === msg.tool;
+              const isRunning = t.status === "running";
+              if (isRunning && (matchesCallId || matchesName)) {
+                return {
+                  ...t,
+                  status: nextStatus as "done" | "error",
+                  ...(msg.result ? { result: msg.result } : {}),
+                  ...(msg.meta ? { meta: msg.meta } : {}),
+                };
+              }
+              return t;
+            });
+            return { ...m, toolUses };
+          }),
+        );
         return;
       }
 

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -216,7 +216,28 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
   };
   const runsRef = useRef<Map<string, RunState>>(new Map());
 
-  const getOrCreateBubble = useCallback((runId: string): string => {
+  // Tracks runIds that have been finalized (done / error / budget / cancel /
+  // clear / agent-drop). Any late chunk/thinking/tool_start event arriving for
+  // one of these runIds is silently dropped by getOrCreateBubble — without
+  // this, such a late event would create a brand-new empty assistant bubble
+  // and flip isStreaming back to true (ghost-bubble regression, M1).
+  //
+  // Bounded to ~100 entries via FIFO eviction below; the first-inserted runId
+  // is evicted when the set would otherwise grow past the cap. This avoids
+  // unbounded growth over long sessions while still covering the protocol's
+  // realistic out-of-order window (events straggle within a single turn, not
+  // across dozens of turns).
+  const finalizedRunsRef = useRef<Set<string>>(new Set());
+
+  const getOrCreateBubble = useCallback((runId: string): string | null => {
+    // Late event for an already-finalized run — drop silently. This
+    // replicates the old `if (!currentAssistantIdRef.current) return;`
+    // blanket guard, but scoped to truly-finalized runs instead of the
+    // global streaming flag.
+    if (finalizedRunsRef.current.has(runId)) {
+      return null;
+    }
+
     const existing = runsRef.current.get(runId);
     if (existing) return existing.messageId;
 
@@ -234,6 +255,14 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
   const finalizeBubble = useCallback((runId: string) => {
     runsRef.current.delete(runId);
+    finalizedRunsRef.current.add(runId);
+    // Bounded LRU-ish: cap size to avoid unbounded growth on long sessions.
+    // Set iteration order is insertion order, so values().next() gives the
+    // oldest entry.
+    if (finalizedRunsRef.current.size > 100) {
+      const first = finalizedRunsRef.current.values().next().value;
+      if (first) finalizedRunsRef.current.delete(first);
+    }
     if (runsRef.current.size === 0) {
       setIsStreaming(false, `run-${runId.slice(0, 12)}-done`);
     }
@@ -373,6 +402,8 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       if (msg.type === "chunk") {
         const runId = msg.runId ?? "_default";
         const messageId = getOrCreateBubble(runId);
+        // Late event for a finalized run — drop.
+        if (!messageId) return;
         const run = runsRef.current.get(runId)!;
         run.streamContent = msg.content;
         const updatedContent = run.streamContent;
@@ -409,6 +440,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
           );
           setMessages((prev) => prev.filter((m) => !activeMessageIds.has(m.id)));
           runsRef.current.clear();
+          finalizedRunsRef.current.clear();
           setIsStreaming(false, "error-budget");
           return;
         }
@@ -426,6 +458,29 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
               ),
             );
             finalizeBubble(msg.runId);
+          } else {
+            // Unknown runId: the error fired before any chunk/thinking/
+            // tool_start arrived, so no bubble exists yet. Append a visible
+            // error-marked assistant message so the user sees the failure
+            // (same UX as the sendMessage catch branch below), and clear
+            // the streaming flag if no other runs are active — otherwise
+            // sendMessage's early setIsStreaming(true) leaves the input
+            // stuck in "Stop" mode (Codex P1 / S3).
+            const errMsgId = `assistant-${crypto.randomUUID()}`;
+            setMessages((prev) => [
+              ...prev,
+              { id: errMsgId, role: "assistant", content: `Error: ${displayError}` },
+            ]);
+            // Remember this runId as finalized so any late straggler events
+            // for it don't create a ghost bubble.
+            finalizedRunsRef.current.add(msg.runId);
+            if (finalizedRunsRef.current.size > 100) {
+              const first = finalizedRunsRef.current.values().next().value;
+              if (first) finalizedRunsRef.current.delete(first);
+            }
+            if (runsRef.current.size === 0) {
+              setIsStreaming(false, "error-scoped-unknown-run");
+            }
           }
           setError(displayError);
           return;
@@ -444,6 +499,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         );
         setError(displayError);
         runsRef.current.clear();
+        finalizedRunsRef.current.clear();
         setIsStreaming(false, "error-generic");
         return;
       }
@@ -451,6 +507,8 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       if (msg.type === "thinking") {
         const runId = msg.runId ?? "_default";
         const messageId = getOrCreateBubble(runId);
+        // Late event for a finalized run — drop.
+        if (!messageId) return;
         const run = runsRef.current.get(runId)!;
         run.thinking = msg.content;
         const updatedThinking = run.thinking;
@@ -465,6 +523,8 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       if (msg.type === "tool_start") {
         const runId = msg.runId ?? "_default";
         const messageId = getOrCreateBubble(runId);
+        // Late event for a finalized run — drop.
+        if (!messageId) return;
         setMessages((prev) =>
           prev.map((m) => {
             if (m.id !== messageId) return m;
@@ -505,11 +565,40 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         const runId = msg.runId ?? "_default";
         const run = runsRef.current.get(runId);
         const messageId = run?.messageId;
+        const nextStatus = msg.type === "tool_end" ? "done" : "error";
+
         if (!messageId) {
-          // No bubble for this run (unknown runId) — nothing to update.
+          // No active run for this runId — the bubble was already finalized
+          // (late tool_end after chat.final, or error-scoped-unknown-run).
+          // Fall back to a toolCallId scan across all assistant messages so
+          // the toolCall doesn't stay stuck at status "running" forever (S2).
+          if (msg.toolCallId !== undefined) {
+            const targetCallId = msg.toolCallId;
+            setMessages((prev) => {
+              let matched = false;
+              const next = prev.map((m) => {
+                if (m.role !== "assistant") return m;
+                const toolUses = m.toolUses ?? [];
+                const idx = toolUses.findIndex(
+                  (t) => t.toolCallId === targetCallId && t.status === "running",
+                );
+                if (idx < 0) return m;
+                matched = true;
+                const updated = toolUses.slice();
+                updated[idx] = {
+                  ...updated[idx],
+                  status: nextStatus as "done" | "error",
+                  ...(msg.result ? { result: msg.result } : {}),
+                  ...(msg.meta ? { meta: msg.meta } : {}),
+                };
+                return { ...m, toolUses: updated };
+              });
+              return matched ? next : prev;
+            });
+          }
+          // If no toolCallId or no match, silently drop (same as before).
           return;
         }
-        const nextStatus = msg.type === "tool_end" ? "done" : "error";
         setMessages((prev) =>
           prev.map((m) => {
             if (m.id !== messageId) return m;
@@ -821,6 +910,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     // Immediately update local state so the UI feels responsive
     setIsStreaming(false, "cancelMessage");
     runsRef.current.clear();
+    finalizedRunsRef.current.clear();
   }, [isStreaming, sendReq, sessionName]);
 
   // ---- Clear messages ----
@@ -838,6 +928,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     setError(null);
     setIsStreaming(false, "clearMessages");
     runsRef.current.clear();
+    finalizedRunsRef.current.clear();
   }, [sessionName]);
 
   // ---- Resolve approval (allow-once / allow-always / deny) ----

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -400,7 +400,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "chunk") {
-        const runId = msg.runId ?? "_default";
+        const runId = msg.runId;
         const messageId = getOrCreateBubble(runId);
         // Late event for a finalized run — drop.
         if (!messageId) return;
@@ -416,7 +416,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "done") {
-        const runId = msg.runId ?? "_default";
+        const runId = msg.runId;
         finalizeBubble(runId);
         return;
       }
@@ -505,7 +505,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "thinking") {
-        const runId = msg.runId ?? "_default";
+        const runId = msg.runId;
         const messageId = getOrCreateBubble(runId);
         // Late event for a finalized run — drop.
         if (!messageId) return;
@@ -521,7 +521,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "tool_start") {
-        const runId = msg.runId ?? "_default";
+        const runId = msg.runId;
         const messageId = getOrCreateBubble(runId);
         // Late event for a finalized run — drop.
         if (!messageId) return;
@@ -562,7 +562,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "tool_end" || msg.type === "tool_error") {
-        const runId = msg.runId ?? "_default";
+        const runId = msg.runId;
         const run = runsRef.current.get(runId);
         const messageId = run?.messageId;
         const nextStatus = msg.type === "tool_end" ? "done" : "error";

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -403,14 +403,13 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "done") {
-        setIsStreaming(false, "done-event");
-        currentAssistantIdRef.current = null;
-        streamContentRef.current = "";
+        const runId = msg.runId ?? "_default";
+        finalizeBubble(runId);
         return;
       }
 
       if (msg.type === "error") {
-        // Handle budget exceeded errors specially
+        // Budget-exceeded is a global terminal — not tied to a specific run.
         if (msg.code === "BUDGET_EXCEEDED") {
           setBudgetError({
             code: "BUDGET_EXCEEDED",
@@ -422,32 +421,48 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
             is_subscribed: msg.is_subscribed ?? false,
             tier: msg.tier ?? "free",
           });
-          // Remove the empty assistant message placeholder
-          if (currentAssistantIdRef.current) {
-            setMessages((prev) =>
-              prev.filter((m) => m.id !== currentAssistantIdRef.current),
-            );
-          }
+          // Remove any empty assistant placeholders across active runs.
+          const activeMessageIds = new Set(
+            Array.from(runsRef.current.values()).map((r) => r.messageId),
+          );
+          setMessages((prev) => prev.filter((m) => !activeMessageIds.has(m.id)));
+          runsRef.current.clear();
           setIsStreaming(false, "error-budget");
-          currentAssistantIdRef.current = null;
-          streamContentRef.current = "";
           return;
         }
 
         const displayError = friendlyError(msg.message);
-        if (currentAssistantIdRef.current) {
-          setMessages((prev) =>
-            prev.map((m) =>
-              m.id === currentAssistantIdRef.current
-                ? { ...m, content: displayError }
-                : m,
-            ),
-          );
+
+        if (msg.runId) {
+          // Scoped error: finalize that bubble only. Other runs continue.
+          const run = runsRef.current.get(msg.runId);
+          if (run) {
+            const messageId = run.messageId;
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === messageId ? { ...m, content: `Error: ${displayError}` } : m,
+              ),
+            );
+            finalizeBubble(msg.runId);
+          }
+          setError(displayError);
+          return;
         }
+
+        // Global error (no runId): mark every active bubble and clear state.
+        const activeMessageIds = new Set(
+          Array.from(runsRef.current.values()).map((r) => r.messageId),
+        );
+        setMessages((prev) =>
+          prev.map((m) =>
+            activeMessageIds.has(m.id)
+              ? { ...m, content: `Error: ${displayError}` }
+              : m,
+          ),
+        );
         setError(displayError);
+        runsRef.current.clear();
         setIsStreaming(false, "error-generic");
-        currentAssistantIdRef.current = null;
-        streamContentRef.current = "";
         return;
       }
 

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -229,7 +229,33 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
   // across dozens of turns).
   const finalizedRunsRef = useRef<Set<string>>(new Set());
 
+  // When cancelMessage/clearMessages fires before any event has arrived for
+  // the in-flight turn, we don't know what runId the server will use — so
+  // we can't pre-populate finalizedRunsRef. This flag closes the window:
+  // any unknown runId arriving while pending-cancel is set is treated as
+  // the cancelled turn and silently dropped. Cleared on the next
+  // sendMessage.
+  const pendingCancelRef = useRef<boolean>(false);
+
   const getOrCreateBubble = useCallback((runId: string): string | null => {
+    // Cancel-before-first-event race: if the user hit Stop/Clear BEFORE any
+    // chunk/thinking/tool_start arrived for the in-flight turn, runsRef was
+    // empty — so finalizeAllActiveRuns had no runIds to tombstone. A late
+    // first event for that cancelled turn would otherwise fall through to
+    // bubble-creation below, spawning a ghost bubble and flipping
+    // isStreaming back to true (silently undoing the cancel). Treat any
+    // unknown runId arriving during the pending-cancel window as the
+    // cancelled turn and drop it.
+    const existing = runsRef.current.get(runId);
+    if (!existing && pendingCancelRef.current) {
+      finalizedRunsRef.current.add(runId);
+      if (finalizedRunsRef.current.size > 100) {
+        const first = finalizedRunsRef.current.values().next().value;
+        if (first) finalizedRunsRef.current.delete(first);
+      }
+      return null;
+    }
+
     // Late event for an already-finalized run — drop silently. This
     // replicates the old `if (!currentAssistantIdRef.current) return;`
     // blanket guard, but scoped to truly-finalized runs instead of the
@@ -238,7 +264,6 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       return null;
     }
 
-    const existing = runsRef.current.get(runId);
     if (existing) return existing.messageId;
 
     const messageId = `assistant-${crypto.randomUUID()}`;
@@ -248,7 +273,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       { id: messageId, role: "assistant", content: "" },
     ]);
     if (!isStreamingRef.current) {
-      setIsStreaming(true, `run-${runId.slice(0, 12)}-start`);
+      setIsStreaming(true, `run-${String(runId).slice(0, 12)}-start`);
     }
     return messageId;
   }, [setIsStreaming]);
@@ -264,7 +289,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       if (first) finalizedRunsRef.current.delete(first);
     }
     if (runsRef.current.size === 0) {
-      setIsStreaming(false, `run-${runId.slice(0, 12)}-done`);
+      setIsStreaming(false, `run-${String(runId).slice(0, 12)}-done`);
     }
   }, [setIsStreaming]);
 
@@ -459,6 +484,8 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
           );
           setMessages((prev) => prev.filter((m) => !activeMessageIds.has(m.id)));
           finalizeAllActiveRuns();
+          // Close the window for late stragglers whose runId we never saw.
+          pendingCancelRef.current = true;
           setIsStreaming(false, "error-budget");
           return;
         }
@@ -517,6 +544,8 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         );
         setError(displayError);
         finalizeAllActiveRuns();
+        // Close the window for late stragglers whose runId we never saw.
+        pendingCancelRef.current = true;
         setIsStreaming(false, "error-generic");
         return;
       }
@@ -862,6 +891,10 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         msg_length: message.length,
       });
 
+      // A new turn invalidates any pending-cancel window from the previous
+      // turn. Events for this new turn must be allowed through normally.
+      pendingCancelRef.current = false;
+
       if (!agentIdRef.current) {
         throw new Error("No agent selected");
       }
@@ -927,6 +960,11 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     // Immediately update local state so the UI feels responsive
     setIsStreaming(false, "cancelMessage");
     finalizeAllActiveRuns();
+    // Close the cancel-before-first-event window: if runsRef was empty at
+    // this point (cancel fired before any event for the in-flight turn),
+    // finalizeAllActiveRuns had no runIds to tombstone, so the next late
+    // first-event would spawn a ghost bubble without this flag.
+    pendingCancelRef.current = true;
   }, [isStreaming, sendReq, sessionName, finalizeAllActiveRuns]);
 
   // ---- Clear messages ----
@@ -944,6 +982,9 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     setError(null);
     setIsStreaming(false, "clearMessages");
     finalizeAllActiveRuns();
+    // Same reasoning as cancelMessage: cover the case where clear fires
+    // before any event for the in-flight turn has arrived.
+    pendingCancelRef.current = true;
   }, [sessionName, finalizeAllActiveRuns]);
 
   // ---- Resolve approval (allow-once / allow-always / deny) ----

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -205,12 +205,9 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
   const [historyLoadState, setHistoryLoadState] = useState<"idle" | "loading" | "done">("idle");
   const isLoadingHistory = historyLoadState === "loading";
 
-  const currentAssistantIdRef = useRef<string | null>(null);
-  const streamContentRef = useRef<string>("");
-
-  // Multi-bubble: one assistant message per OpenClaw runId. This replaces
-  // currentAssistantIdRef + streamContentRef. OpenClaw assigns a new runId
-  // per LLM turn within a single chat.send; each turn gets its own bubble.
+  // Multi-bubble: one assistant message per OpenClaw runId. OpenClaw assigns
+  // a new runId per LLM turn within a single chat.send; each turn gets its
+  // own bubble.
   // See docs/superpowers/specs/2026-04-21-multi-bubble-chat-design.md.
   type RunState = {
     messageId: string;
@@ -327,7 +324,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
           msg_type: msg.type,
           msg_agent_id: (msg as { agent_id?: string }).agent_id,
           my_agent_id: agentIdRef.current,
-          ref: currentAssistantIdRef.current,
+          run_count: runsRef.current.size,
           streaming: isStreamingRef.current,
           error_code: (msg as { code?: string }).code,
           // NOTE: deliberately do not include the error message string — it
@@ -349,24 +346,9 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
           content_length: msg.content?.length ?? 0,
           msg_agent_id: msg.agent_id,
           my_agent_id: agentIdRef.current,
-          ref: currentAssistantIdRef.current,
+          run_count: runsRef.current.size,
           streaming: isStreamingRef.current,
         });
-      }
-
-      // Only process if we're currently streaming
-      if (!currentAssistantIdRef.current) {
-        if (msg.type !== "chunk" && msg.type !== "heartbeat") {
-          chatDebug("chat_msg_dropped_no_ref", { msg_type: msg.type });
-        } else if (msg.type === "chunk" && isChatDebugEnabled()) {
-          // Dropped chunk — critical signal for the post-approval bug.
-          // eslint-disable-next-line no-console
-          console.log("[chat-debug]", "chunk_dropped_no_ref", {
-            ts: Date.now(),
-            content_length: msg.content?.length ?? 0,
-          });
-        }
-        return;
       }
 
       // Drop messages meant for a different agent. Heartbeat and
@@ -555,14 +537,20 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
 
       if (msg.type === "heartbeat") {
-        if (!streamContentRef.current && currentAssistantIdRef.current) {
-          setMessages((prev) =>
-            prev.map((m) =>
-              m.id === currentAssistantIdRef.current
-                ? { ...m, content: "Agent is working..." }
-                : m,
-            ),
-          );
+        // If any run has empty content so far, show a "working..." hint on
+        // its bubble. Picks the first empty run (usually there's only one).
+        for (const run of runsRef.current.values()) {
+          if (!run.streamContent) {
+            const messageId = run.messageId;
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === messageId && !m.content
+                  ? { ...m, content: "Agent is working..." }
+                  : m,
+              ),
+            );
+            break;
+          }
         }
       }
     });
@@ -594,7 +582,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         host: payload?.request?.host,
         // shape only — no raw command (may contain paths/args)
         has_command: Boolean(payload?.request?.command),
-        ref: currentAssistantIdRef.current,
+        run_count: runsRef.current.size,
         streaming: isStreamingRef.current,
       });
       if (!payload?.id || !payload.request?.command) return;
@@ -620,59 +608,90 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       };
       const correlation = payload.request.toolCallId ?? payload.request.approvalCorrelationId;
 
-      if (!currentAssistantIdRef.current) return;
-      setMessages((prev) =>
-        prev.map((m) => {
-          if (m.id !== currentAssistantIdRef.current) return m;
-          const existing = m.toolUses ?? [];
-
-          // Idempotent: a retry/reconnect can redeliver the same approval.
-          // Overwrite the existing entry rather than creating a duplicate.
-          const idDupeIdx = existing.findIndex(
+      setMessages((prev) => {
+        // Idempotent: a retry/reconnect can redeliver the same approval.
+        // First pass: find any existing bubble that already has this approval
+        // id (dedupe).
+        for (const m of prev) {
+          if (m.role !== "assistant") continue;
+          const idx = (m.toolUses ?? []).findIndex(
             (t) => t.pendingApproval?.id === req.id,
           );
-          if (idDupeIdx >= 0) {
-            const next = existing.slice();
-            next[idDupeIdx] = {
-              ...next[idDupeIdx],
-              status: "pending-approval",
-              pendingApproval: req,
-            };
-            return { ...m, toolUses: next };
+          if (idx >= 0) {
+            return prev.map((row) => {
+              if (row.id !== m.id) return row;
+              const next = (row.toolUses ?? []).slice();
+              next[idx] = {
+                ...next[idx],
+                status: "pending-approval",
+                pendingApproval: req,
+              };
+              return { ...row, toolUses: next };
+            });
           }
+        }
 
-          // Pick the target ToolUse to promote to pending-approval.
-          // Prefer exact toolCallId match. For correlationless events, bind
-          // to the NEWEST running exec so concurrent commands don't misroute
-          // the card to an older, unrelated call.
-          let targetIdx = -1;
-          if (correlation) {
-            targetIdx = existing.findIndex(
+        // Second pass: find the target tool use by correlation id across
+        // all assistant messages. Prefer exact toolCallId match; for
+        // correlationless events, bind to the NEWEST running exec.
+        if (correlation) {
+          for (const m of prev) {
+            if (m.role !== "assistant") continue;
+            const idx = (m.toolUses ?? []).findIndex(
               (t) => t.toolCallId === correlation,
             );
-          } else {
-            for (let i = existing.length - 1; i >= 0; i--) {
-              if (existing[i].tool === "exec" && existing[i].status === "running") {
-                targetIdx = i;
-                break;
+            if (idx >= 0) {
+              return prev.map((row) => {
+                if (row.id !== m.id) return row;
+                const next = (row.toolUses ?? []).slice();
+                next[idx] = {
+                  ...next[idx],
+                  status: "pending-approval",
+                  pendingApproval: req,
+                };
+                return { ...row, toolUses: next };
+              });
+            }
+          }
+        } else {
+          // Scan from newest message backwards for a running exec.
+          for (let i = prev.length - 1; i >= 0; i--) {
+            const m = prev[i];
+            if (m.role !== "assistant") continue;
+            const toolUses = m.toolUses ?? [];
+            for (let j = toolUses.length - 1; j >= 0; j--) {
+              if (toolUses[j].tool === "exec" && toolUses[j].status === "running") {
+                return prev.map((row, rowIdx) => {
+                  if (rowIdx !== i) return row;
+                  const next = toolUses.slice();
+                  next[j] = {
+                    ...next[j],
+                    status: "pending-approval",
+                    pendingApproval: req,
+                  };
+                  return { ...row, toolUses: next };
+                });
               }
             }
           }
+        }
 
-          if (targetIdx >= 0) {
-            const next = existing.slice();
-            next[targetIdx] = {
-              ...next[targetIdx],
-              status: "pending-approval",
-              pendingApproval: req,
-            };
-            return { ...m, toolUses: next };
+        // Nothing matched — attach to the newest assistant message as a new
+        // tool entry (preserves old behavior for correlationless cases
+        // where no tool has started yet).
+        const lastAssistantIdx = (() => {
+          for (let i = prev.length - 1; i >= 0; i--) {
+            if (prev[i].role === "assistant") return i;
           }
-
+          return -1;
+        })();
+        if (lastAssistantIdx < 0) return prev;
+        return prev.map((row, i) => {
+          if (i !== lastAssistantIdx) return row;
           return {
-            ...m,
+            ...row,
             toolUses: [
-              ...existing,
+              ...(row.toolUses ?? []),
               {
                 tool: "exec",
                 toolCallId: correlation,
@@ -681,8 +700,8 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
               },
             ],
           };
-        }),
-      );
+        });
+      });
     });
 
     const unsubResolved = onEvent((eventName, data) => {
@@ -691,7 +710,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       chatDebug("approval_resolved_event_rx", {
         id: payload?.id,
         decision: payload?.decision,
-        ref: currentAssistantIdRef.current,
+        run_count: runsRef.current.size,
         streaming: isStreamingRef.current,
       });
       if (!payload?.id) return;
@@ -726,10 +745,9 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
   const sendMessage = useCallback(
     async (message: string): Promise<void> => {
       chatDebug("sendMessage_entry", {
-        prev_ref: currentAssistantIdRef.current,
+        prev_run_count: runsRef.current.size,
         prev_streaming: isStreamingRef.current,
         agent: agentIdRef.current,
-        // shape only — no raw user content
         msg_length: message.length,
       });
 
@@ -745,20 +763,17 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       setError(null);
       setBudgetError(null);
 
-      // Clear bootstrap flag once user sends their first message
       const key = agentIdRef.current ? `${agentIdRef.current}:${sessionName}` : null;
       if (key) _needsBootstrap.delete(key);
 
       const userMsgId = `user-${crypto.randomUUID()}`;
-      const assistantMsgId = `assistant-${crypto.randomUUID()}`;
 
-      currentAssistantIdRef.current = assistantMsgId;
-      streamContentRef.current = "";
-
+      // Add only the user message. Assistant bubbles are created lazily
+      // when OpenClaw emits the first event for a new runId — matches
+      // OpenClaw control-ui's implicit-bubble design. See spec §4.
       setMessages((prev) => [
         ...prev,
         { id: userMsgId, role: "user", content: message },
-        { id: assistantMsgId, role: "assistant", content: "" },
       ]);
       setIsStreaming(true, "sendMessage");
 
@@ -769,16 +784,14 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
           err instanceof Error ? err.message : "Failed to send message",
         );
         setError(errorMessage);
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantMsgId
-              ? { ...m, content: errorMessage }
-              : m,
-          ),
-        );
+        // No placeholder to update — append an error-marked assistant
+        // message so the user sees failure feedback.
+        const errMsgId = `assistant-${crypto.randomUUID()}`;
+        setMessages((prev) => [
+          ...prev,
+          { id: errMsgId, role: "assistant", content: `Error: ${errorMessage}` },
+        ]);
         setIsStreaming(false, "sendMessage-catch");
-        currentAssistantIdRef.current = null;
-        streamContentRef.current = "";
       }
     },
     [sendChat, isConnected, sessionName],
@@ -788,7 +801,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
   const cancelMessage = useCallback(async () => {
     chatDebug("cancelMessage_entry", {
-      ref: currentAssistantIdRef.current,
+      run_count: runsRef.current.size,
       streaming: isStreamingRef.current,
     });
     if (!agentIdRef.current || !isStreaming) return;
@@ -802,15 +815,14 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
     // Immediately update local state so the UI feels responsive
     setIsStreaming(false, "cancelMessage");
-    currentAssistantIdRef.current = null;
-    streamContentRef.current = "";
+    runsRef.current.clear();
   }, [isStreaming, sendReq, sessionName]);
 
   // ---- Clear messages ----
 
   const clearMessages = useCallback(() => {
     chatDebug("clearMessages_entry", {
-      ref: currentAssistantIdRef.current,
+      run_count: runsRef.current.size,
       streaming: isStreamingRef.current,
     });
     setMessages([]);
@@ -820,8 +832,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     }
     setError(null);
     setIsStreaming(false, "clearMessages");
-    currentAssistantIdRef.current = null;
-    streamContentRef.current = "";
+    runsRef.current.clear();
   }, [sessionName]);
 
   // ---- Resolve approval (allow-once / allow-always / deny) ----
@@ -830,14 +841,14 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     async (id: string, decision: ExecApprovalDecision): Promise<void> => {
       chatDebug("resolveApproval_start", {
         decision,
-        ref: currentAssistantIdRef.current,
+        run_count: runsRef.current.size,
         streaming: isStreamingRef.current,
       });
       try {
         const result = await sendReq("exec.approval.resolve", { id, decision });
         chatDebug("resolveApproval_done", {
           decision,
-          ref: currentAssistantIdRef.current,
+          run_count: runsRef.current.size,
           streaming: isStreamingRef.current,
           result_keys: result && typeof result === "object" ? Object.keys(result as object) : null,
         });

--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -47,10 +47,10 @@ export interface BudgetExceededPayload {
 export type ToolResultBlock = { type: string; text?: string; bytes?: number; omitted?: boolean };
 
 export type ChatIncomingMessage =
-  | { type: "chunk"; content: string; agent_id?: string }
-  | { type: "thinking"; content: string; agent_id?: string }
-  | { type: "done"; agent_id?: string }
-  | { type: "error"; message: string; code?: string; agent_id?: string } & Partial<BudgetExceededPayload>
+  | { type: "chunk"; content: string; agent_id?: string; runId?: string }
+  | { type: "thinking"; content: string; agent_id?: string; runId?: string }
+  | { type: "done"; agent_id?: string; runId?: string }
+  | ({ type: "error"; message: string; code?: string; agent_id?: string; runId?: string } & Partial<BudgetExceededPayload>)
   | { type: "heartbeat" }
   | {
       type: "tool_start";
@@ -58,6 +58,7 @@ export type ChatIncomingMessage =
       toolCallId?: string;
       args?: Record<string, unknown>;
       agent_id?: string;
+      runId?: string;
     }
   | {
       type: "tool_end";
@@ -66,6 +67,7 @@ export type ChatIncomingMessage =
       result?: ToolResultBlock[];
       meta?: string;
       agent_id?: string;
+      runId?: string;
     }
   | {
       type: "tool_error";
@@ -74,6 +76,7 @@ export type ChatIncomingMessage =
       result?: ToolResultBlock[];
       meta?: string;
       agent_id?: string;
+      runId?: string;
     }
   | { type: "update_available" };
 

--- a/apps/frontend/src/hooks/useGateway.tsx
+++ b/apps/frontend/src/hooks/useGateway.tsx
@@ -47,9 +47,9 @@ export interface BudgetExceededPayload {
 export type ToolResultBlock = { type: string; text?: string; bytes?: number; omitted?: boolean };
 
 export type ChatIncomingMessage =
-  | { type: "chunk"; content: string; agent_id?: string; runId?: string }
-  | { type: "thinking"; content: string; agent_id?: string; runId?: string }
-  | { type: "done"; agent_id?: string; runId?: string }
+  | { type: "chunk"; content: string; agent_id?: string; runId: string }
+  | { type: "thinking"; content: string; agent_id?: string; runId: string }
+  | { type: "done"; agent_id?: string; runId: string }
   | ({ type: "error"; message: string; code?: string; agent_id?: string; runId?: string } & Partial<BudgetExceededPayload>)
   | { type: "heartbeat" }
   | {
@@ -58,7 +58,7 @@ export type ChatIncomingMessage =
       toolCallId?: string;
       args?: Record<string, unknown>;
       agent_id?: string;
-      runId?: string;
+      runId: string;
     }
   | {
       type: "tool_end";
@@ -67,7 +67,7 @@ export type ChatIncomingMessage =
       result?: ToolResultBlock[];
       meta?: string;
       agent_id?: string;
-      runId?: string;
+      runId: string;
     }
   | {
       type: "tool_error";
@@ -76,7 +76,7 @@ export type ChatIncomingMessage =
       result?: ToolResultBlock[];
       meta?: string;
       agent_id?: string;
-      runId?: string;
+      runId: string;
     }
   | { type: "update_available" };
 


### PR DESCRIPTION
## Summary

Frontend half of the multi-bubble chat refactor. Backend counterpart: #349.

Replaces the single-`currentAssistantIdRef` state in `useAgentChat` with a `runsRef: Map<runId, RunState>`. Each distinct `runId` arriving from OpenClaw gets its own assistant bubble, matching OpenClaw control-ui's protocol-native design.

## Why

Root cause of the long-standing post-tool-approval one-turn-behind bug: OpenClaw emits `chat.state: "final"` **per LLM turn**, not per user message. Each turn has a distinct `runId` (and post-approval turns use the named `exec-approval-followup:<id>` runId). Our single-bubble code treated the first `final` as terminal and silently dropped subsequent turns' chunks until the *next* user message created a new bubble — visible as output appearing one turn late.

Confirmed empirically via CloudWatch: a single `chat.send` produced runIds `76b77ee2-…`, `92aaf3d5-…`, `daf5422d-…`, `595083a1-…`, `exec-approval-followup:c663eb07-…`.

## What changed

- `useGateway.tsx` — `runId?: string` added to every `ChatIncomingMessage` variant (chunk/thinking/done/error/tool_start/tool_end/tool_error)
- `useAgentChat.ts`
  - New `type RunState = { messageId, streamContent, thinking }` and `runsRef: useRef<Map<string, RunState>>(new Map())`
  - `getOrCreateBubble(runId)` lazily mints a fresh assistant message when the first event for a new runId arrives
  - `finalizeBubble(runId)` cleans up on `done` / scoped `error`
  - `sendMessage` no longer pre-creates an empty assistant placeholder — bubbles are created lazily on first chunk
  - `exec.approval.requested` correlation scan widened across **all** assistant messages (not just the last) so approvals that match a toolCall on an earlier bubble land correctly
  - All references to the old `currentAssistantIdRef` / `streamContentRef` removed
- New unit tests in `useAgentChat.test.ts` (7 total):
  - Single-run: chunks route to one bubble
  - Multi-run: chunks with different runIds create separate bubbles
  - Union: `isStreaming` reflects any active run
  - Scoped error (runId) → only that bubble marked
  - Global error (no runId) → all active bubbles marked, runsRef cleared
  - `sendMessage` does not pre-create a placeholder
  - Cross-bubble approval correlation

`MessageList.tsx` is unchanged — rendering already iterates messages in order.

## Test plan

- [x] 7/7 new multi-bubble unit tests pass
- [x] Full frontend suite: 281 pass / 9 pre-existing baseline failures (no new failures)
- [x] `pnpm tsc --noEmit` clean
- [ ] On dev: single-turn chat still streams into one bubble
- [ ] On dev: multi-turn chat (tool call → approval → post-approval response) now renders each LLM turn as its own bubble, post-approval response appears in the correct turn (not one-turn-behind)
- [ ] On dev: global errors still clear all active runs; scoped errors still target a single bubble

## Refs

- Spec: `docs/superpowers/specs/2026-04-21-multi-bubble-chat-design.md`
- Plan: `docs/superpowers/plans/2026-04-21-multi-bubble-chat.md`
- Backend PR: #349 (must deploy first — forwards `runId` on chat-terminal events)
- Cleanup PR (forthcoming): will remove the debug instrumentation introduced in #332/#333/#336/#338

🤖 Generated with [Claude Code](https://claude.com/claude-code)