### PR TITLE
fix(ci): drop pnpm version pin in desktop-build

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -18,9 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm version governed by the root package.json#packageManager field
+      # (pnpm@9.15.0). Pinning a second time here triggers
+      # ERR_PNPM_BAD_PM_VERSION when the two disagree.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- pnpm/action-setup@v4 fails on the first `desktop-dev-v0.2.0` tag run because both the step and `package.json#packageManager` specify a pnpm version: \`ERR_PNPM_BAD_PM_VERSION\`
- Drop the step-level \`version: 9\` input; let \`packageManager: pnpm@9.15.0\` in the root \`package.json\` govern

## Test plan
- [ ] After merge, re-tag \`desktop-dev-v0.2.1\` and confirm the pnpm/action-setup step now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)