### PR TITLE
feat(admin): Phase A — infra + config foundations (#351)

### DIFF
--- a/apps/backend/core/config.py
+++ b/apps/backend/core/config.py
@@ -58,11 +58,42 @@ class Settings(BaseSettings):
     AGENT_CATALOG_BUCKET: str = os.getenv("AGENT_CATALOG_BUCKET", "")
 
     # --- Platform admin ---
-    # Comma-separated Clerk user IDs allowed to call /admin/catalog/publish.
+    # Comma-separated Clerk user IDs allowed to call /admin/catalog/publish
+    # AND every endpoint under /api/v1/admin/* (the admin dashboard).
     # v1 is env-driven rather than org-role-driven because "platform admin"
-    # (Isol8 team publishing curated agents) is distinct from "org admin"
-    # (customer admin of a customer org).
+    # (Isol8 team) is distinct from "org admin" (customer admin of a
+    # customer org). See require_platform_admin in core/auth.py.
     PLATFORM_ADMIN_USER_IDS: str = os.getenv("PLATFORM_ADMIN_USER_IDS", "")
+
+    # --- Admin dashboard (v1, see #351) ---
+    # Master switch — false means /admin/* returns 404 from the Next.js
+    # middleware. Flip true on a per-environment basis to expose the surface.
+    ADMIN_UI_ENABLED: bool = os.getenv("ADMIN_UI_ENABLED", "false").lower() == "true"
+
+    # Per-user opt-in allowlist for staged rollout. When non-empty, only
+    # listed Clerk user IDs see the admin UI even when ADMIN_UI_ENABLED=true.
+    # Comma-separated. Empty string = open to every PLATFORM_ADMIN_USER_IDS member.
+    ADMIN_UI_ENABLED_USER_IDS: str = os.getenv("ADMIN_UI_ENABLED_USER_IDS", "")
+
+    # Whether to write an audit row for every read-only admin GET
+    # (e.g. /admin/users/{id}/overview). Default true so PII viewing
+    # leaves a trail. Disable to reduce DDB write volume in dev.
+    ADMIN_AUDIT_VIEWS: bool = os.getenv("ADMIN_AUDIT_VIEWS", "true").lower() == "true"
+
+    # --- PostHog (server-side, distinct from NEXT_PUBLIC_POSTHOG_KEY) ---
+    # Used by core/services/posthog_admin.py to query the Persons API for the
+    # admin dashboard's Activity tab. Empty defaults so the admin client
+    # stubs gracefully (returns {events: [], stubbed: true}) when unset —
+    # local dev works without a real PostHog project.
+    POSTHOG_HOST: str = os.getenv("POSTHOG_HOST", "https://app.posthog.com")
+    POSTHOG_PROJECT_ID: str = os.getenv("POSTHOG_PROJECT_ID", "")
+    POSTHOG_PROJECT_API_KEY: str = os.getenv("POSTHOG_PROJECT_API_KEY", "")
+
+    @property
+    def admin_ui_enabled_user_ids(self) -> set[str]:
+        """Parsed allowlist for ADMIN_UI_ENABLED_USER_IDS."""
+        raw = self.ADMIN_UI_ENABLED_USER_IDS or ""
+        return {u.strip() for u in raw.split(",") if u.strip()}
 
     # --- IAM ---
     CONTAINER_EXECUTION_ROLE_ARN: str = os.getenv("CONTAINER_EXECUTION_ROLE_ARN", "")

--- a/apps/backend/tests/unit/core/test_config_admin.py
+++ b/apps/backend/tests/unit/core/test_config_admin.py
@@ -1,0 +1,111 @@
+"""Unit tests for admin-dashboard settings in core.config.
+
+Covers ADMIN_UI_ENABLED feature flag, ADMIN_UI_ENABLED_USER_IDS allowlist
+override (with parsed @property), ADMIN_AUDIT_VIEWS toggle, and
+POSTHOG_HOST/POSTHOG_PROJECT_ID/POSTHOG_PROJECT_API_KEY server-side
+PostHog secrets.
+"""
+
+import os
+from unittest.mock import patch
+
+
+class TestAdminUiSettings:
+    def test_admin_ui_enabled_defaults_false(self):
+        """v1 ships dark — admin surface returns 404 unless explicitly flipped."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ADMIN_UI_ENABLED", None)
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.ADMIN_UI_ENABLED is False
+
+    def test_admin_ui_enabled_reads_env(self):
+        with patch.dict(os.environ, {"ADMIN_UI_ENABLED": "true"}):
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.ADMIN_UI_ENABLED is True
+
+    def test_admin_ui_enabled_user_ids_default_empty(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ADMIN_UI_ENABLED_USER_IDS", None)
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.ADMIN_UI_ENABLED_USER_IDS == ""
+            assert fresh.admin_ui_enabled_user_ids == set()
+
+    def test_admin_ui_enabled_user_ids_parses_csv(self):
+        with patch.dict(
+            os.environ,
+            {"ADMIN_UI_ENABLED_USER_IDS": "user_alpha, user_beta ,user_gamma"},
+        ):
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.admin_ui_enabled_user_ids == {
+                "user_alpha",
+                "user_beta",
+                "user_gamma",
+            }
+
+    def test_admin_ui_enabled_user_ids_skips_empty_entries(self):
+        with patch.dict(os.environ, {"ADMIN_UI_ENABLED_USER_IDS": "user_alpha,, ,user_beta"}):
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.admin_ui_enabled_user_ids == {"user_alpha", "user_beta"}
+
+    def test_admin_audit_views_defaults_true(self):
+        """Read endpoints log audit rows by default — admins probing user data leaves a trail."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ADMIN_AUDIT_VIEWS", None)
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.ADMIN_AUDIT_VIEWS is True
+
+    def test_admin_audit_views_can_be_disabled(self):
+        with patch.dict(os.environ, {"ADMIN_AUDIT_VIEWS": "false"}):
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.ADMIN_AUDIT_VIEWS is False
+
+
+class TestPostHogServerSettings:
+    def test_posthog_host_defaults_to_us_cloud(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("POSTHOG_HOST", None)
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.POSTHOG_HOST == "https://app.posthog.com"
+
+    def test_posthog_project_id_defaults_empty(self):
+        """Empty defaults make posthog_admin client stub gracefully when unset."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("POSTHOG_PROJECT_ID", None)
+            os.environ.pop("POSTHOG_PROJECT_API_KEY", None)
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.POSTHOG_PROJECT_ID == ""
+            assert fresh.POSTHOG_PROJECT_API_KEY == ""
+
+    def test_posthog_settings_reads_env(self):
+        with patch.dict(
+            os.environ,
+            {
+                "POSTHOG_HOST": "https://eu.posthog.com",
+                "POSTHOG_PROJECT_ID": "12345",
+                "POSTHOG_PROJECT_API_KEY": "phc_secret_xyz",
+            },
+        ):
+            from core.config import Settings
+
+            fresh = Settings()
+            assert fresh.POSTHOG_HOST == "https://eu.posthog.com"
+            assert fresh.POSTHOG_PROJECT_ID == "12345"
+            assert fresh.POSTHOG_PROJECT_API_KEY == "phc_secret_xyz"

--- a/apps/infra/lib/isol8-stage.ts
+++ b/apps/infra/lib/isol8-stage.ts
@@ -75,6 +75,7 @@ export class Isol8Stage extends cdk.Stage {
         usageCountersTable: database.usageCountersTable,
         pendingUpdatesTable: database.pendingUpdatesTable,
         channelLinksTable: database.channelLinksTable,
+        adminActionsTable: database.adminActionsTable,
       },
       // Pass secret names as plain strings to avoid cross-stack refs to AuthStack.
       // These names match the secretName used in AuthStack's createSecret helper.

--- a/apps/infra/lib/local-stage.ts
+++ b/apps/infra/lib/local-stage.ts
@@ -80,6 +80,7 @@ export class LocalStage extends cdk.Stage {
         usageCountersTable: database.usageCountersTable,
         pendingUpdatesTable: database.pendingUpdatesTable,
         channelLinksTable: database.channelLinksTable,
+        adminActionsTable: database.adminActionsTable,
       },
       secretNames: {
         clerkIssuer: `isol8/${env}/clerk_issuer`,

--- a/apps/infra/lib/stacks/database-stack.ts
+++ b/apps/infra/lib/stacks/database-stack.ts
@@ -22,6 +22,7 @@ export class DatabaseStack extends cdk.Stack {
   public readonly pendingUpdatesTable: dynamodb.Table;
   public readonly channelLinksTable: dynamodb.Table;
   public readonly webhookDedupTable: dynamodb.Table;
+  public readonly adminActionsTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: DatabaseStackProps) {
     super(scope, id, props);
@@ -146,6 +147,33 @@ export class DatabaseStack extends cdk.Stack {
     new cdk.CfnOutput(this, "WebhookDedupTableName", {
       value: this.webhookDedupTable.tableName,
       exportName: `${this.stackName}-webhook-dedup-table`,
+    });
+
+    // Admin-actions audit table — every platform-admin write to /api/v1/admin/*
+    // appends a row via @audit_admin_action. PK admin_user_id + SK timestamp#uuidv7
+    // for chronological-per-admin queries; GSI flips to target_user_id for the
+    // "show me all actions taken against this user" view. No TTL (CEO review:
+    // audit rows kept forever). Customer-managed KMS encryption like every
+    // other table in this stack.
+    this.adminActionsTable = new dynamodb.Table(this, "AdminActionsTable", {
+      tableName: `isol8-${env}-admin-actions`,
+      partitionKey: { name: "admin_user_id", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "timestamp_action_id", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: config.removalPolicy,
+      pointInTimeRecovery: true,
+      encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey: props.kmsKey,
+    });
+    this.adminActionsTable.addGlobalSecondaryIndex({
+      indexName: "target-timestamp-index",
+      partitionKey: { name: "target_user_id", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "timestamp_action_id", type: dynamodb.AttributeType.STRING },
+    });
+
+    new cdk.CfnOutput(this, "AdminActionsTableName", {
+      value: this.adminActionsTable.tableName,
+      exportName: `${this.stackName}-admin-actions-table`,
     });
 
     new cdk.CfnOutput(this, "DynamoTablePrefix", {

--- a/apps/infra/lib/stacks/service-stack.ts
+++ b/apps/infra/lib/stacks/service-stack.ts
@@ -286,9 +286,14 @@ export class ServiceStack extends cdk.Stack {
     );
 
     // CloudWatch Logs read — for the admin dashboard inline log viewer
-    // (apps/backend/core/services/cloudwatch_logs.py). Scoped to the
-    // backend's own log group ARN; never "*" — least privilege per CEO
-    // review (#351, Phase A Task 2).
+    // (apps/backend/core/services/cloudwatch_logs.py, Phase B). Scoped to
+    // the backend's own log group ARN; never "*" — least privilege per
+    // CEO review (#351, Phase A Task 2).
+    //
+    // Log group name matches service-stack.ts:519 + isol8-stage.ts:113 +
+    // local-stage.ts:116 — `/ecs/isol8-${env}` (no /aws prefix, no
+    // -backend suffix). The Phase B cloudwatch_logs service must use this
+    // same name when constructing FilterLogEvents calls.
     this.taskRole.addToPolicy(
       new iam.PolicyStatement({
         sid: "CloudWatchLogsReadForAdmin",
@@ -301,7 +306,7 @@ export class ServiceStack extends cdk.Stack {
           "logs:DescribeLogStreams",
         ],
         resources: [
-          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/ecs/isol8-${env}-backend:*`,
+          `arn:aws:logs:${this.region}:${this.account}:log-group:/ecs/isol8-${env}:*`,
         ],
       }),
     );

--- a/apps/infra/lib/stacks/service-stack.ts
+++ b/apps/infra/lib/stacks/service-stack.ts
@@ -41,6 +41,7 @@ export interface ServiceStackProps extends cdk.StackProps {
     usageCountersTable: dynamodb.Table;
     pendingUpdatesTable: dynamodb.Table;
     channelLinksTable: dynamodb.Table;
+    adminActionsTable: dynamodb.Table;
   };
   /** Pass secret names (strings) to avoid cross-stack KMS auto-grant cycles. */
   secretNames: SecretNames;
@@ -229,6 +230,7 @@ export class ServiceStack extends cdk.Stack {
     props.database.usageCountersTable.grantReadWriteData(this.taskRole);
     props.database.pendingUpdatesTable.grantReadWriteData(this.taskRole);
     props.database.channelLinksTable.grantReadWriteData(this.taskRole);
+    props.database.adminActionsTable.grantReadWriteData(this.taskRole);
 
     // Bedrock
     this.taskRole.addToPolicy(
@@ -280,6 +282,27 @@ export class ServiceStack extends cdk.Stack {
           "cloudwatch:PutMetricData",
         ],
         resources: ["*"],
+      }),
+    );
+
+    // CloudWatch Logs read — for the admin dashboard inline log viewer
+    // (apps/backend/core/services/cloudwatch_logs.py). Scoped to the
+    // backend's own log group ARN; never "*" — least privilege per CEO
+    // review (#351, Phase A Task 2).
+    this.taskRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: "CloudWatchLogsReadForAdmin",
+        actions: [
+          "logs:FilterLogEvents",
+          "logs:StartQuery",
+          "logs:StopQuery",
+          "logs:GetQueryResults",
+          "logs:GetLogEvents",
+          "logs:DescribeLogStreams",
+        ],
+        resources: [
+          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/ecs/isol8-${env}-backend:*`,
+        ],
       }),
     );
 

--- a/apps/infra/test/database-stack.test.ts
+++ b/apps/infra/test/database-stack.test.ts
@@ -1,0 +1,102 @@
+import * as cdk from "aws-cdk-lib";
+import * as kms from "aws-cdk-lib/aws-kms";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { DatabaseStack } from "../lib/stacks/database-stack";
+
+function buildStack(environment: "dev" | "prod"): Template {
+  const app = new cdk.App();
+  const env = { account: "877352799272", region: "us-east-1" };
+  const supportStack = new cdk.Stack(app, `Support-${environment}`, { env });
+  const kmsKey = new kms.Key(supportStack, "KmsKey");
+  const databaseStack = new DatabaseStack(app, `Database-${environment}`, {
+    env,
+    environment,
+    kmsKey,
+  });
+  return Template.fromStack(databaseStack);
+}
+
+describe("DatabaseStack — admin-actions table", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = buildStack("dev");
+  });
+
+  test("creates isol8-{env}-admin-actions with composite key", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "isol8-dev-admin-actions",
+      KeySchema: [
+        { AttributeName: "admin_user_id", KeyType: "HASH" },
+        { AttributeName: "timestamp_action_id", KeyType: "RANGE" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    });
+  });
+
+  test("admin-actions has target-timestamp GSI for per-target audit queries", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "isol8-dev-admin-actions",
+      GlobalSecondaryIndexes: Match.arrayWith([
+        Match.objectLike({
+          IndexName: "target-timestamp-index",
+          KeySchema: [
+            { AttributeName: "target_user_id", KeyType: "HASH" },
+            { AttributeName: "timestamp_action_id", KeyType: "RANGE" },
+          ],
+        }),
+      ]),
+    });
+  });
+
+  test("admin-actions uses customer-managed KMS encryption (matches other tables)", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "isol8-dev-admin-actions",
+      SSESpecification: Match.objectLike({
+        SSEEnabled: true,
+        SSEType: "KMS",
+      }),
+    });
+  });
+
+  test("admin-actions has point-in-time recovery enabled", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "isol8-dev-admin-actions",
+      PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+    });
+  });
+
+  test("admin-actions has NO TTL (audit rows kept forever per CEO review)", () => {
+    // CDK omits the TimeToLiveSpecification entirely when no TTL is set.
+    // Assert it's absent on this specific table.
+    const tables = template.findResources("AWS::DynamoDB::Table", {
+      Properties: { TableName: "isol8-dev-admin-actions" },
+    });
+    const tableLogicalIds = Object.keys(tables);
+    expect(tableLogicalIds).toHaveLength(1);
+    const props = tables[tableLogicalIds[0]].Properties;
+    expect(props.TimeToLiveSpecification).toBeUndefined();
+  });
+
+  test("dev environment uses DESTROY removal policy (matches other dev tables)", () => {
+    const tables = template.findResources("AWS::DynamoDB::Table", {
+      Properties: { TableName: "isol8-dev-admin-actions" },
+    });
+    const logicalId = Object.keys(tables)[0];
+    expect(tables[logicalId].DeletionPolicy).toBe("Delete");
+  });
+});
+
+describe("DatabaseStack — admin-actions table — prod", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = buildStack("prod");
+  });
+
+  test("prod environment uses RETAIN removal policy", () => {
+    const tables = template.findResources("AWS::DynamoDB::Table", {
+      Properties: { TableName: "isol8-prod-admin-actions" },
+    });
+    const logicalId = Object.keys(tables)[0];
+    expect(tables[logicalId].DeletionPolicy).toBe("Retain");
+  });
+});

--- a/docs/runbooks/admin-rollout.md
+++ b/docs/runbooks/admin-rollout.md
@@ -69,7 +69,7 @@ DNS alias and Vercel project remain. Once the incident is resolved, restore the 
 | `/admin/me` returns 403 | Your Clerk user_id missing from `PLATFORM_ADMIN_USER_IDS` | Add it; redeploy |
 | Admin page renders but Stripe panel shows error banner | Stripe API timeout or auth issue; `admin_service` returns partial responses on upstream failure | Check Stripe dashboard health; verify `STRIPE_SECRET_KEY` in Secrets Manager |
 | PostHog tab shows "No PostHog activity recorded — user may not have visited the frontend" | User legitimately has no PostHog identify yet; OR `POSTHOG_PROJECT_API_KEY` is unset | Confirm by visiting the frontend as that user; otherwise mint the PostHog project key |
-| CloudWatch Logs tab shows "no logs" | LocalStack (no real CWL); user hasn't generated logs in the time window; or IAM missing on the backend task role | Check task role has `logs:FilterLogEvents` on the backend log group ARN (added in #PR-N) |
+| CloudWatch Logs tab shows "no logs" | LocalStack (no real CWL); user hasn't generated logs in the time window; or IAM missing on the backend task role | Check task role has `logs:FilterLogEvents` on `arn:aws:logs:{region}:{account}:log-group:/ecs/isol8-{env}:*` (added in #355) |
 | Write action returns `audit_status: "panic"` | DDB write to `admin-actions` failed after the action executed | Check CloudWatch for `ADMIN_AUDIT_PANIC` log entries; investigate DDB connectivity / IAM. The action *did* run; the audit row is missing. |
 
 ## When to add an edge gate (Phase 2 trigger)

--- a/docs/runbooks/admin-rollout.md
+++ b/docs/runbooks/admin-rollout.md
@@ -1,0 +1,109 @@
+# Admin dashboard rollout
+
+Operational runbook for `admin.isol8.co` (and `admin-dev.isol8.co`).
+
+**Tracking issue:** [Isol8AI/isol8#351](https://github.com/Isol8AI/isol8/issues/351)
+**Spec:** [`docs/superpowers/specs/2026-04-21-admin-dashboard-design.md`](../superpowers/specs/2026-04-21-admin-dashboard-design.md)
+**Plan:** [`docs/superpowers/plans/2026-04-21-admin-dashboard.md`](../superpowers/plans/2026-04-21-admin-dashboard.md)
+
+## What's in v1
+
+- Dedicated subdomain `admin.isol8.co` aliased to the existing `isol8-frontend-*` Vercel project.
+- Route group at `apps/frontend/src/app/admin/*`, gated by host-based middleware (only the admin host serves these routes).
+- Backend `/api/v1/admin/*` endpoints, gated by `Depends(require_platform_admin)` (allowlist driven by `PLATFORM_ADMIN_USER_IDS`).
+- Audit table `isol8-{env}-admin-actions` records every write action.
+- **No edge SSO gate.** Defense-in-depth = host-check + Clerk + allowlist + audit. (See "When to add an edge gate" below.)
+
+## Prerequisites — one-time per environment
+
+1. **DNS + Vercel domain alias:** `admin-dev.isol8.co` → `isol8-frontend-dev` Vercel project; `admin.isol8.co` → `isol8-frontend-prod`. Verify with `dig admin-dev.isol8.co CNAME`.
+2. **Backend secrets** (Secrets Manager entry `isol8/{env}/backend-env`):
+   - `PLATFORM_ADMIN_USER_IDS` — comma-separated Clerk user IDs of the Isol8 team
+   - `ADMIN_UI_ENABLED=true`
+   - `ADMIN_UI_ENABLED_USER_IDS` — comma-separated subset for staged rollout (start small)
+   - `ADMIN_AUDIT_VIEWS=true`
+   - `POSTHOG_HOST` (default `https://app.posthog.com`), `POSTHOG_PROJECT_ID`, `POSTHOG_PROJECT_API_KEY` (mint a project API key in PostHog dashboard with scopes `person:read`, `events:read`, `session_recording:read`)
+3. **Backend redeploy** so the new env vars propagate (env vars are read at module load).
+
+## Adding a new admin
+
+1. Get the new admin's Clerk user_id (visible in Clerk dashboard → Users; or query via `clerk_sync_service.get_user_by_email`).
+2. Update Secrets Manager:
+
+   ```bash
+   aws secretsmanager get-secret-value --secret-id isol8/dev/backend-env \
+     --query SecretString --output text --profile isol8-admin \
+     | jq --arg id "$NEW_USER_ID" '
+         .PLATFORM_ADMIN_USER_IDS = (.PLATFORM_ADMIN_USER_IDS + "," + $id | sub("^,"; "")) |
+         .ADMIN_UI_ENABLED_USER_IDS = (.ADMIN_UI_ENABLED_USER_IDS + "," + $id | sub("^,"; ""))
+       ' \
+     | aws secretsmanager update-secret --secret-id isol8/dev/backend-env --secret-string file:///dev/stdin --profile isol8-admin
+   ```
+
+3. Redeploy backend. Within ~2 min the new admin can sign into `https://admin-{env}.isol8.co/admin` via Clerk and reach `/admin/users`.
+
+## Removing an admin (immediate)
+
+1. Remove their user_id from `PLATFORM_ADMIN_USER_IDS` in Secrets Manager (and `ADMIN_UI_ENABLED_USER_IDS`).
+2. Redeploy backend. The next API call from any open admin session 403s.
+3. Optional: revoke their Clerk sessions via another admin's UI: `Actions → /admin/users/{user_id}/account/force-signout`.
+
+## Breaking glass — disable admin entirely
+
+```bash
+aws secretsmanager get-secret-value --secret-id isol8/{env}/backend-env \
+  --query SecretString --output text --profile isol8-admin \
+  | jq '.PLATFORM_ADMIN_USER_IDS = ""' \
+  | aws secretsmanager update-secret --secret-id isol8/{env}/backend-env --secret-string file:///dev/stdin --profile isol8-admin
+```
+
+Redeploy backend. Every `/admin/*` API endpoint 403s within ~2 min. The Next.js middleware still serves the host so users hitting `admin.isol8.co/admin` see the not-authorized page (no information leak).
+
+DNS alias and Vercel project remain. Once the incident is resolved, restore the env var and redeploy.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `/admin` returns 404 in browser | Wrong host (you're on `isol8.co/admin` instead of `admin.isol8.co/admin`); `ADMIN_UI_ENABLED=false`; or your Clerk user_id missing from `ADMIN_UI_ENABLED_USER_IDS` | Check URL; check Secrets Manager values |
+| `/admin/me` returns 403 | Your Clerk user_id missing from `PLATFORM_ADMIN_USER_IDS` | Add it; redeploy |
+| Admin page renders but Stripe panel shows error banner | Stripe API timeout or auth issue; `admin_service` returns partial responses on upstream failure | Check Stripe dashboard health; verify `STRIPE_SECRET_KEY` in Secrets Manager |
+| PostHog tab shows "No PostHog activity recorded — user may not have visited the frontend" | User legitimately has no PostHog identify yet; OR `POSTHOG_PROJECT_API_KEY` is unset | Confirm by visiting the frontend as that user; otherwise mint the PostHog project key |
+| CloudWatch Logs tab shows "no logs" | LocalStack (no real CWL); user hasn't generated logs in the time window; or IAM missing on the backend task role | Check task role has `logs:FilterLogEvents` on the backend log group ARN (added in #PR-N) |
+| Write action returns `audit_status: "panic"` | DDB write to `admin-actions` failed after the action executed | Check CloudWatch for `ADMIN_AUDIT_PANIC` log entries; investigate DDB connectivity / IAM. The action *did* run; the audit row is missing. |
+
+## When to add an edge gate (Phase 2 trigger)
+
+V1 deliberately ships without an edge SSO gate to avoid adding a vendor. Defense relies on host-check + Clerk + `require_platform_admin` + audit.
+
+Watch the `admin_api.errors` CloudWatch metric (added in Phase B) for repeated 403s on `/admin/me` from unknown IPs. If probe traffic appears, prioritize Phase 2 backlog item 14 — pick one of:
+
+- **Cloudflare Access** — SSO gate in front of the subdomain. Requires Cloudflare as a vendor + DNS handover.
+- **Vercel Deployment Protection** — Vercel-native password / SSO gate. Pro+ plan only.
+- **HTTP basic auth via Next.js middleware** — ~15 LOC: if `host=admin.isol8.co` and no `Authorization: Basic` header, return 401 challenge. Username/password in `ADMIN_BASIC_AUTH_*` env vars. Zero new vendor.
+
+## Local development
+
+`apps/backend/.env.local` should include:
+
+```
+PLATFORM_ADMIN_USER_IDS=user_<your dev Clerk id>
+ADMIN_UI_ENABLED=true
+ADMIN_UI_ENABLED_USER_IDS=user_<your dev Clerk id>
+ADMIN_AUDIT_VIEWS=true
+# Stub PostHog — leave POSTHOG_PROJECT_API_KEY unset to short-circuit the API call
+```
+
+Frontend env (`apps/frontend/.env.local`):
+
+```
+NEXT_PUBLIC_ADMIN_HOSTS=admin.isol8.co,admin-dev.isol8.co,admin.localhost:3000
+```
+
+Then `pnpm dev` and visit `http://admin.localhost:3000/admin` (Chrome/Safari resolve `*.localhost` → 127.0.0.1 automatically — no `/etc/hosts` edit).
+
+## Related
+
+- [Phase B onwards](../superpowers/plans/2026-04-21-admin-dashboard.md) — backend router + frontend pages.
+- `core/auth.py:242` — `require_platform_admin`.
+- `apps/infra/lib/stacks/database-stack.ts` — `admin-actions` table.


### PR DESCRIPTION
## Summary

Phase A of the admin dashboard implementation per the merged plan ([`docs/superpowers/plans/2026-04-21-admin-dashboard.md`](../blob/main/docs/superpowers/plans/2026-04-21-admin-dashboard.md)). All foundations: DDB audit table, IAM, backend config, runbook. **No application code, no router, no UI** — those are Phases B–F. This PR is the safe-to-deploy substrate everything else builds on.

Closes Phase A of #351 (4 of 4 code tasks; Task 4 is manual DNS/Vercel ops, no commit).

## What lands

| Task | Layer | Files | Tests |
|---|---|---|---|
| 1. `admin-actions` DDB table | infra | `apps/infra/lib/stacks/database-stack.ts` | 7 new in `apps/infra/test/database-stack.test.ts` |
| 2. CloudWatch Logs IAM + DDB grant | infra | `apps/infra/lib/stacks/service-stack.ts`, `lib/isol8-stage.ts`, `lib/local-stage.ts` | CDK synth pass |
| 3. Admin + PostHog config settings | backend | `apps/backend/core/config.py` | 10 new in `apps/backend/tests/unit/core/test_config_admin.py` |
| 5. Admin rollout runbook | docs | `docs/runbooks/admin-rollout.md` | n/a |

Phase A Task 4 (DNS + Vercel domain alias) is one-time manual ops with no code commit. The runbook (Task 5) documents the steps.

## Architecture decisions baked in

- **`admin-actions` DDB table:** PK `admin_user_id` + SK `timestamp_action_id` (`{ISO8601}#{uuidv7}`); GSI `target-timestamp-index` for "all actions taken against this user"; no TTL (audit kept forever per CEO review #351); customer-managed KMS encryption matching every other table; dev=DESTROY, prod=RETAIN.
- **CloudWatch Logs IAM:** least-privilege scoping. New `CloudWatchLogsReadForAdmin` policy adds `logs:FilterLogEvents`, `logs:StartQuery`, `logs:StopQuery`, `logs:GetQueryResults`, `logs:GetLogEvents`, `logs:DescribeLogStreams` — but only on `arn:aws:logs:{region}:{account}:log-group:/aws/ecs/isol8-{env}-backend:*`. Never `*`.
- **Config settings:** `ADMIN_UI_ENABLED` (master switch, default false), `ADMIN_UI_ENABLED_USER_IDS` (per-user opt-in, parsed via `admin_ui_enabled_user_ids` @property), `ADMIN_AUDIT_VIEWS` (default true — read endpoints log audit rows so PII viewing leaves a trail). Three `POSTHOG_*` server-side settings — empty defaults so the eventual PostHog client stubs gracefully when unset.
- **Runbook:** add/remove admin via `aws secretsmanager` + jq snippets, breaking-glass procedure (clear `PLATFORM_ADMIN_USER_IDS` → all 403), troubleshooting matrix, "when to add an edge gate" trigger (Phase 2 backlog item 14).

## Tests

```bash
cd apps/infra && pnpm jest              # 33 tests (was 26 + 7 new), all pass
pnpm cdk synth                          # exit 0
cd apps/backend && CLERK_ISSUER=https://test.clerk.accounts.dev \
  uv run pytest tests/unit/core/ tests/unit/test_auth_platform_admin.py -v --no-cov
                                        # 17 tests pass (10 new + 7 existing)
```

## Test plan (CI / pre-merge)

- [x] `pnpm jest` (apps/infra) — 33 pass
- [x] `pnpm cdk synth` — clean
- [x] `pytest tests/unit/core/test_config_admin.py` — 10 pass
- [x] `pytest tests/unit/test_auth_platform_admin.py` — 3 pass (existing — unchanged)
- [ ] Backend full pytest — depends on CI env vars
- [ ] Backend ruff — pre-commit ran, all checks passed locally

## Phase A → B handoff

Once this merges, Phase B (backend foundation) starts on a fresh branch off main:
- `core/repositories/admin_actions_repo.py` — DDB CRUD using `admin-actions` table from Task 1
- `core/services/admin_audit.py` — `@audit_admin_action` decorator (fail-closed per CEO S1)
- `core/services/cloudwatch_logs.py` — uses IAM from Task 2
- `core/services/posthog_admin.py` — uses settings from Task 3
- `core/services/admin_service.py` — composition layer
- Plus tests

Nothing in Phase A wires into the running backend yet — `admin-actions` table is unreferenced in code; CloudWatch Logs IAM is unused; new config fields are unread. Phase B activates them.

## Refs

- Tracking issue: #351
- Plan: `docs/superpowers/plans/2026-04-21-admin-dashboard.md` (merged in #353)
- Spec: `docs/superpowers/specs/2026-04-21-admin-dashboard-design.md` (merged in #353)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
