### PR TITLE
chore(chat): strip debug instrumentation + tighten runId forwarding contract

### DIFF
--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -716,9 +716,12 @@ class GatewayConnection:
                 # route responses to the correct agent conversation.
                 event_agent_id = parsed_key.get("agent_id")
                 # runId is a required field on every chat-terminal event we
-                # forward: the frontend keys its per-run assistant bubble on it.
-                # OpenClaw guarantees it (server-chat.ts `chat` event emitter),
-                # so no defensive guard here.
+                # forward: the frontend keys its per-run assistant bubble on
+                # it. OpenClaw guarantees it on final/error/aborted (server-
+                # chat.ts `chat` event emitter), so no defensive guard here.
+                # Delta/unknown states never forward, so they don't need it.
+                if state not in ("final", "error", "aborted"):
+                    return
                 run_id = payload["runId"]
                 if state == "final":
                     put_metric("chat.message.count")

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -652,27 +652,13 @@ class GatewayConnection:
                 return
             if event_name != "agent":
                 state = payload.get("state", "") if isinstance(payload, dict) else ""
-                # Temporary extra fields for the post-approval chunk-routing
-                # investigation. `runId`/`seq`/`clientRunId` show up on chat
-                # events; `id` shows up on exec.approval.{requested,resolved}.
-                # Remove after the bug is diagnosed.
-                extras = ""
-                if isinstance(payload, dict):
-                    approval_id = payload.get("id", "-") if event_name.startswith("exec.approval") else "-"
-                    extras = (
-                        f" runId={payload.get('runId', '-')}"
-                        f" seq={payload.get('seq', '-')}"
-                        f" clientRunId={payload.get('clientRunId', '-')}"
-                        f" approvalId={approval_id}"
-                    )
                 logger.info(
-                    "[%s] gateway event=%s state=%s sessionKey=%s target=%s%s",
+                    "[%s] gateway event=%s state=%s sessionKey=%s target=%s",
                     self.user_id,
                     event_name,
                     state,
                     session_key[:60] if session_key else "-",
                     target_member or "broadcast",
-                    extras,
                 )
 
             if event_name == "agent":
@@ -724,27 +710,6 @@ class GatewayConnection:
                 # Chat events -- only terminal states.
                 # Delta states are skipped; agent events handle streaming.
                 state = payload.get("state", "")
-                if state in ("final", "error", "aborted"):
-                    # Temporary debug logging: dump identifying fields
-                    # (runId, seq, clientRunId) so we can tell whether
-                    # OpenClaw assigns a new runId per LLM turn or reuses
-                    # one across the whole chat.send — needed to
-                    # disambiguate the "mid-run chat.final fires before
-                    # user approves" case from a true end-of-run.
-                    # Remove once the post-approval chunk-routing bug
-                    # is diagnosed.
-                    logger.info(
-                        "[%s] chat %s sessionKey=%s target=%s runId=%s seq=%s clientRunId=%s parentRunId=%s stopReason=%s",
-                        self.user_id,
-                        state,
-                        session_key[:60] if session_key else "-",
-                        target_member or "broadcast",
-                        payload.get("runId", "-"),
-                        payload.get("seq", "-"),
-                        payload.get("clientRunId", "-"),
-                        payload.get("parentRunId", "-"),
-                        payload.get("stopReason", "-"),
-                    )
                 # Tag all chat messages with agent_id so the frontend can
                 # route responses to the correct agent conversation.
                 event_agent_id = parsed_key.get("agent_id")

--- a/apps/backend/core/gateway/connection_pool.py
+++ b/apps/backend/core/gateway/connection_pool.py
@@ -343,9 +343,11 @@ class GatewayConnection:
         if transformed is None:
             return None
 
-        run_id = payload.get("runId")
-        if run_id:
-            transformed["runId"] = run_id
+        # OpenClaw emits runId on every agent event we forward (assistant/
+        # reasoning/thinking/tool streams), so treat it as a required field.
+        # Frontend routes chunks/tools to a per-run assistant bubble keyed by
+        # this id — a missing runId would silently break multi-bubble rendering.
+        transformed["runId"] = payload["runId"]
         return transformed
 
     @staticmethod
@@ -713,8 +715,11 @@ class GatewayConnection:
                 # Tag all chat messages with agent_id so the frontend can
                 # route responses to the correct agent conversation.
                 event_agent_id = parsed_key.get("agent_id")
-                # runId lets the frontend route to a per-run assistant bubble.
-                run_id = payload.get("runId") if isinstance(payload, dict) else None
+                # runId is a required field on every chat-terminal event we
+                # forward: the frontend keys its per-run assistant bubble on it.
+                # OpenClaw guarantees it (server-chat.ts `chat` event emitter),
+                # so no defensive guard here.
+                run_id = payload["runId"]
                 if state == "final":
                     put_metric("chat.message.count")
                     # Deliver thinking from content blocks for models that
@@ -727,8 +732,7 @@ class GatewayConnection:
                         fwd: dict = {"type": "thinking", "content": thinking_text}
                         if event_agent_id:
                             fwd["agent_id"] = event_agent_id
-                        if run_id:
-                            fwd["runId"] = run_id
+                        fwd["runId"] = run_id
                         self._forward_to_frontends(fwd, target_member)
                     # OpenClaw guarantees the full text reached us via agent
                     # stream="assistant" events (with flushBufferedChatDeltaIfNeeded
@@ -736,8 +740,7 @@ class GatewayConnection:
                     fwd = {"type": "done"}
                     if event_agent_id:
                         fwd["agent_id"] = event_agent_id
-                    if run_id:
-                        fwd["runId"] = run_id
+                    fwd["runId"] = run_id
                     self._forward_to_frontends(fwd, target_member)
                 elif state == "error":
                     put_metric("chat.error", dimensions={"reason": "agent_error"})
@@ -750,16 +753,14 @@ class GatewayConnection:
                     fwd = {"type": "error", "message": err_msg}
                     if event_agent_id:
                         fwd["agent_id"] = event_agent_id
-                    if run_id:
-                        fwd["runId"] = run_id
+                    fwd["runId"] = run_id
                     self._forward_to_frontends(fwd, target_member)
                 elif state == "aborted":
                     put_metric("chat.error", dimensions={"reason": "aborted"})
                     fwd = {"type": "error", "message": "Agent run was cancelled"}
                     if event_agent_id:
                         fwd["agent_id"] = event_agent_id
-                    if run_id:
-                        fwd["runId"] = run_id
+                    fwd["runId"] = run_id
                     self._forward_to_frontends(fwd, target_member)
 
             else:

--- a/apps/backend/tests/unit/core/test_chat_event_transform.py
+++ b/apps/backend/tests/unit/core/test_chat_event_transform.py
@@ -65,19 +65,21 @@ class TestTransformAgentEvent:
 
     def test_assistant_stream_with_text(self):
         result = GatewayConnection._transform_agent_event(
-            {"stream": "assistant", "data": {"text": "Hello", "delta": "o"}}
+            {"stream": "assistant", "data": {"text": "Hello", "delta": "o"}, "runId": "run-1"}
         )
-        assert result == {"type": "chunk", "content": "Hello"}
+        assert result == {"type": "chunk", "content": "Hello", "runId": "run-1"}
 
     def test_assistant_stream_cumulative(self):
         """Successive events carry progressively longer cumulative text."""
-        r1 = GatewayConnection._transform_agent_event({"stream": "assistant", "data": {"text": "He", "delta": "He"}})
-        assert r1 == {"type": "chunk", "content": "He"}
+        r1 = GatewayConnection._transform_agent_event(
+            {"stream": "assistant", "data": {"text": "He", "delta": "He"}, "runId": "run-1"}
+        )
+        assert r1 == {"type": "chunk", "content": "He", "runId": "run-1"}
 
         r2 = GatewayConnection._transform_agent_event(
-            {"stream": "assistant", "data": {"text": "Hello world", "delta": "llo world"}}
+            {"stream": "assistant", "data": {"text": "Hello world", "delta": "llo world"}, "runId": "run-1"}
         )
-        assert r2 == {"type": "chunk", "content": "Hello world"}
+        assert r2 == {"type": "chunk", "content": "Hello world", "runId": "run-1"}
 
     def test_non_assistant_non_tool_stream_ignored(self):
         assert GatewayConnection._transform_agent_event({"stream": "lifecycle", "data": {"phase": "start"}}) is None
@@ -93,6 +95,7 @@ class TestTransformAgentEvent:
                     "toolCallId": "abc-123",
                     "args": {"query": "weather in Berwyn"},
                 },
+                "runId": "run-1",
             }
         )
         assert result == {
@@ -100,14 +103,19 @@ class TestTransformAgentEvent:
             "tool": "web_search",
             "toolCallId": "abc-123",
             "args": {"query": "weather in Berwyn"},
+            "runId": "run-1",
         }
 
     def test_tool_stream_start_without_args(self):
         """args key missing — output omits it rather than sending null."""
         result = GatewayConnection._transform_agent_event(
-            {"stream": "tool", "data": {"name": "web_search", "phase": "start", "toolCallId": "abc-123"}}
+            {
+                "stream": "tool",
+                "data": {"name": "web_search", "phase": "start", "toolCallId": "abc-123"},
+                "runId": "run-1",
+            }
         )
-        assert result == {"type": "tool_start", "tool": "web_search", "toolCallId": "abc-123"}
+        assert result == {"type": "tool_start", "tool": "web_search", "toolCallId": "abc-123", "runId": "run-1"}
 
     def test_tool_stream_result_phase(self):
         result = GatewayConnection._transform_agent_event(
@@ -120,6 +128,7 @@ class TestTransformAgentEvent:
                     "result": [{"type": "text", "text": "72°F"}],
                     "meta": "Berwyn, PA",
                 },
+                "runId": "run-1",
             }
         )
         assert result == {
@@ -128,6 +137,7 @@ class TestTransformAgentEvent:
             "toolCallId": "abc-123",
             "result": [{"type": "text", "text": "72°F"}],
             "meta": "Berwyn, PA",
+            "runId": "run-1",
         }
 
     def test_tool_stream_result_with_is_error(self):
@@ -142,6 +152,7 @@ class TestTransformAgentEvent:
                     "isError": True,
                     "result": [{"type": "text", "text": "Perplexity API 404"}],
                 },
+                "runId": "run-1",
             }
         )
         assert result == {
@@ -149,6 +160,7 @@ class TestTransformAgentEvent:
             "tool": "web_search",
             "toolCallId": "abc-123",
             "result": [{"type": "text", "text": "Perplexity API 404"}],
+            "runId": "run-1",
         }
 
     def test_tool_stream_update_phase_ignored(self):
@@ -166,16 +178,16 @@ class TestTransformAgentEvent:
 
     def test_thinking_stream_with_text(self):
         result = GatewayConnection._transform_agent_event(
-            {"stream": "thinking", "data": {"text": "Let me think...", "delta": "..."}}
+            {"stream": "thinking", "data": {"text": "Let me think...", "delta": "..."}, "runId": "run-1"}
         )
-        assert result == {"type": "thinking", "content": "Let me think..."}
+        assert result == {"type": "thinking", "content": "Let me think...", "runId": "run-1"}
 
     def test_reasoning_stream_with_text(self):
         """OpenClaw may emit reasoning events under either stream name."""
         result = GatewayConnection._transform_agent_event(
-            {"stream": "reasoning", "data": {"text": "Considering options", "delta": "s"}}
+            {"stream": "reasoning", "data": {"text": "Considering options", "delta": "s"}, "runId": "run-1"}
         )
-        assert result == {"type": "thinking", "content": "Considering options"}
+        assert result == {"type": "thinking", "content": "Considering options", "runId": "run-1"}
 
     def test_thinking_stream_empty_text_ignored(self):
         assert GatewayConnection._transform_agent_event({"stream": "thinking", "data": {"text": ""}}) is None
@@ -231,10 +243,12 @@ class TestHandleMessage:
             {
                 "type": "event",
                 "event": "agent",
-                "payload": {"stream": "assistant", "data": {"text": "Hello", "delta": "o"}},
+                "payload": {"stream": "assistant", "data": {"text": "Hello", "delta": "o"}, "runId": "run-1"},
             }
         )
-        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "chunk", "content": "Hello"})
+        mock_management_api.send_message.assert_called_once_with(
+            "conn-1", {"type": "chunk", "content": "Hello", "runId": "run-1"}
+        )
 
     def test_agent_non_assistant_event_skipped(self, connection, mock_management_api):
         connection._handle_message(
@@ -251,11 +265,15 @@ class TestHandleMessage:
             {
                 "type": "event",
                 "event": "agent",
-                "payload": {"stream": "tool", "data": {"name": "web_search", "phase": "start", "toolCallId": "t1"}},
+                "payload": {
+                    "stream": "tool",
+                    "data": {"name": "web_search", "phase": "start", "toolCallId": "t1"},
+                    "runId": "run-1",
+                },
             }
         )
         mock_management_api.send_message.assert_called_once_with(
-            "conn-1", {"type": "tool_start", "tool": "web_search", "toolCallId": "t1"}
+            "conn-1", {"type": "tool_start", "tool": "web_search", "toolCallId": "t1", "runId": "run-1"}
         )
 
     def test_agent_tool_end_forwarded(self, connection, mock_management_api):
@@ -263,11 +281,15 @@ class TestHandleMessage:
             {
                 "type": "event",
                 "event": "agent",
-                "payload": {"stream": "tool", "data": {"name": "web_search", "phase": "result", "toolCallId": "t1"}},
+                "payload": {
+                    "stream": "tool",
+                    "data": {"name": "web_search", "phase": "result", "toolCallId": "t1"},
+                    "runId": "run-1",
+                },
             }
         )
         mock_management_api.send_message.assert_called_once_with(
-            "conn-1", {"type": "tool_end", "tool": "web_search", "toolCallId": "t1"}
+            "conn-1", {"type": "tool_end", "tool": "web_search", "toolCallId": "t1", "runId": "run-1"}
         )
 
     def test_agent_events_tagged_with_agent_id_from_session_key(self, connection, mock_management_api):
@@ -280,11 +302,12 @@ class TestHandleMessage:
                     "stream": "assistant",
                     "data": {"text": "Hello"},
                     "sessionKey": "agent:my-agent-id:main",
+                    "runId": "run-1",
                 },
             }
         )
         mock_management_api.send_message.assert_called_once_with(
-            "conn-1", {"type": "chunk", "content": "Hello", "agent_id": "my-agent-id"}
+            "conn-1", {"type": "chunk", "content": "Hello", "agent_id": "my-agent-id", "runId": "run-1"}
         )
 
     def test_chat_final_tagged_with_agent_id(self, connection, mock_management_api):
@@ -295,12 +318,15 @@ class TestHandleMessage:
                 "event": "chat",
                 "payload": {
                     "state": "final",
+                    "runId": "run-1",
                     "sessionKey": "agent:my-agent-id:main",
                     "message": {"role": "assistant", "content": [{"type": "text", "text": "Done."}]},
                 },
             }
         )
-        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "done", "agent_id": "my-agent-id"})
+        mock_management_api.send_message.assert_called_once_with(
+            "conn-1", {"type": "done", "agent_id": "my-agent-id", "runId": "run-1"}
+        )
 
     # -- Chat events (terminal states only) --
 
@@ -326,6 +352,7 @@ class TestHandleMessage:
                 "event": "chat",
                 "payload": {
                     "state": "final",
+                    "runId": "run-1",
                     "message": {
                         "role": "assistant",
                         "content": [{"type": "text", "text": "Complete response here."}],
@@ -333,7 +360,7 @@ class TestHandleMessage:
                 },
             }
         )
-        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "done"})
+        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "done", "runId": "run-1"})
 
     def test_chat_final_with_thinking_sends_thinking_then_done(self, connection, mock_management_api):
         """Thinking blocks in the final message are forwarded for models that batch reasoning."""
@@ -343,6 +370,7 @@ class TestHandleMessage:
                 "event": "chat",
                 "payload": {
                     "state": "final",
+                    "runId": "run-1",
                     "message": {
                         "role": "assistant",
                         "content": [
@@ -355,39 +383,43 @@ class TestHandleMessage:
         )
         assert mock_management_api.send_message.call_count == 2
         calls = mock_management_api.send_message.call_args_list
-        assert calls[0] == call("conn-1", {"type": "thinking", "content": "Let me reason about this..."})
-        assert calls[1] == call("conn-1", {"type": "done"})
+        assert calls[0] == call(
+            "conn-1", {"type": "thinking", "content": "Let me reason about this...", "runId": "run-1"}
+        )
+        assert calls[1] == call("conn-1", {"type": "done", "runId": "run-1"})
 
     def test_chat_final_without_text_sends_only_done(self, connection, mock_management_api):
         connection._handle_message(
             {
                 "type": "event",
                 "event": "chat",
-                "payload": {"state": "final"},
+                "payload": {"state": "final", "runId": "run-1"},
             }
         )
-        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "done"})
+        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "done", "runId": "run-1"})
 
     def test_chat_error_with_dict(self, connection, mock_management_api):
         connection._handle_message(
             {
                 "type": "event",
                 "event": "chat",
-                "payload": {"state": "error", "error": {"message": "Rate limited"}},
+                "payload": {"state": "error", "runId": "run-1", "error": {"message": "Rate limited"}},
             }
         )
-        mock_management_api.send_message.assert_called_once_with("conn-1", {"type": "error", "message": "Rate limited"})
+        mock_management_api.send_message.assert_called_once_with(
+            "conn-1", {"type": "error", "message": "Rate limited", "runId": "run-1"}
+        )
 
     def test_chat_error_with_string(self, connection, mock_management_api):
         connection._handle_message(
             {
                 "type": "event",
                 "event": "chat",
-                "payload": {"state": "error", "error": "Something broke"},
+                "payload": {"state": "error", "runId": "run-1", "error": "Something broke"},
             }
         )
         mock_management_api.send_message.assert_called_once_with(
-            "conn-1", {"type": "error", "message": "Something broke"}
+            "conn-1", {"type": "error", "message": "Something broke", "runId": "run-1"}
         )
 
     def test_chat_aborted(self, connection, mock_management_api):
@@ -395,11 +427,11 @@ class TestHandleMessage:
             {
                 "type": "event",
                 "event": "chat",
-                "payload": {"state": "aborted"},
+                "payload": {"state": "aborted", "runId": "run-1"},
             }
         )
         mock_management_api.send_message.assert_called_once_with(
-            "conn-1", {"type": "error", "message": "Agent run was cancelled"}
+            "conn-1", {"type": "error", "message": "Agent run was cancelled", "runId": "run-1"}
         )
 
     def test_chat_unknown_state_skipped(self, connection, mock_management_api):
@@ -433,7 +465,7 @@ class TestHandleMessage:
             {
                 "type": "event",
                 "event": "agent",
-                "payload": {"stream": "assistant", "data": {"text": "Hi"}},
+                "payload": {"stream": "assistant", "data": {"text": "Hi"}, "runId": "run-1"},
             }
         )
         assert mock_management_api.send_message.call_count == 2

--- a/apps/backend/tests/unit/core/test_connection_pool.py
+++ b/apps/backend/tests/unit/core/test_connection_pool.py
@@ -365,9 +365,9 @@ class TestTransformAgentEvent:
     """Test static helper for extracting streaming text from agent events."""
 
     def test_returns_chunk_for_assistant_stream(self):
-        payload = {"stream": "assistant", "data": {"text": "Hello world"}}
+        payload = {"stream": "assistant", "data": {"text": "Hello world"}, "runId": "run-1"}
         result = GatewayConnection._transform_agent_event(payload)
-        assert result == {"type": "chunk", "content": "Hello world"}
+        assert result == {"type": "chunk", "content": "Hello world", "runId": "run-1"}
 
     def test_returns_none_for_non_assistant_stream(self):
         payload = {"stream": "system", "data": {"text": "ignored"}}

--- a/apps/backend/tests/unit/core/test_connection_pool.py
+++ b/apps/backend/tests/unit/core/test_connection_pool.py
@@ -462,12 +462,15 @@ class TestTransformAgentEvent:
             "runId": "run-tool-err",
         }
 
-    def test_omits_run_id_when_not_in_payload(self):
-        """Transform should not add runId key when source payload lacks it."""
+    def test_raises_when_run_id_missing(self):
+        """runId is a required field on agent events — absence is a protocol bug.
+
+        Guarding would hide a contract violation (frontend keys per-run
+        assistant bubbles on this id). Surface it loudly instead.
+        """
         payload = {"stream": "assistant", "data": {"text": "Hello"}}
-        result = GatewayConnection._transform_agent_event(payload)
-        assert result == {"type": "chunk", "content": "Hello"}
-        assert "runId" not in result
+        with pytest.raises(KeyError):
+            GatewayConnection._transform_agent_event(payload)
 
 
 class TestHandleMessageChatEvents:
@@ -494,11 +497,11 @@ class TestHandleMessageChatEvents:
             {
                 "type": "event",
                 "event": "chat",
-                "payload": {"state": "final", "message": {"content": []}},
+                "payload": {"state": "final", "runId": "run-1", "message": {"content": []}},
             }
         )
         calls = [c.args[1] for c in mgmt.send_message.call_args_list]
-        assert {"type": "done"} in calls
+        assert {"type": "done", "runId": "run-1"} in calls
 
     def test_chat_final_does_not_emit_text_chunk(self, connection):
         """chat state=final emits only the done signal — assistant text already
@@ -510,13 +513,14 @@ class TestHandleMessageChatEvents:
                 "event": "chat",
                 "payload": {
                     "state": "final",
+                    "runId": "run-1",
                     "message": {"content": [{"type": "text", "text": "complete answer"}]},
                 },
             }
         )
         calls = [c.args[1] for c in mgmt.send_message.call_args_list]
         assert all(c.get("type") != "chunk" for c in calls)
-        assert {"type": "done"} in calls
+        assert {"type": "done", "runId": "run-1"} in calls
 
     def test_chat_error_sends_error_message(self, connection):
         """chat state=error forwards an error type message."""
@@ -525,7 +529,7 @@ class TestHandleMessageChatEvents:
             {
                 "type": "event",
                 "event": "chat",
-                "payload": {"state": "error", "error": {"message": "timeout"}},
+                "payload": {"state": "error", "runId": "run-e", "error": {"message": "timeout"}},
             }
         )
         calls = [c.args[1] for c in mgmt.send_message.call_args_list]
@@ -539,7 +543,7 @@ class TestHandleMessageChatEvents:
             {
                 "type": "event",
                 "event": "chat",
-                "payload": {"state": "aborted"},
+                "payload": {"state": "aborted", "runId": "run-a"},
             }
         )
         calls = [c.args[1] for c in mgmt.send_message.call_args_list]
@@ -799,20 +803,18 @@ class TestChatEventForwarding:
         assert len(error_msgs) == 1
         assert error_msgs[0]["runId"] == "run-abort-1"
 
-    def test_done_without_run_id_still_forwarded(self, connection, mock_management_api):
-        """When OpenClaw omits runId, the forwarded done has no runId key (not None)."""
-        connection._handle_message(
-            {
-                "type": "event",
-                "event": "chat",
-                "payload": {
-                    "state": "final",
-                    "sessionKey": "agent:main:user-1",
-                },
-            }
-        )
-        done_msgs = [
-            c.args[1] for c in mock_management_api.send_message.call_args_list if c.args[1].get("type") == "done"
-        ]
-        assert len(done_msgs) == 1
-        assert "runId" not in done_msgs[0]
+    def test_done_without_run_id_raises(self, connection, mock_management_api):
+        """runId is required on chat-terminal events. Missing runId is a
+        protocol violation — fail loudly rather than silently forwarding
+        without it (frontend multi-bubble routing would break)."""
+        with pytest.raises(KeyError):
+            connection._handle_message(
+                {
+                    "type": "event",
+                    "event": "chat",
+                    "payload": {
+                        "state": "final",
+                        "sessionKey": "agent:main:user-1",
+                    },
+                }
+            )

--- a/apps/backend/tests/unit/gateway/test_lifecycle_billing.py
+++ b/apps/backend/tests/unit/gateway/test_lifecycle_billing.py
@@ -158,6 +158,7 @@ async def test_chat_final_no_longer_calls_billing(conn):
     payload = {
         "sessionKey": "agent:main:main",
         "state": "final",
+        "runId": "run-1",
         "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
     }
 

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -14,7 +14,6 @@
 
 import * as React from "react";
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
-import posthog from "posthog-js";
 import {
   useGateway,
   type ChatIncomingMessage,
@@ -25,51 +24,6 @@ import type {
   ExecApprovalDecision,
   ToolUse,
 } from "@/components/chat/MessageList";
-
-// =============================================================================
-// Debug instrumentation
-//
-// Temporary. Wired to diagnose the "one-turn-behind after tool approval" bug —
-// where isStreaming appears to flip to false at the click of an approval
-// decision, and the subsequent post-approval stream lands in the NEXT
-// user-message bubble.
-//
-// OFF BY DEFAULT IN PRODUCTION. User opts in per-browser via devtools:
-//   localStorage.setItem("chat_debug", "1")   // then reload
-//   localStorage.removeItem("chat_debug")     // to disable
-//
-// When enabled, emits to console.debug (live devtools inspection) AND
-// posthog ("chat_debug" event, persistent queryable timeline). Chunk /
-// heartbeat events are excluded from posthog to keep volume down.
-//
-// Payload scrubbing: never include raw user messages, assistant content,
-// or command args. Only log shape/metadata — lengths, counts, type tags,
-// boolean flags, identifiers.
-//
-// Rip this out once the bug is identified.
-// =============================================================================
-function isChatDebugEnabled(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem("chat_debug") === "1";
-  } catch {
-    return false;
-  }
-}
-function chatDebug(event: string, payload: Record<string, unknown> = {}) {
-  if (!isChatDebugEnabled()) return;
-  // Using console.log rather than console.debug so entries show up at
-  // the Chrome default log level (debug is a Verbose-only level, hidden
-  // by default and a common source of "I see nothing in the console"
-  // confusion).
-  // eslint-disable-next-line no-console
-  console.log("[chat-debug]", event, { ts: Date.now(), ...payload });
-  try {
-    posthog?.capture?.("chat_debug", { event, ...payload });
-  } catch {
-    // posthog not initialized (local dev without key) — ignore.
-  }
-}
 
 // Re-export ToolUse so existing consumers (AgentChatWindow) keep working
 // after this hook switched to the canonical MessageList definition.
@@ -191,13 +145,9 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     () => (cacheKey ? _messageCache.get(cacheKey) ?? [] : []),
   );
   const [isStreaming, _setIsStreamingRaw] = useState(false);
-  // Debug wrapper: every streaming-flag flip is logged with source. Removing
-  // this wrapper once the post-approval bug is diagnosed.
   const isStreamingRef = useRef(false);
-  const setIsStreaming = useCallback((value: boolean, source?: string) => {
-    const prev = isStreamingRef.current;
+  const setIsStreaming = useCallback((value: boolean) => {
     isStreamingRef.current = value;
-    chatDebug("setIsStreaming", { from: prev, to: value, source: source ?? "unknown" });
     _setIsStreamingRaw(value);
   }, []);
   const [error, setError] = useState<string | null>(null);
@@ -273,7 +223,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       { id: messageId, role: "assistant", content: "" },
     ]);
     if (!isStreamingRef.current) {
-      setIsStreaming(true, `run-${String(runId).slice(0, 12)}-start`);
+      setIsStreaming(true);
     }
     return messageId;
   }, [setIsStreaming]);
@@ -289,7 +239,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       if (first) finalizedRunsRef.current.delete(first);
     }
     if (runsRef.current.size === 0) {
-      setIsStreaming(false, `run-${String(runId).slice(0, 12)}-done`);
+      setIsStreaming(false);
     }
   }, [setIsStreaming]);
 
@@ -390,40 +340,6 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
   useEffect(() => {
     return onChatMessage((msg: ChatIncomingMessage) => {
-      // Debug: log every non-chunk message at arrival, plus chunk metadata
-      // (not content — chunks fire per-token and would spam posthog).
-      if (msg.type !== "chunk" && msg.type !== "heartbeat") {
-        chatDebug("chat_msg_rx", {
-          msg_type: msg.type,
-          msg_agent_id: (msg as { agent_id?: string }).agent_id,
-          my_agent_id: agentIdRef.current,
-          run_count: runsRef.current.size,
-          streaming: isStreamingRef.current,
-          error_code: (msg as { code?: string }).code,
-          // NOTE: deliberately do not include the error message string — it
-          // can carry user-provided content (budget/tier labels, partial
-          // agent output on aborted runs).
-          has_error_message: Boolean((msg as { message?: string }).message),
-        });
-      }
-
-      // Chunk arrival tracer (console-only — NEVER posthog, NEVER content).
-      // We need to know WHEN chunks arrive relative to approval events to
-      // decide whether the post-approval chunk-routing bug is a same-bubble
-      // or cross-bubble misrouting. Logs length only (shape, not content).
-      // Skips posthog entirely to avoid per-token volume.
-      if (msg.type === "chunk" && isChatDebugEnabled()) {
-        // eslint-disable-next-line no-console
-        console.log("[chat-debug]", "chunk_rx", {
-          ts: Date.now(),
-          content_length: msg.content?.length ?? 0,
-          msg_agent_id: msg.agent_id,
-          my_agent_id: agentIdRef.current,
-          run_count: runsRef.current.size,
-          streaming: isStreamingRef.current,
-        });
-      }
-
       // Drop messages meant for a different agent. Heartbeat and
       // update_available aren't tied to a specific run. Errors are
       // allowed through even without agent_id as a safety valve —
@@ -433,13 +349,6 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         msg.type === "heartbeat" || msg.type === "update_available";
       const isUntaggedError = msg.type === "error" && msg.agent_id === undefined;
       if (!isUntaggedBroadcast && !isUntaggedError && msg.agent_id !== agentIdRef.current) {
-        // TS has narrowed out "heartbeat"/"chunk" by this point via the
-        // isUntaggedBroadcast aliased condition; log unconditionally.
-        chatDebug("chat_msg_dropped_agent_mismatch", {
-          msg_type: (msg as { type: string }).type,
-          msg_agent_id: (msg as { agent_id?: string }).agent_id,
-          my_agent_id: agentIdRef.current,
-        });
         return;
       }
 
@@ -486,7 +395,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
           finalizeAllActiveRuns();
           // Close the window for late stragglers whose runId we never saw.
           pendingCancelRef.current = true;
-          setIsStreaming(false, "error-budget");
+          setIsStreaming(false);
           return;
         }
 
@@ -524,7 +433,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
               if (first) finalizedRunsRef.current.delete(first);
             }
             if (runsRef.current.size === 0) {
-              setIsStreaming(false, "error-scoped-unknown-run");
+              setIsStreaming(false);
             }
           }
           setError(displayError);
@@ -546,7 +455,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         finalizeAllActiveRuns();
         // Close the window for late stragglers whose runId we never saw.
         pendingCancelRef.current = true;
-        setIsStreaming(false, "error-generic");
+        setIsStreaming(false);
         return;
       }
 
@@ -712,14 +621,6 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         createdAtMs?: number;
         expiresAtMs?: number;
       };
-      chatDebug("approval_requested_event_rx", {
-        id: payload?.id,
-        host: payload?.request?.host,
-        // shape only — no raw command (may contain paths/args)
-        has_command: Boolean(payload?.request?.command),
-        run_count: runsRef.current.size,
-        streaming: isStreamingRef.current,
-      });
       if (!payload?.id || !payload.request?.command) return;
 
       // Scope to this chat's agent. The backend forwards non-agent/chat events
@@ -847,12 +748,6 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     const unsubResolved = onEvent((eventName, data) => {
       if (eventName !== "exec.approval.resolved") return;
       const payload = data as { id?: string; decision?: ExecApprovalDecision };
-      chatDebug("approval_resolved_event_rx", {
-        id: payload?.id,
-        decision: payload?.decision,
-        run_count: runsRef.current.size,
-        streaming: isStreamingRef.current,
-      });
       if (!payload?.id) return;
 
       setMessages((prev) =>
@@ -884,13 +779,6 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
   const sendMessage = useCallback(
     async (message: string): Promise<void> => {
-      chatDebug("sendMessage_entry", {
-        prev_run_count: runsRef.current.size,
-        prev_streaming: isStreamingRef.current,
-        agent: agentIdRef.current,
-        msg_length: message.length,
-      });
-
       // A new turn invalidates any pending-cancel window from the previous
       // turn. Events for this new turn must be allowed through normally.
       pendingCancelRef.current = false;
@@ -919,7 +807,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
         ...prev,
         { id: userMsgId, role: "user", content: message },
       ]);
-      setIsStreaming(true, "sendMessage");
+      setIsStreaming(true);
 
       try {
         sendChat(agentIdRef.current, message);
@@ -935,7 +823,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
           ...prev,
           { id: errMsgId, role: "assistant", content: `Error: ${errorMessage}` },
         ]);
-        setIsStreaming(false, "sendMessage-catch");
+        setIsStreaming(false);
       }
     },
     [sendChat, isConnected, sessionName],
@@ -944,10 +832,6 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
   // ---- Cancel / stop agent ----
 
   const cancelMessage = useCallback(async () => {
-    chatDebug("cancelMessage_entry", {
-      run_count: runsRef.current.size,
-      streaming: isStreamingRef.current,
-    });
     if (!agentIdRef.current || !isStreaming) return;
 
     const sessionKey = `agent:${agentIdRef.current}:${sessionName}`;
@@ -958,7 +842,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     }
 
     // Immediately update local state so the UI feels responsive
-    setIsStreaming(false, "cancelMessage");
+    setIsStreaming(false);
     finalizeAllActiveRuns();
     // Close the cancel-before-first-event window: if runsRef was empty at
     // this point (cancel fired before any event for the in-flight turn),
@@ -970,17 +854,13 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
   // ---- Clear messages ----
 
   const clearMessages = useCallback(() => {
-    chatDebug("clearMessages_entry", {
-      run_count: runsRef.current.size,
-      streaming: isStreamingRef.current,
-    });
     setMessages([]);
     const key = agentIdRef.current ? `${agentIdRef.current}:${sessionName}` : null;
     if (key) {
       _messageCache.delete(key);
     }
     setError(null);
-    setIsStreaming(false, "clearMessages");
+    setIsStreaming(false);
     finalizeAllActiveRuns();
     // Same reasoning as cancelMessage: cover the case where clear fires
     // before any event for the in-flight turn has arrived.
@@ -991,26 +871,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
   const resolveApproval = React.useCallback(
     async (id: string, decision: ExecApprovalDecision): Promise<void> => {
-      chatDebug("resolveApproval_start", {
-        decision,
-        run_count: runsRef.current.size,
-        streaming: isStreamingRef.current,
-      });
-      try {
-        const result = await sendReq("exec.approval.resolve", { id, decision });
-        chatDebug("resolveApproval_done", {
-          decision,
-          run_count: runsRef.current.size,
-          streaming: isStreamingRef.current,
-          result_keys: result && typeof result === "object" ? Object.keys(result as object) : null,
-        });
-      } catch (err) {
-        chatDebug("resolveApproval_error", {
-          decision,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        throw err;
-      }
+      await sendReq("exec.approval.resolve", { id, decision });
     },
     [sendReq],
   );


### PR DESCRIPTION
## Summary

End-of-cycle cleanup for the multi-bubble chat refactor (#349/#350/#352). Removes the debug tracers used to diagnose the post-approval streaming bug now that the real fix has shipped to prod. Also tightens the `runId` forwarding contract on the backend.

## What's removed

### Frontend — `apps/frontend/src/hooks/useAgentChat.ts`
- `chatDebug()` wrapper + `isChatDebugEnabled()` localStorage-flag helper
- All `chatDebug(...)` call sites (sendMessage entry, chunk arrival, approval events, cancel/clear, etc.)
- `console.log("[chat-debug]", ...)` tracers
- `posthog.capture("chat_debug", ...)` calls

### Backend — `apps/backend/core/gateway/connection_pool.py`
- Per-event debug log lines from #336 that dumped `runId/seq/clientRunId` on chat-terminal events and `approvalId` on exec.approval.* events
- The 5 `if run_id:` forwarding guards (see below)

### Reverses (only the debug portions of)
- #332 — debug(chat): instrument stream state machine
- #333 — debug(chat): console.log visibility
- #336 — debug(gateway): dump runId/seq/clientRunId
- #338 — only the chunk-arrival tracer part; PostHog `/ingest/*` reverse-proxy stays (prod-useful, bypasses ad-blockers)

## Contract tightening

OpenClaw emits `runId` on every agent event (assistant/reasoning/thinking/tool) and every chat-terminal event (final/error/aborted). Frontend #350 made `runId: string` (required) on `ChatIncomingMessage`. Backend was still guarding forwarding with `if run_id:`, a dead branch that only fires if OpenClaw breaks its own contract.

Codex flagged this as a runtime/type mismatch on #350 (L464). Closing the gap:
- `_transform_agent_event`: `transformed["runId"] = payload["runId"]` (unconditional)
- 4 chat-terminal forwarding sites (thinking / done / error / aborted): `fwd["runId"] = run_id` (unconditional)
- Missing runId now raises `KeyError` — surfaces a protocol violation loudly instead of silently breaking multi-bubble routing

## Test plan

- [x] Commit 1: frontend `pnpm tsc --noEmit` clean, `useAgentChat.test.ts` 13/13 pass, backend `test_connection_pool.py` 47/47 pass
- [x] Commit 2: backend tests updated — `test_omits_run_id_when_not_in_payload` → `test_raises_when_run_id_missing`, `test_done_without_run_id_still_forwarded` → `test_done_without_run_id_raises`, and chat-terminal tests now include `runId` in payloads
- [ ] CI: full backend + frontend suites (local venv corrupted by disk pressure; relying on CI for commit 2 verification — scope is shape-only)
- [ ] Verify on dev: chat still streams / tool approval flow still works after deploy

## Commit structure

1. `chore(chat): remove debug instrumentation from multi-bubble refactor` — `6167e909`
2. `refactor(gateway): runId is always forwarded — drop if-guards` — `cbc5e0cf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)