### PR TITLE
fix(chat): auto-scroll during streaming + typing placeholder header

### DIFF
--- a/apps/frontend/src/components/chat/MessageList.tsx
+++ b/apps/frontend/src/components/chat/MessageList.tsx
@@ -411,13 +411,87 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
   function MessageList({ messages, isTyping, agentName, onRetry, onOpenFile, onDecide }, ref) {
     const { containerRef, endRef, scrollToBottom } = useScrollToBottom();
 
+    // Track whether the user is at (or near) the bottom of the scroll
+    // container. While true, incoming streamed chunks pull the view down.
+    // If the user scrolls up to re-read an earlier message, we stop
+    // pulling — they'll scroll back down themselves. Threshold matches
+    // Tailwind's `space-y-10` (~40px) plus a comfortable margin.
+    const isNearBottomRef = React.useRef(true);
+    const hasMountedRef = React.useRef(false);
+    const prevMessagesLengthRef = React.useRef(0);
+    const prevLastContentLengthRef = React.useRef(0);
+    const prevLastRoleRef = React.useRef<"user" | "assistant" | undefined>(undefined);
+
     React.useImperativeHandle(ref, () => ({
       scrollToBottom,
     }));
 
+    const handleScroll = React.useCallback(() => {
+      const c = containerRef.current;
+      if (!c) return;
+      const distance = c.scrollHeight - c.scrollTop - c.clientHeight;
+      isNearBottomRef.current = distance < 120;
+    }, [containerRef]);
+
+    // Auto-scroll rules:
+    //   - First render (agent switch / history load) → snap to bottom.
+    //   - Length increased → a new message arrived; snap if near bottom,
+    //     or unconditionally if the new message is from the user (they
+    //     just sent it, they want to see it).
+    //   - Length same, last message's content grew → streaming chunk on
+    //     the tail bubble; snap only if near bottom (so a user who
+    //     scrolled up isn't yanked back while reading).
+    React.useEffect(() => {
+      const container = containerRef.current;
+      const end = endRef.current;
+      if (!container || !end) return;
+
+      const lastMsg = messages[messages.length - 1];
+      const lastContentLength = lastMsg?.content?.length ?? 0;
+      const lastRole = lastMsg?.role;
+
+      const lengthIncreased = messages.length > prevMessagesLengthRef.current;
+      const contentGrew =
+        messages.length === prevMessagesLengthRef.current &&
+        lastContentLength > prevLastContentLengthRef.current;
+      const newUserMessage =
+        lengthIncreased && lastRole === "user" && lastRole !== prevLastRoleRef.current;
+
+      const isFirstPaintWithMessages = !hasMountedRef.current && messages.length > 0;
+
+      // JSDOM test envs don't always polyfill scrollIntoView; production
+      // browsers always have it. Optional-chain so tests that don't mock
+      // it don't crash when they transitively render MessageList.
+      if (isFirstPaintWithMessages || newUserMessage) {
+        end.scrollIntoView?.({ behavior: "auto", block: "end" });
+        isNearBottomRef.current = true;
+        hasMountedRef.current = true;
+      } else if ((lengthIncreased || contentGrew) && isNearBottomRef.current) {
+        end.scrollIntoView?.({ behavior: "auto", block: "end" });
+      }
+
+      if (messages.length > 0) hasMountedRef.current = true;
+      prevMessagesLengthRef.current = messages.length;
+      prevLastContentLengthRef.current = lastContentLength;
+      prevLastRoleRef.current = lastRole;
+    }, [messages, containerRef, endRef]);
+
+    // The "typing placeholder" shows the agent header (animated thinking
+    // glyph) during the window between `sendMessage` and the first
+    // streamed chunk. Since multi-bubble rendering creates assistant
+    // bubbles lazily on first event (spec §4), nothing else is on screen
+    // to signal "the agent received your message and is working." This
+    // placeholder is rendered only when streaming is active AND the last
+    // message is a user message (or there are no messages yet).
+    const showTypingPlaceholder =
+      !!isTyping &&
+      (messages.length === 0 ||
+        messages[messages.length - 1].role === "user");
+
     return (
       <div
         ref={containerRef}
+        onScroll={handleScroll}
         className="flex-1 min-h-0 overflow-y-auto p-4 md:px-8"
         data-lenis-prevent
       >
@@ -478,6 +552,16 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
             </div>
           );
           })}
+          {showTypingPlaceholder && (
+            <div
+              data-testid="typing-placeholder"
+              className="flex w-full justify-start"
+            >
+              <div className="flex flex-col min-w-0 max-w-[85%]">
+                <AgentHead name={agentName || "Assistant"} state="thinking" />
+              </div>
+            </div>
+          )}
           <div ref={endRef} />
         </div>
       </div>

--- a/apps/frontend/src/components/chat/MessageList.tsx
+++ b/apps/frontend/src/components/chat/MessageList.tsx
@@ -454,8 +454,12 @@ export const MessageList = React.forwardRef<MessageListHandle, MessageListProps>
       const contentGrew =
         messages.length === prevMessagesLengthRef.current &&
         lastContentLength > prevLastContentLengthRef.current;
-      const newUserMessage =
-        lengthIncreased && lastRole === "user" && lastRole !== prevLastRoleRef.current;
+      // Any new message whose tail is a user message is a fresh user send
+      // (multi-bubble `sendMessage` appends only the user row, and a
+      // cancel-before-first-event turn can leave the previous tail as
+      // user too — so don't gate on role *changing*, just on "new tail
+      // is user"). Always snap so the user's own message is visible.
+      const newUserMessage = lengthIncreased && lastRole === "user";
 
       const isFirstPaintWithMessages = !hasMountedRef.current && messages.length > 0;
 

--- a/apps/frontend/tests/unit/components/chat/MessageList.test.tsx
+++ b/apps/frontend/tests/unit/components/chat/MessageList.test.tsx
@@ -75,7 +75,7 @@ describe('MessageList', () => {
   });
 
   describe('typing indicator', () => {
-    it('shows for empty assistant message when isTyping', () => {
+    it('shows the thinking glyph on an existing empty assistant bubble when isTyping', () => {
       render(
         <MessageList
           messages={[{ id: '1', role: 'assistant', content: '' }]}
@@ -83,8 +83,8 @@ describe('MessageList', () => {
         />
       );
 
-      const infinity = document.querySelectorAll('.thinking-infinity');
-      expect(infinity.length).toBe(1);
+      const thinking = document.querySelectorAll('.agent-glyph--thinking');
+      expect(thinking.length).toBe(1);
     });
 
     it('hides when not typing', () => {
@@ -95,39 +95,146 @@ describe('MessageList', () => {
         />
       );
 
-      const infinity = document.querySelectorAll('.thinking-infinity');
-      expect(infinity.length).toBe(0);
+      const thinking = document.querySelectorAll('.agent-glyph--thinking');
+      expect(thinking.length).toBe(0);
     });
 
-    it('never shows for user messages', () => {
+    it('does NOT attach to user messages', () => {
       render(
         <MessageList
-          messages={[{ id: '1', role: 'user', content: '' }]}
+          messages={[{ id: '1', role: 'user', content: 'hi' }]}
+          isTyping={false}
+        />
+      );
+
+      // No assistant bubble exists, no typing either → nothing to show.
+      expect(document.querySelectorAll('.agent-glyph--thinking').length).toBe(0);
+      expect(screen.queryByTestId('typing-placeholder')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('typing placeholder (pre-stream header)', () => {
+    // Fixes "I don't see the header loading while the response is coming at
+    // first" — multi-bubble rendering creates assistant bubbles lazily on
+    // first chunk, so the window between sendMessage and first chunk had no
+    // AgentHead to animate. The placeholder fills that gap.
+
+    it('shows when last message is user AND isTyping', () => {
+      render(
+        <MessageList
+          messages={[{ id: '1', role: 'user', content: 'What is the weather?' }]}
+          isTyping={true}
+          agentName="Robbie"
+        />
+      );
+
+      expect(screen.getByTestId('typing-placeholder')).toBeInTheDocument();
+      // The placeholder renders an AgentHead with state="thinking" —
+      // verify the animated glyph is there and the agent name is shown.
+      const placeholder = screen.getByTestId('typing-placeholder');
+      expect(placeholder.querySelector('.agent-glyph--thinking')).toBeInTheDocument();
+      expect(placeholder).toHaveTextContent('Robbie');
+    });
+
+    it('shows when there are no messages yet AND isTyping', () => {
+      render(<MessageList messages={[]} isTyping={true} />);
+      expect(screen.getByTestId('typing-placeholder')).toBeInTheDocument();
+    });
+
+    it('hides once an assistant bubble exists (even if still streaming)', () => {
+      render(
+        <MessageList
+          messages={[
+            { id: '1', role: 'user', content: 'hi' },
+            { id: '2', role: 'assistant', content: 'Hello' },
+          ]}
           isTyping={true}
         />
       );
 
-      const infinity = document.querySelectorAll('.thinking-infinity');
-      expect(infinity.length).toBe(0);
+      // Assistant bubble is present → the real AgentHead carries the
+      // thinking state; the placeholder stays hidden.
+      expect(screen.queryByTestId('typing-placeholder')).not.toBeInTheDocument();
+      expect(document.querySelectorAll('.agent-glyph--thinking').length).toBe(1);
+    });
+
+    it('hides when isTyping is false', () => {
+      render(
+        <MessageList
+          messages={[{ id: '1', role: 'user', content: 'hi' }]}
+          isTyping={false}
+        />
+      );
+      expect(screen.queryByTestId('typing-placeholder')).not.toBeInTheDocument();
     });
   });
 
   describe('auto-scroll', () => {
     it('renders scroll anchor element at end of messages', () => {
-      // The useScrollToBottom hook provides refs for CSS-based scrolling
-      // The endRef element acts as a scroll anchor
       const { container } = render(
         <MessageList messages={[{ id: '1', role: 'user', content: 'Test message' }]} />
       );
 
-      // Verify the scroll container and end anchor exist
       const scrollContainer = container.querySelector('[data-lenis-prevent]');
       expect(scrollContainer).toBeInTheDocument();
 
-      // The end ref div should exist after messages
       const messageContainer = container.querySelector('.space-y-10');
       expect(messageContainer).toBeInTheDocument();
       expect(messageContainer?.lastElementChild?.tagName).toBe('DIV');
+    });
+
+    it('scrolls to bottom on first paint with messages (agent-entry / history load)', () => {
+      const scrollSpy = vi.fn();
+      Element.prototype.scrollIntoView = scrollSpy;
+
+      render(<MessageList messages={mockMessages} />);
+
+      // The effect should have fired the anchor's scrollIntoView at least
+      // once for the initial paint. Assert behavior: "auto" (no animation)
+      // so long histories don't animate.
+      expect(scrollSpy).toHaveBeenCalled();
+      expect(scrollSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ behavior: 'auto' }),
+      );
+    });
+
+    it('scrolls when a new user message is added (force-scroll)', () => {
+      const scrollSpy = vi.fn();
+      Element.prototype.scrollIntoView = scrollSpy;
+
+      const { rerender } = render(
+        <MessageList messages={[{ id: '1', role: 'assistant', content: 'hi' }]} />
+      );
+      scrollSpy.mockClear();
+
+      rerender(
+        <MessageList
+          messages={[
+            { id: '1', role: 'assistant', content: 'hi' },
+            { id: '2', role: 'user', content: 'hey' },
+          ]}
+        />
+      );
+
+      expect(scrollSpy).toHaveBeenCalled();
+    });
+
+    it('scrolls when streamed content grows on the tail assistant bubble', () => {
+      const scrollSpy = vi.fn();
+      Element.prototype.scrollIntoView = scrollSpy;
+
+      const { rerender } = render(
+        <MessageList messages={[{ id: '1', role: 'assistant', content: 'A' }]} />
+      );
+      scrollSpy.mockClear();
+
+      rerender(
+        <MessageList messages={[{ id: '1', role: 'assistant', content: 'A longer streamed response' }]} />
+      );
+
+      // JSDOM defaults scrollHeight / scrollTop / clientHeight to 0, which
+      // yields distance = 0 → isNearBottom = true → we scroll.
+      expect(scrollSpy).toHaveBeenCalled();
     });
   });
 });

--- a/apps/frontend/tests/unit/components/chat/MessageList.test.tsx
+++ b/apps/frontend/tests/unit/components/chat/MessageList.test.tsx
@@ -219,6 +219,30 @@ describe('MessageList', () => {
       expect(scrollSpy).toHaveBeenCalled();
     });
 
+    it('scrolls when a SECOND user message is sent back-to-back (tail role stays "user")', () => {
+      // Multi-bubble sendMessage appends only a user row — so two sends
+      // in a row (no assistant response between) leave the tail role as
+      // user. The force-scroll rule must not gate on role *changing*.
+      const scrollSpy = vi.fn();
+      Element.prototype.scrollIntoView = scrollSpy;
+
+      const { rerender } = render(
+        <MessageList messages={[{ id: '1', role: 'user', content: 'first' }]} />
+      );
+      scrollSpy.mockClear();
+
+      rerender(
+        <MessageList
+          messages={[
+            { id: '1', role: 'user', content: 'first' },
+            { id: '2', role: 'user', content: 'second' },
+          ]}
+        />
+      );
+
+      expect(scrollSpy).toHaveBeenCalled();
+    });
+
     it('scrolls when streamed content grows on the tail assistant bubble', () => {
       const scrollSpy = vi.fn();
       Element.prototype.scrollIntoView = scrollSpy;


### PR DESCRIPTION
## Summary

Three small UX fixes in `MessageList.tsx`, all follow-ups to the multi-bubble refactor (#350):

1. **Auto-scroll to bottom as streamed chunks arrive** — provided the user is still near the bottom. If they scroll up to re-read an earlier message, we stop pulling the view down. Threshold: 120px from bottom.
2. **Snap to bottom on first paint** (agent entry / history load) — a long conversation opens at the latest exchange instead of the top.
3. **Render a typing placeholder header** during the pre-stream wait — multi-bubble rendering creates assistant bubbles lazily on first event, so the window between `sendMessage` and the first chunk previously had no AgentHead to show the agent was working. The placeholder shows the animated AgentHead glyph + agent name until the real bubble appears.

## Test plan

- [x] MessageList typing-indicator test was pre-existing baseline failure (checked for a removed `.thinking-infinity` class). Rewritten to assert on the real `.agent-glyph--thinking` class and the new placeholder. Net: one baseline failure fixed, no new regressions.
- [x] +7 new tests covering placeholder rules and auto-scroll paths (20/20 pass in `MessageList.test.tsx`).
- [x] Full frontend suite: 295 pass / 8 pre-existing baseline failures (down from 9).
- [x] `pnpm tsc --noEmit` clean.
- [ ] On dev: initial agent-switch opens at the latest messages
- [ ] On dev: header visible immediately after send (before first chunk arrives)
- [ ] On dev: view follows streaming output; stops following if user scrolls up

## Notes

- All changes are in `MessageList.tsx` (+ the targeted test file). No changes to `useAgentChat.ts` — multi-bubble state machine is untouched.
- Optional-chained `scrollIntoView?.(...)` so tests transitively rendering `MessageList` without mocking don't crash in JSDOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)