### PR TITLE
feat(admin): Phase B — backend foundations (#351)

### DIFF
--- a/apps/backend/core/repositories/admin_actions_repo.py
+++ b/apps/backend/core/repositories/admin_actions_repo.py
@@ -1,0 +1,133 @@
+"""Admin-actions repository — DynamoDB CRUD for the audit table.
+
+Every write under /api/v1/admin/* appends a row here via the
+@audit_admin_action decorator. Reads power /admin/actions and the
+per-target audit feed on /admin/users/{user_id}/actions.
+
+Schema (created by apps/infra/lib/stacks/database-stack.ts):
+- PK admin_user_id (Clerk user_id of the admin who took the action)
+- SK timestamp_action_id ({ISO8601}#{ulid-like} for time-ordering)
+- GSI target-timestamp-index (PK target_user_id, SK timestamp_action_id)
+"""
+
+import time
+import uuid
+from typing import Any
+
+from boto3.dynamodb.conditions import Key
+
+from core.dynamodb import get_table, run_in_thread, utc_now_iso
+
+
+def _get_table():
+    return get_table("admin-actions")
+
+
+def _generate_action_id() -> str:
+    """ULID-like ID: timestamp-prefixed, sortable, unique.
+
+    Same shape as update_repo._generate_ulid_like to keep the codebase
+    consistent (avoids pulling in a uuid6/ulid dependency).
+    """
+    ts_ms = int(time.time() * 1000)
+    ts_hex = f"{ts_ms:012x}"
+    rand_hex = uuid.uuid4().hex[:20]
+    return f"{ts_hex}{rand_hex}"
+
+
+async def create(
+    *,
+    admin_user_id: str,
+    target_user_id: str,
+    action: str,
+    payload: dict,
+    result: str,
+    audit_status: str,
+    http_status: int,
+    elapsed_ms: int,
+    error_message: str | None,
+    user_agent: str,
+    ip: str,
+) -> dict:
+    """Append an audit row. Returns the persisted item (with generated SK).
+
+    Called synchronously by @audit_admin_action *before* returning the
+    response — see CEO review S1 (audit fail-closed). The decorator
+    catches DDB errors and degrades to audit_status="panic" + a CRITICAL
+    log entry; this function does not retry on its own.
+    """
+    table = _get_table()
+    iso_ts = utc_now_iso()
+    action_id = _generate_action_id()
+    item: dict[str, Any] = {
+        "admin_user_id": admin_user_id,
+        "timestamp_action_id": f"{iso_ts}#{action_id}",
+        "target_user_id": target_user_id,
+        "action": action,
+        "payload": payload,
+        "result": result,
+        "audit_status": audit_status,
+        "http_status": http_status,
+        "elapsed_ms": elapsed_ms,
+        "user_agent": user_agent,
+        "ip": ip,
+    }
+    if error_message:
+        item["error_message"] = error_message
+    await run_in_thread(table.put_item, Item=item)
+    return item
+
+
+async def query_by_target(
+    target_user_id: str,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> dict:
+    """Newest-first via the target-timestamp-index GSI.
+
+    Returns {items: list[dict], cursor: str | None}.
+    cursor is the LastEvaluatedKey's timestamp_action_id, opaque to callers.
+    """
+    table = _get_table()
+    kwargs: dict[str, Any] = {
+        "IndexName": "target-timestamp-index",
+        "KeyConditionExpression": Key("target_user_id").eq(target_user_id),
+        "Limit": limit,
+        "ScanIndexForward": False,
+    }
+    if cursor:
+        kwargs["ExclusiveStartKey"] = {
+            "target_user_id": target_user_id,
+            "timestamp_action_id": cursor,
+        }
+    response = await run_in_thread(table.query, **kwargs)
+    last = response.get("LastEvaluatedKey")
+    return {
+        "items": response.get("Items", []),
+        "cursor": last.get("timestamp_action_id") if last else None,
+    }
+
+
+async def query_by_admin(
+    admin_user_id: str,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> dict:
+    """Newest-first via the base table's PK/SK."""
+    table = _get_table()
+    kwargs: dict[str, Any] = {
+        "KeyConditionExpression": Key("admin_user_id").eq(admin_user_id),
+        "Limit": limit,
+        "ScanIndexForward": False,
+    }
+    if cursor:
+        kwargs["ExclusiveStartKey"] = {
+            "admin_user_id": admin_user_id,
+            "timestamp_action_id": cursor,
+        }
+    response = await run_in_thread(table.query, **kwargs)
+    last = response.get("LastEvaluatedKey")
+    return {
+        "items": response.get("Items", []),
+        "cursor": last.get("timestamp_action_id") if last else None,
+    }

--- a/apps/backend/core/services/admin_audit.py
+++ b/apps/backend/core/services/admin_audit.py
@@ -1,0 +1,182 @@
+"""@audit_admin_action decorator — synchronous, fail-closed audit for /admin/* writes.
+
+Per CEO review S1 (issue #351):
+- Audit row is written BEFORE the response is returned (synchronous).
+- If DDB write fails, the primary action's side effect has already
+  executed (Stripe/ECS/etc. — can't be rolled back), so:
+    * a CRITICAL log entry "ADMIN_AUDIT_PANIC" is emitted with full context,
+    * the response is annotated audit_status="panic" so the UI can warn.
+- The decorator never raises from its own audit logic; it only re-raises
+  exceptions originating in the wrapped handler.
+
+Usage:
+
+    @router.post("/admin/users/{user_id}/container/reprovision")
+    @audit_admin_action("container.reprovision")
+    async def handler(
+        user_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_platform_admin),
+    ):
+        ...
+
+The wrapped handler MUST take `request: Request` and `auth: AuthContext`
+as kwargs (or args). The target user id comes from a path param named
+`user_id` by default; override via `target_param="owner_id"` etc.
+
+For write endpoints with a request body, also pass `body=<pydantic model>`
+so the decorator can capture and (optionally) redact it for the audit row.
+"""
+
+import functools
+import logging
+import time
+from typing import Any, Callable
+
+from core.auth import AuthContext
+from core.repositories import admin_actions_repo
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_client_ip(request: Any) -> str:
+    """First X-Forwarded-For hop (set by Vercel's edge), or client.host."""
+    if request is None:
+        return "unknown"
+    xff = request.headers.get("x-forwarded-for", "") if hasattr(request, "headers") else ""
+    if xff:
+        return xff.split(",")[0].strip()
+    client = getattr(request, "client", None)
+    return getattr(client, "host", "unknown") if client else "unknown"
+
+
+def _extract_user_agent(request: Any) -> str:
+    if request is None or not hasattr(request, "headers"):
+        return "unknown"
+    return request.headers.get("user-agent", "unknown")
+
+
+def _redact_payload(payload: dict, redact_paths: list[str]) -> dict:
+    """Shallow redaction — replaces top-level keys in redact_paths with '***redacted***'.
+
+    For deep redaction of openclaw.json secret fields, see
+    core.services.admin_redact.redact_openclaw_config (Phase B Task 11).
+    """
+    if not redact_paths:
+        return payload
+    return {k: ("***redacted***" if k in redact_paths else v) for k, v in payload.items()}
+
+
+def _payload_from_body(body: Any) -> dict:
+    if body is None:
+        return {}
+    if hasattr(body, "model_dump"):
+        return body.model_dump()
+    if isinstance(body, dict):
+        return body
+    return {}
+
+
+def _find_auth(args: tuple, kwargs: dict) -> AuthContext | None:
+    auth = kwargs.get("auth")
+    if isinstance(auth, AuthContext):
+        return auth
+    for a in args:
+        if isinstance(a, AuthContext):
+            return a
+    return None
+
+
+def audit_admin_action(
+    action: str,
+    *,
+    target_param: str = "user_id",
+    redact_paths: list[str] | None = None,
+) -> Callable:
+    """Decorate an admin router handler to write an audit row per call.
+
+    See module docstring for the contract. `action` is a dotted name like
+    'container.reprovision' that ends up in the audit_actions DDB row's
+    `action` field (the same value the audit viewer uses for filtering).
+    """
+    redact_paths = redact_paths or []
+
+    def decorator(handler: Callable) -> Callable:
+        @functools.wraps(handler)
+        async def wrapped(*args, **kwargs):
+            auth = _find_auth(args, kwargs)
+            if auth is None:
+                # Programming error — decorator misused. Surface loudly.
+                raise RuntimeError(f"@audit_admin_action({action!r}) requires AuthContext in args or kwargs")
+
+            request = kwargs.get("request")
+            target_user_id = kwargs.get(target_param) or "system"
+            payload = _redact_payload(_payload_from_body(kwargs.get("body")), redact_paths)
+
+            user_agent = _extract_user_agent(request)
+            ip = _extract_client_ip(request)
+
+            started = time.monotonic()
+            result_label = "success"
+            http_status = 200
+            error_message: str | None = None
+            handler_result: Any = None
+            handler_exc: BaseException | None = None
+
+            try:
+                handler_result = await handler(*args, **kwargs)
+            except BaseException as e:  # noqa: BLE001 — re-raised after audit
+                handler_exc = e
+                result_label = "error"
+                http_status = getattr(e, "status_code", 500)
+                error_message = getattr(e, "detail", None) or str(e)
+
+            elapsed_ms = int((time.monotonic() - started) * 1000)
+
+            audit_status = "written"
+            try:
+                await admin_actions_repo.create(
+                    admin_user_id=auth.user_id,
+                    target_user_id=target_user_id,
+                    action=action,
+                    payload=payload,
+                    result=result_label,
+                    audit_status="written",
+                    http_status=http_status,
+                    elapsed_ms=elapsed_ms,
+                    error_message=error_message,
+                    user_agent=user_agent,
+                    ip=ip,
+                )
+            except Exception as audit_exc:  # noqa: BLE001
+                # CEO S1 fail-closed: action already executed; surface the
+                # gap loudly but don't double-fail the request.
+                audit_status = "panic"
+                logger.critical(
+                    "ADMIN_AUDIT_PANIC action=%s admin=%s target=%s err=%s",
+                    action,
+                    auth.user_id,
+                    target_user_id,
+                    audit_exc,
+                    extra={
+                        "admin_action": action,
+                        "admin_user_id": auth.user_id,
+                        "target_user_id": target_user_id,
+                        "result": result_label,
+                        "http_status": http_status,
+                        "audit_error": str(audit_exc),
+                    },
+                )
+
+            if handler_exc is not None:
+                raise handler_exc
+
+            # Tag dict responses with audit_status so the UI can warn the operator
+            # when a write succeeded but the audit row didn't land.
+            if isinstance(handler_result, dict):
+                return {**handler_result, "audit_status": audit_status}
+            return handler_result
+
+        return wrapped
+
+    return decorator

--- a/apps/backend/core/services/admin_redact.py
+++ b/apps/backend/core/services/admin_redact.py
@@ -1,0 +1,61 @@
+"""Recursive openclaw.json secret-field redactor.
+
+Per CEO review S3 (#351): the admin agent-detail page renders a user's
+openclaw.json config inline, but that config can contain BYOK provider
+keys, webhook URLs, and other secrets. Strip them before serializing
+to the admin frontend.
+
+Pattern allowlist (case-insensitive on keys):
+- *_key, *_secret, *_token, *_password
+- webhook_url, api_key, bearer
+
+Values get replaced with the literal string "***redacted***". Keys
+themselves stay (so the admin can see "anthropic_api_key was set"
+without seeing the value).
+
+Note: this is the deep-recursive redactor for nested config dicts.
+The lighter `_redact_payload` in admin_audit.py (Task 7) is a shallow
+top-level redact — different use case (audit row payload vs full
+config tree).
+"""
+
+import re
+from typing import Any
+
+_REDACT_PATTERNS = [
+    re.compile(r"_key$"),
+    re.compile(r"_secret$"),
+    re.compile(r"_token$"),
+    re.compile(r"_password$"),
+    re.compile(r"^webhook_url$"),
+    re.compile(r"^api_key$"),
+    re.compile(r"^bearer$"),
+]
+
+REDACTED_VALUE = "***redacted***"
+
+
+def _should_redact(key: str) -> bool:
+    if not isinstance(key, str):
+        return False
+    lowered = key.lower()
+    return any(pattern.search(lowered) for pattern in _REDACT_PATTERNS)
+
+
+def redact_openclaw_config(value: Any) -> Any:
+    """Walk a JSON-shaped value and redact any sensitive leaves.
+
+    Preserves shape — dict keys remain, list ordering remains, scalar
+    values pass through. Only values whose dict-key matches the
+    redact patterns get replaced.
+
+    Idempotent: redacting an already-redacted structure is a no-op.
+    """
+    if isinstance(value, dict):
+        return {
+            key: (REDACTED_VALUE if _should_redact(key) else redact_openclaw_config(child))
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_openclaw_config(item) for item in value]
+    return value

--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -1,0 +1,250 @@
+"""Admin dashboard composition layer (CEO C1: composes existing services).
+
+Read-side aggregation for /api/v1/admin/* endpoints. Phase B v1 covers:
+- list_users (Clerk + container_repo join)
+- get_overview (Clerk + Stripe DDB row + container DDB row + usage)
+- list_user_agents (gateway RPC, with E2 timeout + E3 stopped detection)
+- get_agent_detail (4-way gateway parallel + S3 redaction)
+- get_logs (delegates to cloudwatch_logs)
+- get_cloudwatch_url (delegates to cloudwatch_url)
+- get_posthog_timeline (delegates to posthog_admin)
+- get_actions_audit (delegates to admin_actions_repo)
+
+Mutation-side composition (cancel_subscription, etc.) lives in Phase C
+admin router handlers — they call existing services directly via the
+@audit_admin_action decorator.
+
+CEO P1: parallel reads in get_overview wrap each upstream with a 2s
+timeout via _with_timeout. Slow Stripe doesn't starve other panels.
+"""
+
+import asyncio
+import logging
+from typing import Any
+
+from core.containers import get_ecs_manager, get_gateway_pool
+from core.repositories import admin_actions_repo, billing_repo, container_repo, usage_repo
+from core.services import clerk_admin, cloudwatch_logs, cloudwatch_url, posthog_admin
+from core.services.admin_redact import redact_openclaw_config
+
+logger = logging.getLogger(__name__)
+
+
+_PARALLEL_TIMEOUT_S = 2.0
+_GATEWAY_RPC_TIMEOUT_S = 3.0
+
+
+async def _with_timeout(coro, label: str, timeout_s: float | None = None):
+    """Wrap a coroutine with a timeout; return {error, source} on timeout/error.
+
+    Used in get_overview's parallel fetches so a slow Clerk/Stripe doesn't
+    take the whole overview page down (CEO P1). timeout_s defaults to the
+    module-level _PARALLEL_TIMEOUT_S resolved at call time so tests can
+    monkeypatch the constant.
+    """
+    effective_timeout = timeout_s if timeout_s is not None else _PARALLEL_TIMEOUT_S
+    try:
+        return await asyncio.wait_for(coro, timeout=effective_timeout)
+    except asyncio.TimeoutError:
+        return {"error": "timeout", "source": label}
+    except Exception as e:  # noqa: BLE001
+        logger.warning("admin_service: %s upstream failed: %s", label, e)
+        return {"error": str(e), "source": label}
+
+
+async def list_users(*, q: str = "", limit: int = 50, cursor: str | None = None) -> dict:
+    """Paginated user list joined with container status.
+
+    cursor is opaque — pass back to fetch next page. Internally a string
+    representation of Clerk's offset (since Clerk uses int offsets, we
+    stringify them so the frontend treats cursor uniformly).
+    """
+    offset = int(cursor) if cursor and cursor.isdigit() else 0
+    page = await clerk_admin.list_users(query=q, limit=limit, offset=offset)
+
+    clerk_users = page.get("users", [])
+    user_ids = [u["id"] for u in clerk_users]
+
+    # Per-user container lookup. Parallel since container_repo.get_by_owner_id
+    # makes one DDB call each.
+    containers = await asyncio.gather(
+        *(container_repo.get_by_owner_id(uid) for uid in user_ids),
+        return_exceptions=True,
+    )
+    container_by_uid = {uid: (c if not isinstance(c, BaseException) else None) for uid, c in zip(user_ids, containers)}
+
+    rows = []
+    for u in clerk_users:
+        container = container_by_uid.get(u["id"]) or {}
+        emails = u.get("email_addresses", [])
+        primary_email = emails[0].get("email_address") if emails else None
+        rows.append(
+            {
+                "clerk_id": u["id"],
+                "email": primary_email,
+                "created_at": u.get("created_at"),
+                "last_sign_in_at": u.get("last_sign_in_at"),
+                "banned": u.get("banned", False),
+                "container_status": container.get("status", "none"),
+                "plan_tier": container.get("plan_tier", "free"),
+            }
+        )
+
+    return {
+        "users": rows,
+        "cursor": str(page["next_offset"]) if page.get("next_offset") is not None else None,
+        "stubbed": page.get("stubbed", False),
+    }
+
+
+async def get_overview(user_id: str) -> dict:
+    """Identity + billing + container + usage in one payload.
+
+    Five parallel fetches with per-call timeout — slow Stripe doesn't
+    starve the others; each panel can render even if its source errors.
+    """
+    period = "current"  # usage_repo uses "YYYY-MM" or "current"; current covers month-to-date
+
+    clerk, container, billing, usage = await asyncio.gather(
+        _with_timeout(clerk_admin.get_user(user_id), "clerk"),
+        _with_timeout(container_repo.get_by_owner_id(user_id), "ddb_containers"),
+        _with_timeout(billing_repo.get_by_owner_id(user_id), "ddb_billing"),
+        _with_timeout(usage_repo.get_period_usage(user_id, period), "ddb_usage"),
+    )
+
+    return {
+        "identity": clerk,
+        "container": container,
+        "billing": billing,
+        "usage": usage,
+    }
+
+
+async def list_user_agents(user_id: str, *, cursor: str | None = None, limit: int = 50) -> dict:
+    """Agents list via gateway RPC with E2 timeout + E3 stopped detection."""
+    container_row = await container_repo.get_by_owner_id(user_id)
+    if not container_row or container_row.get("status") != "running":
+        return {
+            "agents": [],
+            "cursor": None,
+            "container_status": (container_row or {}).get("status", "none"),
+        }
+
+    ecs = get_ecs_manager()
+    container, ip = await ecs.resolve_running_container(user_id)
+    if not container or not ip:
+        return {"agents": [], "cursor": None, "container_status": "unreachable"}
+
+    pool = get_gateway_pool()
+    try:
+        result = await asyncio.wait_for(
+            pool.send_rpc(
+                user_id=user_id,
+                req_id=f"admin-agents-list-{user_id}",
+                method="agents.list",
+                params={"cursor": cursor, "limit": limit},
+                ip=ip,
+                token=container["gateway_token"],
+            ),
+            timeout=_GATEWAY_RPC_TIMEOUT_S,  # read at call time so tests can monkeypatch
+        )
+    except asyncio.TimeoutError:
+        return {
+            "agents": [],
+            "cursor": None,
+            "container_status": "timeout",
+            "error": "gateway_rpc_timeout",
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.warning("admin_service.list_user_agents gateway error: %s", e)
+        return {"agents": [], "cursor": None, "container_status": "error", "error": str(e)}
+
+    return {
+        "agents": result.get("agents", []) if isinstance(result, dict) else [],
+        "cursor": result.get("cursor") if isinstance(result, dict) else None,
+        "container_status": "running",
+    }
+
+
+async def get_agent_detail(user_id: str, agent_id: str) -> dict:
+    """Per-agent detail: identity + sessions + skills + redacted config.
+
+    Four parallel gateway RPCs with a single shared timeout. CEO S3
+    redaction applied to the openclaw.json config slice before return.
+    """
+    container_row = await container_repo.get_by_owner_id(user_id)
+    if not container_row or container_row.get("status") != "running":
+        return {"error": "container_not_running", "container_status": (container_row or {}).get("status", "none")}
+
+    ecs = get_ecs_manager()
+    container, ip = await ecs.resolve_running_container(user_id)
+    if not container or not ip:
+        return {"error": "container_unreachable"}
+
+    pool = get_gateway_pool()
+    token = container["gateway_token"]
+
+    async def _rpc(method: str, params: dict, suffix: str) -> Any:
+        return await pool.send_rpc(
+            user_id=user_id,
+            req_id=f"admin-{suffix}-{agent_id}",
+            method=method,
+            params=params,
+            ip=ip,
+            token=token,
+        )
+
+    try:
+        agent, sessions, skills, config = await asyncio.wait_for(
+            asyncio.gather(
+                _rpc("agents.get", {"agent_id": agent_id}, "agent-get"),
+                _rpc("sessions.list", {"agent_id": agent_id, "limit": 20}, "sessions"),
+                _rpc("skills.list", {"agent_id": agent_id}, "skills"),
+                _rpc("config.get", {"agent_id": agent_id}, "config"),
+            ),
+            timeout=_GATEWAY_RPC_TIMEOUT_S,  # read at call time so tests can monkeypatch
+        )
+    except asyncio.TimeoutError:
+        return {"error": "gateway_rpc_timeout"}
+    except Exception as e:  # noqa: BLE001
+        logger.warning("admin_service.get_agent_detail gateway error: %s", e)
+        return {"error": str(e)}
+
+    return {
+        "agent": agent,
+        "sessions": sessions.get("sessions", []) if isinstance(sessions, dict) else [],
+        "skills": skills.get("skills", []) if isinstance(skills, dict) else [],
+        "config_redacted": redact_openclaw_config(config),
+    }
+
+
+# Thin pass-through wrappers — admin_service is the single import point
+# for the router so all admin-related logic flows through one module.
+
+
+async def get_logs(
+    user_id: str, *, level: str = "ERROR", hours: int = 24, limit: int = 20, cursor: str | None = None
+) -> dict:
+    return await cloudwatch_logs.filter_user_logs(user_id=user_id, level=level, hours=hours, limit=limit, cursor=cursor)
+
+
+def get_cloudwatch_url(user_id: str, *, start: str, end: str, level: str = "ERROR") -> str:
+    return cloudwatch_url.build_insights_url(user_id=user_id, start=start, end=end, level=level)
+
+
+async def get_posthog_timeline(user_id: str, *, limit: int = 100) -> dict:
+    return await posthog_admin.get_person_events(distinct_id=user_id, limit=limit)
+
+
+async def get_actions_audit(
+    *,
+    target_user_id: str | None = None,
+    admin_user_id: str | None = None,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> dict:
+    if target_user_id:
+        return await admin_actions_repo.query_by_target(target_user_id, limit=limit, cursor=cursor)
+    if admin_user_id:
+        return await admin_actions_repo.query_by_admin(admin_user_id, limit=limit, cursor=cursor)
+    raise ValueError("get_actions_audit requires target_user_id or admin_user_id")

--- a/apps/backend/core/services/clerk_admin.py
+++ b/apps/backend/core/services/clerk_admin.py
@@ -1,0 +1,82 @@
+"""Clerk Backend API client for admin-side read operations.
+
+Phase B v1 surface: list users, get one user. Mutation operations
+(ban / unban / revoke sessions / resend verification) are added in
+Phase C alongside the admin router endpoints that need them.
+
+There is no centralized Clerk client in this codebase yet — billing.py
+and desktop_auth.py call api.clerk.com inline via httpx. This module
+consolidates the admin-side calls so admin_service.py can compose
+without duplicating httpx setup.
+
+Empty/missing CLERK_SECRET_KEY → callers get a stubbed empty response
+so local dev without real Clerk admin creds still renders the admin
+UI (with no users listed).
+"""
+
+import logging
+
+import httpx
+
+from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+_CLERK_API_BASE = "https://api.clerk.com/v1"
+_TIMEOUT_S = 5.0
+
+
+async def list_users(*, query: str = "", limit: int = 50, offset: int = 0) -> dict:
+    """Paginated list. Returns {users: list[dict], next_offset: int | None}.
+
+    `query` is a Clerk search string (matches email, first/last name,
+    user_id). `offset` is integer-paged (Clerk supports limit + offset).
+    Stubs when CLERK_SECRET_KEY is unset.
+    """
+    if not settings.CLERK_SECRET_KEY:
+        return {"users": [], "next_offset": None, "stubbed": True}
+
+    params: dict = {"limit": min(limit, 500), "offset": offset, "order_by": "-created_at"}
+    if query:
+        params["query"] = query
+
+    headers = {"Authorization": f"Bearer {settings.CLERK_SECRET_KEY}"}
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+            response = await client.get(f"{_CLERK_API_BASE}/users", headers=headers, params=params)
+    except httpx.TimeoutException:
+        return {"users": [], "next_offset": None, "error": "timeout"}
+    except Exception as e:  # noqa: BLE001
+        logger.warning("clerk_admin.list_users network error: %s", e)
+        return {"users": [], "next_offset": None, "error": str(e)}
+
+    if response.status_code >= 400:
+        logger.warning("clerk_admin.list_users HTTP %s", response.status_code)
+        return {"users": [], "next_offset": None, "error": f"http_{response.status_code}"}
+
+    users = response.json()
+    next_offset = offset + len(users) if len(users) >= limit else None
+    return {"users": users, "next_offset": next_offset, "stubbed": False}
+
+
+async def get_user(user_id: str) -> dict | None:
+    """Single user by Clerk user_id. Returns None on 404."""
+    if not settings.CLERK_SECRET_KEY:
+        return None
+
+    headers = {"Authorization": f"Bearer {settings.CLERK_SECRET_KEY}"}
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+            response = await client.get(f"{_CLERK_API_BASE}/users/{user_id}", headers=headers)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("clerk_admin.get_user network error: %s", e)
+        return None
+
+    if response.status_code == 404:
+        return None
+    if response.status_code >= 400:
+        logger.warning("clerk_admin.get_user HTTP %s", response.status_code)
+        return None
+    return response.json()

--- a/apps/backend/core/services/cloudwatch_logs.py
+++ b/apps/backend/core/services/cloudwatch_logs.py
@@ -1,0 +1,161 @@
+"""CloudWatch Logs reader for the admin dashboard.
+
+Two callers in v1:
+- /admin/users/{user_id}/logs — per-user inline log viewer (filter_user_logs).
+- /admin/health — fleet-scoped recent errors panel (recent_errors_fleet).
+
+Backed by boto3 logs.FilterLogEvents on the backend service log group.
+The IAM permission lives on the backend ECS task role
+(see apps/infra/lib/stacks/service-stack.ts: CloudWatchLogsReadForAdmin).
+
+Log group naming matches service-stack.ts:519 + isol8-stage.ts:113 +
+local-stage.ts:116 — `/ecs/isol8-${env}` (no /aws prefix, no -backend
+suffix). Phase A's IAM policy was originally scoped to the wrong ARN
+and got fixed in commit 9f5323f2 — keep this module's name in sync.
+"""
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import boto3
+
+from core.config import settings
+from core.dynamodb import run_in_thread
+
+logger = logging.getLogger(__name__)
+
+
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        _client = boto3.client("logs", region_name=settings.AWS_REGION)
+    return _client
+
+
+def _backend_log_group() -> str:
+    env = settings.ENVIRONMENT or "dev"
+    return f"/ecs/isol8-{env}"
+
+
+def _parse_event(raw: dict) -> dict:
+    """Structured-log JSON → row shape consumed by the admin Logs tab."""
+    parsed = None
+    try:
+        parsed = json.loads(raw["message"])
+    except (ValueError, TypeError):
+        pass
+
+    iso_ts = datetime.fromtimestamp(raw["timestamp"] / 1000, tz=timezone.utc).isoformat()
+
+    if parsed is not None:
+        return {
+            "timestamp": iso_ts,
+            "level": parsed.get("level"),
+            "message": parsed.get("message", raw["message"]),
+            "correlation_id": parsed.get("correlation_id"),
+            "raw_json": parsed,
+        }
+    return {
+        "timestamp": iso_ts,
+        "level": None,
+        "message": raw["message"],
+        "correlation_id": None,
+        "raw_json": None,
+    }
+
+
+async def filter_user_logs(
+    *,
+    user_id: str,
+    level: str = "ERROR",
+    hours: int = 24,
+    limit: int = 20,
+    cursor: str | None = None,
+) -> dict:
+    """Return recent structured logs filtered to a specific user.
+
+    Returns: {events: list[dict], cursor: str | None, missing: bool}
+    - cursor is the FilterLogEvents nextToken — opaque to callers, pass
+      back as `cursor` to fetch the next page (CEO E4).
+    - missing=True when the log group does not exist (LocalStack /
+      fresh env). Callers should render "no logs configured" rather than
+      treating it as an empty result.
+    - On non-NotFound errors, returns {events: [], missing: False, error: str}
+      so the admin page degrades gracefully instead of 500ing.
+    """
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(hours=hours)
+
+    kwargs: dict[str, Any] = {
+        "logGroupName": _backend_log_group(),
+        "startTime": int(start.timestamp() * 1000),
+        "endTime": int(end.timestamp() * 1000),
+        "filterPattern": f'{{ $.user_id = "{user_id}" && $.level = "{level}" }}',
+        "limit": min(limit, 100),
+    }
+    if cursor:
+        kwargs["nextToken"] = cursor
+
+    client = _get_client()
+    try:
+        response = await run_in_thread(client.filter_log_events, **kwargs)
+    except client.exceptions.ResourceNotFoundException:
+        return {"events": [], "cursor": None, "missing": True}
+    except Exception as e:  # noqa: BLE001 — degrade gracefully
+        logger.warning("cloudwatch_logs.filter_user_logs failed: %s", e)
+        return {"events": [], "cursor": None, "missing": False, "error": str(e)}
+
+    return {
+        "events": [_parse_event(raw) for raw in response.get("events", [])],
+        "cursor": response.get("nextToken"),
+        "missing": False,
+    }
+
+
+async def recent_errors_fleet(*, hours: int = 24, limit: int = 20) -> list[dict]:
+    """Cross-user recent errors for /admin/health.
+
+    Same primitive as filter_user_logs but filter pattern is level-only.
+    Returns simplified row shape: {timestamp, user_id, message, correlation_id}.
+    Empty list on log-group-not-found or any error (the health endpoint
+    must never 500 because of CWL).
+    """
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(hours=hours)
+
+    client = _get_client()
+    try:
+        response = await run_in_thread(
+            client.filter_log_events,
+            logGroupName=_backend_log_group(),
+            startTime=int(start.timestamp() * 1000),
+            endTime=int(end.timestamp() * 1000),
+            filterPattern='{ $.level = "ERROR" }',
+            limit=min(limit, 100),
+        )
+    except client.exceptions.ResourceNotFoundException:
+        return []
+    except Exception as e:  # noqa: BLE001
+        logger.warning("cloudwatch_logs.recent_errors_fleet failed: %s", e)
+        return []
+
+    out = []
+    for raw in response.get("events", []):
+        try:
+            parsed = json.loads(raw["message"])
+        except (ValueError, TypeError):
+            parsed = {}
+        out.append(
+            {
+                "timestamp": datetime.fromtimestamp(raw["timestamp"] / 1000, tz=timezone.utc).isoformat(),
+                "user_id": parsed.get("user_id"),
+                "message": parsed.get("message") or raw["message"],
+                "correlation_id": parsed.get("correlation_id"),
+            }
+        )
+    return out

--- a/apps/backend/core/services/cloudwatch_url.py
+++ b/apps/backend/core/services/cloudwatch_url.py
@@ -1,0 +1,66 @@
+"""CloudWatch Logs Insights deep-link builder.
+
+Pure string assembly — no AWS SDK call. Used by /admin/users/{user_id}/cloudwatch-url
+to give admins a "Open in CloudWatch" button that lands on the AWS Console
+with a pre-filled query filtering to the specified user_id.
+
+Useful when the inline log viewer (cloudwatch_logs.filter_user_logs) hits
+its 1 MB / 10k event response cap and the admin needs cross-user or
+longer-range search power that the inline viewer can't provide.
+"""
+
+import urllib.parse
+
+from core.config import settings
+
+
+def _backend_log_group() -> str:
+    env = settings.ENVIRONMENT or "dev"
+    return f"/ecs/isol8-{env}"
+
+
+def _encode_insights_param(value: str) -> str:
+    """CloudWatch Insights URLs use a custom encoding — `~` for tildes,
+    `*` for percent, then URL-encode the rest. The query parameter values
+    look like `~(end~'2026-04-21T00:00:00Z*20...)`.
+
+    For our purposes, we URL-encode each interpolated value (timestamps,
+    user_id) so reserved chars don't break the query string."""
+    return urllib.parse.quote(value, safe="")
+
+
+def build_insights_url(*, user_id: str, start: str, end: str, level: str = "ERROR") -> str:
+    """Construct an AWS Console CWL Insights URL pre-filtered to user_id.
+
+    `start` / `end` are ISO-8601 timestamps; `level` is the structured-log
+    level filter ("ERROR" by default, can be "WARN", "INFO", etc.).
+
+    The Insights query:
+        fields @timestamp, @message
+        | filter user_id = "{user_id}" and level = "{level}"
+        | sort @timestamp desc
+        | limit 100
+    """
+    region = settings.AWS_REGION
+    log_group = _backend_log_group()
+
+    query = (
+        f'fields @timestamp, @message | filter user_id = "{user_id}" '
+        f'and level = "{level}" | sort @timestamp desc | limit 100'
+    )
+
+    # Insights URL params use a custom delimiter scheme. Encode each piece
+    # then assemble. The format mirrors what AWS Console produces when you
+    # share a query.
+    detail = (
+        f"~(end~'{_encode_insights_param(end)}"
+        f"~start~'{_encode_insights_param(start)}"
+        f"~timeType~'ABSOLUTE~tz~'UTC"
+        f"~editorString~'{_encode_insights_param(query)}"
+        f"~source~(~'{_encode_insights_param(log_group)}))"
+    )
+
+    return (
+        f"https://{region}.console.aws.amazon.com/cloudwatch/home"
+        f"?region={region}#logsV2:logs-insights?queryDetail={detail}"
+    )

--- a/apps/backend/core/services/posthog_admin.py
+++ b/apps/backend/core/services/posthog_admin.py
@@ -1,0 +1,94 @@
+"""PostHog Persons API client for the admin dashboard.
+
+Used by /admin/users/{user_id}/posthog to render the Activity tab —
+recent events for a specific user plus a deep link to PostHog's
+session-replay UI.
+
+The user's PostHog `distinct_id` is the Clerk user_id, because
+apps/frontend/src/components/PostHogProvider.tsx:51 already calls
+`posthog.identify(userId, ...)` with the Clerk JWT's `sub`.
+
+Stubs gracefully when POSTHOG_PROJECT_API_KEY is unset (returns
+{events: [], stubbed: True}) — local dev works without a real
+PostHog project. Returns missing=True on 404 so the UI can render
+"no PostHog activity recorded" instead of treating the user as
+broken (CEO E5).
+"""
+
+import logging
+
+import httpx
+
+from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+_TIMEOUT_S = 5.0
+
+
+async def get_person_events(*, distinct_id: str, limit: int = 100) -> dict:
+    """Fetch recent events for a Clerk user from PostHog.
+
+    Returns:
+        {events: list[dict], stubbed: bool, missing: bool, error: str | None}
+
+    - stubbed=True when POSTHOG_PROJECT_API_KEY is unset; events=[].
+    - missing=True when PostHog returns 404 (user never identified); events=[].
+    - error populated on transient failures (timeout, 5xx); events=[].
+    - Otherwise, events is a list of {timestamp, event, properties, session_id}.
+
+    Each event includes `session_id` (from the `$session_id` property) so the
+    UI can deep-link to the session replay via session_replay_url().
+    """
+    if not settings.POSTHOG_PROJECT_API_KEY or not settings.POSTHOG_PROJECT_ID:
+        return {"events": [], "stubbed": True, "missing": False, "error": None}
+
+    url = f"{settings.POSTHOG_HOST}/api/projects/{settings.POSTHOG_PROJECT_ID}/persons/"
+    headers = {"Authorization": f"Bearer {settings.POSTHOG_PROJECT_API_KEY}"}
+    params = {"distinct_id": distinct_id, "limit": min(limit, 500)}
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+            response = await client.get(url, headers=headers, params=params)
+    except httpx.TimeoutException:
+        return {"events": [], "stubbed": False, "missing": False, "error": "timeout"}
+    except Exception as e:  # noqa: BLE001
+        logger.warning("posthog_admin.get_person_events network error: %s", e)
+        return {"events": [], "stubbed": False, "missing": False, "error": str(e)}
+
+    if response.status_code == 404:
+        return {"events": [], "stubbed": False, "missing": True, "error": None}
+
+    if response.status_code >= 400:
+        logger.warning(
+            "posthog_admin.get_person_events HTTP %s: %s",
+            response.status_code,
+            response.text[:200],
+        )
+        return {
+            "events": [],
+            "stubbed": False,
+            "missing": False,
+            "error": f"http_{response.status_code}",
+        }
+
+    data = response.json()
+    events: list[dict] = []
+    for person in data.get("results", []):
+        for event in person.get("events", [])[:limit]:
+            properties = event.get("properties", {}) or {}
+            events.append(
+                {
+                    "timestamp": event.get("timestamp"),
+                    "event": event.get("event"),
+                    "properties": properties,
+                    "session_id": properties.get("$session_id"),
+                }
+            )
+    return {"events": events, "stubbed": False, "missing": False, "error": None}
+
+
+def session_replay_url(session_id: str) -> str:
+    """Deep link to PostHog's session-replay UI for a given session."""
+    return f"{settings.POSTHOG_HOST}/replay/{session_id}"

--- a/apps/backend/core/services/system_health.py
+++ b/apps/backend/core/services/system_health.py
@@ -1,0 +1,176 @@
+"""/admin/health aggregator.
+
+Composes:
+- Container fleet counts grouped by status (DDB GSI scans).
+- Upstream probes for Clerk, Stripe, DDB — each 2s timeout, results
+  cached for 30s (CEO P2) so the health page doesn't block on slow
+  upstreams every render.
+- Background-task state for the async tasks spawned in main.py lifespan
+  (UsagePoller, IdleChecker, scheduled worker, etc.). main.py registers
+  task references in the BACKGROUND_TASKS dict at startup; we read
+  their .done()/.exception() state here.
+- Recent fleet-wide errors via cloudwatch_logs.recent_errors_fleet.
+
+Read by routers/admin.py: GET /admin/system/health.
+"""
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import boto3
+import httpx
+
+from core.config import settings
+from core.repositories import container_repo
+from core.services import cloudwatch_logs
+
+logger = logging.getLogger(__name__)
+
+
+# Probe cache: {value: dict, ts: monotonic_seconds}
+_PROBE_CACHE_TTL_S = 30
+_probe_cache: dict[str, Any] = {"ts": 0.0, "value": None}
+
+# Set by main.py lifespan to {task_name: asyncio.Task}.
+# Read here to surface "is the IdleChecker still running" on /admin/health.
+BACKGROUND_TASKS: dict[str, asyncio.Task] = {}
+
+_KNOWN_CONTAINER_STATUSES = ("running", "provisioning", "stopped", "error")
+
+
+async def _probe_clerk() -> dict:
+    """Fetch the Clerk JWKS — cheap, exercises auth dependency."""
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            response = await client.get(f"{settings.CLERK_ISSUER}/.well-known/jwks.json")
+        latency_ms = int((time.monotonic() - started) * 1000)
+        return {
+            "status": "ok" if response.status_code == 200 else "degraded",
+            "latency_ms": latency_ms,
+            "http_status": response.status_code,
+        }
+    except Exception as e:  # noqa: BLE001
+        return {"status": "down", "error": str(e)}
+
+
+async def _probe_stripe() -> dict:
+    """Lightweight Stripe ping — Account.retrieve verifies key + connectivity."""
+    if not settings.STRIPE_SECRET_KEY:
+        return {"status": "unconfigured"}
+    started = time.monotonic()
+    try:
+        import stripe
+
+        stripe.api_key = settings.STRIPE_SECRET_KEY
+        await asyncio.to_thread(stripe.Account.retrieve)
+        return {"status": "ok", "latency_ms": int((time.monotonic() - started) * 1000)}
+    except Exception as e:  # noqa: BLE001
+        return {"status": "degraded", "error": str(e)}
+
+
+async def _probe_ddb() -> dict:
+    """DDB ping via DescribeTable on the admin-actions table."""
+    started = time.monotonic()
+    try:
+        client = boto3.client("dynamodb", region_name=settings.AWS_REGION)
+        env = settings.ENVIRONMENT or "dev"
+        table_name = f"isol8-{env}-admin-actions"
+        await asyncio.to_thread(client.describe_table, TableName=table_name)
+        return {"status": "ok", "latency_ms": int((time.monotonic() - started) * 1000)}
+    except Exception as e:  # noqa: BLE001
+        return {"status": "down", "error": str(e)}
+
+
+async def _all_probes() -> dict:
+    """Run all upstream probes in parallel; cache for _PROBE_CACHE_TTL_S."""
+    if _probe_cache["value"] is not None and (time.monotonic() - _probe_cache["ts"]) < _PROBE_CACHE_TTL_S:
+        return _probe_cache["value"]
+
+    results = await asyncio.gather(
+        _probe_clerk(),
+        _probe_stripe(),
+        _probe_ddb(),
+        return_exceptions=True,
+    )
+
+    def _safe(r: Any) -> dict:
+        if isinstance(r, BaseException):
+            return {"status": "down", "error": str(r)}
+        return r
+
+    value = {
+        "clerk": _safe(results[0]),
+        "stripe": _safe(results[1]),
+        "ddb": _safe(results[2]),
+    }
+    _probe_cache["ts"] = time.monotonic()
+    _probe_cache["value"] = value
+    return value
+
+
+async def _fleet_counts() -> dict[str, int]:
+    """Containers by status. Total = sum of known statuses (omits any
+    unknown status, which would indicate a schema drift worth surfacing
+    separately later)."""
+    per_status = await asyncio.gather(
+        *(container_repo.get_by_status(s) for s in _KNOWN_CONTAINER_STATUSES),
+        return_exceptions=True,
+    )
+    counts: dict[str, int] = {}
+    total = 0
+    for status, items in zip(_KNOWN_CONTAINER_STATUSES, per_status):
+        n = 0 if isinstance(items, BaseException) else len(items)
+        counts[status] = n
+        total += n
+    counts["total"] = total
+    return counts
+
+
+def _background_tasks_status() -> dict[str, dict]:
+    """Snapshot current state of registered async tasks."""
+    out: dict[str, dict] = {}
+    for name, task in BACKGROUND_TASKS.items():
+        if task is None:
+            out[name] = {"status": "unregistered"}
+            continue
+        if task.done():
+            try:
+                exc = task.exception()
+                out[name] = {"status": "stopped", "error": str(exc) if exc else None}
+            except asyncio.CancelledError:
+                out[name] = {"status": "cancelled"}
+            except asyncio.InvalidStateError:
+                out[name] = {"status": "stopped"}
+        else:
+            out[name] = {"status": "running"}
+    return out
+
+
+async def get_system_health() -> dict:
+    """Top-level entry — composes everything for /admin/system/health.
+
+    Never raises — all upstream errors degrade to {status: "down"} on
+    that probe so the admin health page always renders.
+    """
+    upstreams, fleet, recent_errors = await asyncio.gather(
+        _all_probes(),
+        _fleet_counts(),
+        cloudwatch_logs.recent_errors_fleet(hours=24, limit=10),
+        return_exceptions=True,
+    )
+
+    def _safe(value: Any, fallback: Any) -> Any:
+        if isinstance(value, BaseException):
+            logger.warning("system_health component failed: %s", value)
+            return fallback
+        return value
+
+    return {
+        "upstreams": _safe(upstreams, {}),
+        "fleet": _safe(fleet, {}),
+        "background_tasks": _background_tasks_status(),
+        "recent_errors": _safe(recent_errors, []),
+    }

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -108,10 +108,18 @@ async def lifespan(app: FastAPI):
 
     idle_checker_task = asyncio.create_task(_safe_idle_checker())
 
+    # Register background tasks so /admin/system/health can surface their state.
+    # See core/services/system_health.py — admin dashboard reads this dict.
+    from core.services import system_health
+
+    system_health.BACKGROUND_TASKS["scheduled_worker"] = worker_task
+    system_health.BACKGROUND_TASKS["idle_checker"] = idle_checker_task
+
     yield
 
     # Shutdown
     logger.info("Shutting down application...")
+    system_health.BACKGROUND_TASKS.clear()
     idle_checker_task.cancel()
     worker_task.cancel()
     try:

--- a/apps/backend/tests/unit/repositories/test_admin_actions_repo.py
+++ b/apps/backend/tests/unit/repositories/test_admin_actions_repo.py
@@ -1,0 +1,178 @@
+"""Tests for admin-actions DynamoDB repository.
+
+Mirrors test_update_repo style — moto mock_aws + table create + patch
+core.dynamodb internals.
+"""
+
+import os
+from unittest.mock import patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+@pytest.fixture
+def dynamodb_table():
+    """Create a moto admin-actions table matching the CDK schema."""
+    with mock_aws():
+        client = boto3.resource("dynamodb", region_name="us-east-1")
+        table = client.create_table(
+            TableName="test-admin-actions",
+            KeySchema=[
+                {"AttributeName": "admin_user_id", "KeyType": "HASH"},
+                {"AttributeName": "timestamp_action_id", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "admin_user_id", "AttributeType": "S"},
+                {"AttributeName": "timestamp_action_id", "AttributeType": "S"},
+                {"AttributeName": "target_user_id", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "target-timestamp-index",
+                    "KeySchema": [
+                        {"AttributeName": "target_user_id", "KeyType": "HASH"},
+                        {"AttributeName": "timestamp_action_id", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        table.meta.client.get_waiter("table_exists").wait(TableName="test-admin-actions")
+
+        with (
+            patch("core.dynamodb._table_prefix", "test-"),
+            patch("core.dynamodb._dynamodb_resource", client),
+        ):
+            yield table
+
+
+def _row(**overrides):
+    base = dict(
+        admin_user_id="user_admin",
+        target_user_id="user_target",
+        action="container.reprovision",
+        payload={"tier": "starter"},
+        result="success",
+        audit_status="written",
+        http_status=200,
+        elapsed_ms=240,
+        error_message=None,
+        user_agent="Mozilla/5.0",
+        ip="203.0.113.1",
+    )
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_create_writes_all_required_fields(dynamodb_table):
+    from core.repositories import admin_actions_repo
+
+    item = await admin_actions_repo.create(**_row())
+    assert item["admin_user_id"] == "user_admin"
+    assert item["target_user_id"] == "user_target"
+    assert item["action"] == "container.reprovision"
+    assert item["payload"] == {"tier": "starter"}
+    assert item["result"] == "success"
+    assert item["audit_status"] == "written"
+    assert item["http_status"] == 200
+    assert item["elapsed_ms"] == 240
+    assert item["user_agent"] == "Mozilla/5.0"
+    assert item["ip"] == "203.0.113.1"
+    # Generated SK shape: {ISO8601}#{ulid-like}
+    sk = item["timestamp_action_id"]
+    assert "#" in sk
+    iso, action_id = sk.split("#", 1)
+    assert "T" in iso  # ISO 8601 timestamp
+    assert len(action_id) > 8  # non-trivial unique id
+
+
+@pytest.mark.asyncio
+async def test_create_omits_error_message_on_success(dynamodb_table):
+    from core.repositories import admin_actions_repo
+
+    item = await admin_actions_repo.create(**_row(error_message=None))
+    assert "error_message" not in item
+
+
+@pytest.mark.asyncio
+async def test_create_includes_error_message_on_failure(dynamodb_table):
+    from core.repositories import admin_actions_repo
+
+    item = await admin_actions_repo.create(**_row(result="error", error_message="container_not_found", http_status=404))
+    assert item["error_message"] == "container_not_found"
+    assert item["http_status"] == 404
+    assert item["result"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_query_by_target_returns_newest_first(dynamodb_table):
+    """Audit feed reads newest-first via the target-timestamp-index GSI."""
+    from core.repositories import admin_actions_repo
+
+    # Three actions on the same target, different times (uuid7 ensures ordering).
+    for i in range(3):
+        await admin_actions_repo.create(**_row(action=f"action_{i}"))
+
+    page = await admin_actions_repo.query_by_target("user_target", limit=10)
+    items = page["items"]
+    assert len(items) == 3
+    # Newest first
+    actions_in_order = [r["action"] for r in items]
+    assert actions_in_order == ["action_2", "action_1", "action_0"]
+
+
+@pytest.mark.asyncio
+async def test_query_by_target_filters_to_specified_user(dynamodb_table):
+    from core.repositories import admin_actions_repo
+
+    await admin_actions_repo.create(**_row(target_user_id="user_a"))
+    await admin_actions_repo.create(**_row(target_user_id="user_b"))
+    await admin_actions_repo.create(**_row(target_user_id="user_a"))
+
+    page = await admin_actions_repo.query_by_target("user_a")
+    assert len(page["items"]) == 2
+    assert all(r["target_user_id"] == "user_a" for r in page["items"])
+
+
+@pytest.mark.asyncio
+async def test_query_by_target_respects_limit(dynamodb_table):
+    from core.repositories import admin_actions_repo
+
+    for _ in range(5):
+        await admin_actions_repo.create(**_row())
+
+    page = await admin_actions_repo.query_by_target("user_target", limit=2)
+    assert len(page["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_query_by_admin_returns_newest_first(dynamodb_table):
+    from core.repositories import admin_actions_repo
+
+    for i in range(3):
+        await admin_actions_repo.create(**_row(action=f"action_{i}"))
+
+    page = await admin_actions_repo.query_by_admin("user_admin", limit=10)
+    items = page["items"]
+    assert len(items) == 3
+    assert [r["action"] for r in items] == ["action_2", "action_1", "action_0"]
+
+
+@pytest.mark.asyncio
+async def test_query_by_admin_isolates_admins(dynamodb_table):
+    from core.repositories import admin_actions_repo
+
+    await admin_actions_repo.create(**_row(admin_user_id="admin_a"))
+    await admin_actions_repo.create(**_row(admin_user_id="admin_b"))
+
+    page_a = await admin_actions_repo.query_by_admin("admin_a")
+    page_b = await admin_actions_repo.query_by_admin("admin_b")
+    assert len(page_a["items"]) == 1
+    assert len(page_b["items"]) == 1
+    assert page_a["items"][0]["admin_user_id"] == "admin_a"

--- a/apps/backend/tests/unit/services/test_admin_audit.py
+++ b/apps/backend/tests/unit/services/test_admin_audit.py
@@ -1,0 +1,207 @@
+"""Tests for the @audit_admin_action decorator.
+
+Covers the CEO S1 fail-closed contract:
+- Synchronous DDB write BEFORE response is returned.
+- On handler success: audit row written, response unchanged plus
+  audit_status="written".
+- On handler exception: audit row written with result="error", original
+  exception re-raised.
+- On DDB write failure: handler result preserved, response annotated with
+  audit_status="panic", CRITICAL log emitted, no exception raised from
+  the audit layer (don't double-fail the request).
+- payload redaction via redact_paths param.
+- elapsed_ms captured.
+- user_agent + ip captured from request headers.
+"""
+
+import logging
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+@pytest.fixture
+def fake_auth():
+    from core.auth import AuthContext
+
+    return AuthContext(user_id="admin_alice", email="alice@isol8.co")
+
+
+@pytest.fixture
+def fake_request():
+    """Mock FastAPI Request with headers + client.host."""
+    request = MagicMock()
+    request.headers = {"user-agent": "Mozilla/5.0 (test)", "x-forwarded-for": "203.0.113.1, 10.0.0.1"}
+    request.client = MagicMock(host="10.0.0.1")
+    return request
+
+
+@pytest.fixture
+def repo_mock():
+    """Patch admin_actions_repo.create to a mock so we can assert calls without DDB."""
+    with patch("core.services.admin_audit.admin_actions_repo.create", new=AsyncMock(return_value={})) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+async def test_happy_path_writes_audit_and_tags_response(repo_mock, fake_auth, fake_request):
+    from core.services.admin_audit import audit_admin_action
+
+    @audit_admin_action("container.reprovision")
+    async def handler(*, user_id, request, auth):
+        return {"status": "started", "run_id": "abc"}
+
+    response = await handler(user_id="user_target", request=fake_request, auth=fake_auth)
+
+    assert response["status"] == "started"
+    assert response["run_id"] == "abc"
+    assert response["audit_status"] == "written"
+
+    repo_mock.assert_awaited_once()
+    call_kwargs = repo_mock.await_args.kwargs
+    assert call_kwargs["admin_user_id"] == "admin_alice"
+    assert call_kwargs["target_user_id"] == "user_target"
+    assert call_kwargs["action"] == "container.reprovision"
+    assert call_kwargs["result"] == "success"
+    assert call_kwargs["audit_status"] == "written"
+    assert call_kwargs["http_status"] == 200
+    assert call_kwargs["error_message"] is None
+    assert call_kwargs["user_agent"] == "Mozilla/5.0 (test)"
+    # First X-Forwarded-For hop
+    assert call_kwargs["ip"] == "203.0.113.1"
+    assert call_kwargs["elapsed_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_audits_then_reraises(repo_mock, fake_auth, fake_request):
+    from fastapi import HTTPException
+
+    from core.services.admin_audit import audit_admin_action
+
+    @audit_admin_action("container.reprovision")
+    async def handler(*, user_id, request, auth):
+        raise HTTPException(status_code=409, detail="container_not_running")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler(user_id="user_target", request=fake_request, auth=fake_auth)
+
+    assert exc_info.value.status_code == 409
+    repo_mock.assert_awaited_once()
+    call_kwargs = repo_mock.await_args.kwargs
+    assert call_kwargs["result"] == "error"
+    assert call_kwargs["http_status"] == 409
+    assert "container_not_running" in (call_kwargs["error_message"] or "")
+
+
+@pytest.mark.asyncio
+async def test_audit_write_failure_returns_panic_status(fake_auth, fake_request, caplog):
+    """CEO S1: DDB write fails → response annotated audit_status='panic',
+    CRITICAL log emitted, original handler result preserved."""
+    from core.services.admin_audit import audit_admin_action
+
+    with patch(
+        "core.services.admin_audit.admin_actions_repo.create",
+        new=AsyncMock(side_effect=RuntimeError("ddb_unreachable")),
+    ):
+
+        @audit_admin_action("billing.cancel_subscription")
+        async def handler(*, user_id, request, auth):
+            return {"status": "ok", "subscription": "sub_123"}
+
+        with caplog.at_level(logging.CRITICAL):
+            response = await handler(user_id="user_target", request=fake_request, auth=fake_auth)
+
+    assert response["status"] == "ok"
+    assert response["subscription"] == "sub_123"
+    assert response["audit_status"] == "panic"
+
+    # CRITICAL log includes the action + admin + target for forensics.
+    panic_logs = [r for r in caplog.records if "ADMIN_AUDIT_PANIC" in r.message]
+    assert len(panic_logs) == 1
+    rec = panic_logs[0]
+    assert rec.levelno == logging.CRITICAL
+    assert "billing.cancel_subscription" in rec.message
+    assert "admin_alice" in rec.message
+    assert "user_target" in rec.message
+
+
+@pytest.mark.asyncio
+async def test_payload_redact_paths_strip_sensitive_keys(repo_mock, fake_auth, fake_request):
+    from core.services.admin_audit import audit_admin_action
+
+    class FakeBody:
+        def model_dump(self):
+            return {"patch": {"providers": {"anthropic_api_key": "sk-ant-xyz"}}, "note": "ok"}
+
+    @audit_admin_action("config.patch", redact_paths=["patch"])
+    async def handler(*, user_id, request, auth, body):
+        return {"status": "patched"}
+
+    await handler(user_id="user_target", request=fake_request, auth=fake_auth, body=FakeBody())
+
+    call_kwargs = repo_mock.await_args.kwargs
+    payload = call_kwargs["payload"]
+    assert payload["patch"] == "***redacted***"
+    assert payload["note"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_payload_default_when_no_body(repo_mock, fake_auth, fake_request):
+    """GET endpoints don't have a body — payload becomes empty dict, not error."""
+    from core.services.admin_audit import audit_admin_action
+
+    @audit_admin_action("user.view")
+    async def handler(*, user_id, request, auth):
+        return {"identity": "redacted"}
+
+    await handler(user_id="user_target", request=fake_request, auth=fake_auth)
+
+    call_kwargs = repo_mock.await_args.kwargs
+    assert call_kwargs["payload"] == {}
+
+
+@pytest.mark.asyncio
+async def test_target_param_default_is_user_id(repo_mock, fake_auth, fake_request):
+    from core.services.admin_audit import audit_admin_action
+
+    @audit_admin_action("container.reprovision")
+    async def handler(*, user_id, request, auth):
+        return {"ok": True}
+
+    await handler(user_id="user_target_xyz", request=fake_request, auth=fake_auth)
+
+    assert repo_mock.await_args.kwargs["target_user_id"] == "user_target_xyz"
+
+
+@pytest.mark.asyncio
+async def test_target_param_can_be_overridden(repo_mock, fake_auth, fake_request):
+    from core.services.admin_audit import audit_admin_action
+
+    @audit_admin_action("agent.delete", target_param="owner_id")
+    async def handler(*, owner_id, request, auth):
+        return {"ok": True}
+
+    await handler(owner_id="user_other", request=fake_request, auth=fake_auth)
+
+    assert repo_mock.await_args.kwargs["target_user_id"] == "user_other"
+
+
+@pytest.mark.asyncio
+async def test_ip_falls_back_to_client_host_when_no_xff(repo_mock, fake_auth):
+    from core.services.admin_audit import audit_admin_action
+
+    request = MagicMock()
+    request.headers = {"user-agent": "curl/8"}
+    request.client = MagicMock(host="192.0.2.5")
+
+    @audit_admin_action("user.view")
+    async def handler(*, user_id, request, auth):
+        return {"ok": True}
+
+    await handler(user_id="user_target", request=request, auth=fake_auth)
+
+    assert repo_mock.await_args.kwargs["ip"] == "192.0.2.5"
+    assert repo_mock.await_args.kwargs["user_agent"] == "curl/8"

--- a/apps/backend/tests/unit/services/test_admin_redact.py
+++ b/apps/backend/tests/unit/services/test_admin_redact.py
@@ -1,0 +1,115 @@
+"""Tests for openclaw.json secret-field redaction (CEO S3)."""
+
+import os
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+def test_redacts_key_suffixed_fields():
+    from core.services.admin_redact import redact_openclaw_config
+
+    config = {
+        "providers": {
+            "anthropic_api_key": "sk-ant-abc",
+            "openai_api_key": "sk-openai-def",
+            "webhook_url": "https://x",
+        },
+        "ok_value": "kept",
+    }
+    out = redact_openclaw_config(config)
+    assert out["providers"]["anthropic_api_key"] == "***redacted***"
+    assert out["providers"]["openai_api_key"] == "***redacted***"
+    assert out["providers"]["webhook_url"] == "***redacted***"
+    assert out["ok_value"] == "kept"
+
+
+def test_redacts_nested_secret_fields():
+    from core.services.admin_redact import redact_openclaw_config
+
+    config = {
+        "outer": {
+            "middle": {
+                "anthropic_secret": "shh",
+                "stripe_token": "tok_xyz",
+                "user_password": "p4ss",
+                "normal": 42,
+            },
+        },
+    }
+    out = redact_openclaw_config(config)
+    assert out["outer"]["middle"]["anthropic_secret"] == "***redacted***"
+    assert out["outer"]["middle"]["stripe_token"] == "***redacted***"
+    assert out["outer"]["middle"]["user_password"] == "***redacted***"
+    assert out["outer"]["middle"]["normal"] == 42
+
+
+def test_redacts_inside_list_elements():
+    from core.services.admin_redact import redact_openclaw_config
+
+    config = {
+        "providers_list": [
+            {"name": "openai", "api_key": "sk-x"},
+            {"name": "anthropic", "api_key": "sk-y"},
+        ],
+    }
+    out = redact_openclaw_config(config)
+    assert out["providers_list"][0]["api_key"] == "***redacted***"
+    assert out["providers_list"][1]["api_key"] == "***redacted***"
+    assert out["providers_list"][0]["name"] == "openai"
+
+
+def test_does_not_touch_non_matching_keys():
+    from core.services.admin_redact import redact_openclaw_config
+
+    config = {"name": "myagent", "model": "claude-opus-4-7", "tools": ["exec", "browser"]}
+    out = redact_openclaw_config(config)
+    assert out == config
+
+
+def test_redacts_bearer_exact_match():
+    from core.services.admin_redact import redact_openclaw_config
+
+    out = redact_openclaw_config({"bearer": "abcdef"})
+    assert out["bearer"] == "***redacted***"
+
+
+def test_does_not_redact_innocent_substrings():
+    """`_key` suffix only — `keystone` or `keyword` should NOT redact."""
+    from core.services.admin_redact import redact_openclaw_config
+
+    out = redact_openclaw_config({"keystone": "ok", "keyword": "phrase"})
+    assert out["keystone"] == "ok"
+    assert out["keyword"] == "phrase"
+
+
+def test_case_insensitive_key_matching():
+    from core.services.admin_redact import redact_openclaw_config
+
+    out = redact_openclaw_config({"ANTHROPIC_API_KEY": "secret", "Bearer": "tok"})
+    assert out["ANTHROPIC_API_KEY"] == "***redacted***"
+    assert out["Bearer"] == "***redacted***"
+
+
+def test_idempotent_on_already_redacted():
+    """Running the redactor twice is a no-op."""
+    from core.services.admin_redact import redact_openclaw_config
+
+    once = redact_openclaw_config({"anthropic_api_key": "sk-x", "name": "ok"})
+    twice = redact_openclaw_config(once)
+    assert once == twice
+
+
+def test_passes_scalars_through():
+    from core.services.admin_redact import redact_openclaw_config
+
+    assert redact_openclaw_config("hello") == "hello"
+    assert redact_openclaw_config(42) == 42
+    assert redact_openclaw_config(None) is None
+    assert redact_openclaw_config(True) is True
+
+
+def test_empty_structures():
+    from core.services.admin_redact import redact_openclaw_config
+
+    assert redact_openclaw_config({}) == {}
+    assert redact_openclaw_config([]) == []

--- a/apps/backend/tests/unit/services/test_admin_service.py
+++ b/apps/backend/tests/unit/services/test_admin_service.py
@@ -1,0 +1,384 @@
+"""Tests for admin_service composition layer (CEO C1, P1, E2, E3, S3).
+
+Read-side composition. Mutation-side composition is tested at the
+router layer in Phase C.
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+# ---- list_users ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_users_joins_clerk_with_container_status():
+    from core.services import admin_service
+
+    async def fake_clerk_list(*, query, limit, offset):
+        return {
+            "users": [
+                {"id": "user_a", "email_addresses": [{"email_address": "a@x.com"}]},
+                {"id": "user_b", "email_addresses": [{"email_address": "b@x.com"}]},
+            ],
+            "next_offset": None,
+            "stubbed": False,
+        }
+
+    async def fake_container_lookup(uid):
+        return {"user_a": {"status": "running", "plan_tier": "starter"}}.get(uid)
+
+    with (
+        patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
+        patch("core.services.admin_service.container_repo.get_by_owner_id", new=fake_container_lookup),
+    ):
+        result = await admin_service.list_users(q="", limit=10)
+
+    assert len(result["users"]) == 2
+    a = next(r for r in result["users"] if r["clerk_id"] == "user_a")
+    b = next(r for r in result["users"] if r["clerk_id"] == "user_b")
+    assert a["email"] == "a@x.com"
+    assert a["container_status"] == "running"
+    assert a["plan_tier"] == "starter"
+    assert b["container_status"] == "none"  # no container → "none" sentinel
+    assert b["plan_tier"] == "free"
+
+
+@pytest.mark.asyncio
+async def test_list_users_passes_through_stubbed_flag():
+    from core.services import admin_service
+
+    async def fake_clerk_list(*, query, limit, offset):
+        return {"users": [], "next_offset": None, "stubbed": True}
+
+    with patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list):
+        result = await admin_service.list_users()
+
+    assert result["stubbed"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_users_paginates_via_cursor():
+    from core.services import admin_service
+
+    captured_offset = {}
+
+    async def fake_clerk_list(*, query, limit, offset):
+        captured_offset["v"] = offset
+        return {"users": [], "next_offset": None, "stubbed": False}
+
+    with patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list):
+        await admin_service.list_users(cursor="50", limit=25)
+
+    assert captured_offset["v"] == 50
+
+
+# ---- get_overview ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_overview_runs_sources_in_parallel():
+    from core.services import admin_service
+
+    with (
+        patch("core.services.admin_service.clerk_admin.get_user", new=AsyncMock(return_value={"id": "u1"})),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch(
+            "core.services.admin_service.billing_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"plan_tier": "starter"}),
+        ),
+        patch(
+            "core.services.admin_service.usage_repo.get_period_usage",
+            new=AsyncMock(return_value={"tokens": 1000}),
+        ),
+    ):
+        result = await admin_service.get_overview("u1")
+
+    assert result["identity"]["id"] == "u1"
+    assert result["container"]["status"] == "running"
+    assert result["billing"]["plan_tier"] == "starter"
+    assert result["usage"]["tokens"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_get_overview_isolates_slow_upstream_via_timeout(monkeypatch):
+    """CEO P1: a stuck upstream returns {error: timeout}, others succeed."""
+    monkeypatch.setattr("core.services.admin_service._PARALLEL_TIMEOUT_S", 0.05)
+
+    from core.services import admin_service
+
+    async def slow_stripe(uid):
+        await asyncio.sleep(1.0)
+        return {"plan_tier": "should_not_be_seen"}
+
+    with (
+        patch("core.services.admin_service.clerk_admin.get_user", new=AsyncMock(return_value={"id": "u1"})),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.billing_repo.get_by_owner_id", new=slow_stripe),
+        patch(
+            "core.services.admin_service.usage_repo.get_period_usage",
+            new=AsyncMock(return_value={"tokens": 1000}),
+        ),
+    ):
+        result = await admin_service.get_overview("u1")
+
+    assert result["identity"]["id"] == "u1"
+    assert result["container"]["status"] == "running"
+    assert result["billing"]["error"] == "timeout"
+    assert result["usage"]["tokens"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_get_overview_errors_dont_starve_other_sources():
+    from core.services import admin_service
+
+    async def failing_billing(uid):
+        raise RuntimeError("ddb_blip")
+
+    with (
+        patch("core.services.admin_service.clerk_admin.get_user", new=AsyncMock(return_value={"id": "u1"})),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.billing_repo.get_by_owner_id", new=failing_billing),
+        patch(
+            "core.services.admin_service.usage_repo.get_period_usage",
+            new=AsyncMock(return_value={"tokens": 1000}),
+        ),
+    ):
+        result = await admin_service.get_overview("u1")
+
+    assert result["billing"]["error"] == "ddb_blip"
+    assert result["container"]["status"] == "running"
+
+
+# ---- list_user_agents -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_user_agents_returns_stopped_when_container_not_running():
+    """CEO E3: container_status surfaces, agents=[]."""
+    from core.services import admin_service
+
+    with patch(
+        "core.services.admin_service.container_repo.get_by_owner_id",
+        new=AsyncMock(return_value={"status": "stopped"}),
+    ):
+        result = await admin_service.list_user_agents("u1")
+
+    assert result["agents"] == []
+    assert result["container_status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_list_user_agents_returns_none_when_no_container():
+    from core.services import admin_service
+
+    with patch(
+        "core.services.admin_service.container_repo.get_by_owner_id",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await admin_service.list_user_agents("u1")
+
+    assert result["container_status"] == "none"
+
+
+def _fake_pool(send_rpc_callable):
+    """Build a fake gateway pool whose send_rpc is the given AsyncMock-like
+    callable. Uses MagicMock instead of `type(...)` so the function isn't
+    bound as a method and self isn't auto-injected."""
+    from unittest.mock import MagicMock
+
+    pool = MagicMock()
+    pool.send_rpc = send_rpc_callable
+    return pool
+
+
+def _fake_ecs(container_token="t", ip="10.0.0.1"):
+    from unittest.mock import MagicMock
+
+    ecs = MagicMock()
+    ecs.resolve_running_container = AsyncMock(return_value=({"gateway_token": container_token}, ip))
+    return ecs
+
+
+@pytest.mark.asyncio
+async def test_list_user_agents_handles_gateway_timeout(monkeypatch):
+    """CEO E2: gateway RPC > timeout → render container_status=timeout, no hang."""
+    monkeypatch.setattr("core.services.admin_service._GATEWAY_RPC_TIMEOUT_S", 0.05)
+
+    from core.services import admin_service
+
+    async def slow_rpc(**kwargs):
+        await asyncio.sleep(1.0)
+        return {"agents": []}
+
+    pool = _fake_pool(slow_rpc)
+    ecs = _fake_ecs()
+
+    with (
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=pool),
+    ):
+        result = await admin_service.list_user_agents("u1")
+
+    assert result["container_status"] == "timeout"
+    assert result["error"] == "gateway_rpc_timeout"
+
+
+@pytest.mark.asyncio
+async def test_list_user_agents_returns_agents_on_running_container():
+    from core.services import admin_service
+
+    pool = _fake_pool(AsyncMock(return_value={"agents": [{"agent_id": "a", "name": "Agent A"}], "cursor": None}))
+    ecs = _fake_ecs()
+
+    with (
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=pool),
+    ):
+        result = await admin_service.list_user_agents("u1")
+
+    assert result["container_status"] == "running"
+    assert len(result["agents"]) == 1
+    assert result["agents"][0]["agent_id"] == "a"
+
+
+# ---- get_agent_detail -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_agent_detail_redacts_config_secrets():
+    """CEO S3: openclaw.json secrets stripped before return."""
+    from core.services import admin_service
+
+    rpc_results = {
+        "agents.get": {"agent_id": "a", "name": "Agent A"},
+        "sessions.list": {"sessions": [{"id": "s1"}]},
+        "skills.list": {"skills": [{"id": "x"}]},
+        "config.get": {"providers": {"anthropic_api_key": "sk-secret-shh"}},
+    }
+
+    async def fake_rpc(**kwargs):
+        return rpc_results[kwargs["method"]]
+
+    pool = _fake_pool(fake_rpc)
+    ecs = _fake_ecs()
+
+    with (
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=pool),
+    ):
+        result = await admin_service.get_agent_detail("u1", "a")
+
+    assert result["agent"]["agent_id"] == "a"
+    assert result["sessions"][0]["id"] == "s1"
+    assert result["config_redacted"]["providers"]["anthropic_api_key"] == "***redacted***"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_detail_returns_error_when_container_not_running():
+    from core.services import admin_service
+
+    with patch(
+        "core.services.admin_service.container_repo.get_by_owner_id",
+        new=AsyncMock(return_value={"status": "stopped"}),
+    ):
+        result = await admin_service.get_agent_detail("u1", "a")
+
+    assert result["error"] == "container_not_running"
+    assert result["container_status"] == "stopped"
+
+
+# ---- pass-through delegations ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_logs_delegates_to_cloudwatch_logs():
+    from core.services import admin_service
+
+    fake = AsyncMock(return_value={"events": [{"x": 1}], "cursor": None, "missing": False})
+    with patch("core.services.admin_service.cloudwatch_logs.filter_user_logs", new=fake):
+        result = await admin_service.get_logs("u1", level="ERROR", hours=12, limit=5)
+
+    assert result["events"][0]["x"] == 1
+    fake.assert_awaited_once_with(user_id="u1", level="ERROR", hours=12, limit=5, cursor=None)
+
+
+def test_get_cloudwatch_url_delegates():
+    from core.services import admin_service
+
+    with patch(
+        "core.services.admin_service.cloudwatch_url.build_insights_url",
+        return_value="https://example.aws/url",
+    ):
+        url = admin_service.get_cloudwatch_url("u1", start="x", end="y", level="WARN")
+
+    assert url == "https://example.aws/url"
+
+
+@pytest.mark.asyncio
+async def test_get_posthog_timeline_delegates():
+    from core.services import admin_service
+
+    fake = AsyncMock(return_value={"events": [], "stubbed": False, "missing": False, "error": None})
+    with patch("core.services.admin_service.posthog_admin.get_person_events", new=fake):
+        result = await admin_service.get_posthog_timeline("u1", limit=20)
+
+    fake.assert_awaited_once_with(distinct_id="u1", limit=20)
+    assert result["stubbed"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_actions_audit_routes_to_target_query():
+    from core.services import admin_service
+
+    fake = AsyncMock(return_value={"items": [{"action": "x"}], "cursor": None})
+    with patch("core.services.admin_service.admin_actions_repo.query_by_target", new=fake):
+        result = await admin_service.get_actions_audit(target_user_id="t1", limit=10)
+
+    fake.assert_awaited_once_with("t1", limit=10, cursor=None)
+    assert result["items"][0]["action"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_get_actions_audit_routes_to_admin_query():
+    from core.services import admin_service
+
+    fake = AsyncMock(return_value={"items": [], "cursor": None})
+    with patch("core.services.admin_service.admin_actions_repo.query_by_admin", new=fake):
+        await admin_service.get_actions_audit(admin_user_id="a1")
+
+    fake.assert_awaited_once_with("a1", limit=50, cursor=None)
+
+
+@pytest.mark.asyncio
+async def test_get_actions_audit_requires_either_target_or_admin():
+    from core.services import admin_service
+
+    with pytest.raises(ValueError):
+        await admin_service.get_actions_audit()

--- a/apps/backend/tests/unit/services/test_clerk_admin.py
+++ b/apps/backend/tests/unit/services/test_clerk_admin.py
@@ -1,0 +1,152 @@
+"""Tests for clerk_admin (Phase B v1 read-side surface).
+
+Same direct-httpx-mock approach as test_posthog_admin.py — respx 0.20.2
++ newer httpx have a route-matching incompat.
+"""
+
+import os
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+def _make_response(status_code: int, json_body=None):
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json = MagicMock(return_value=json_body if json_body is not None else [])
+    return response
+
+
+@asynccontextmanager
+async def _fake_client(response_or_exc):
+    client = MagicMock()
+    if isinstance(response_or_exc, BaseException):
+        client.get = AsyncMock(side_effect=response_or_exc)
+    else:
+        client.get = AsyncMock(return_value=response_or_exc)
+    yield client
+
+
+@pytest.mark.asyncio
+async def test_list_users_stubs_when_no_secret_key(monkeypatch):
+    monkeypatch.setattr("core.config.settings.CLERK_SECRET_KEY", None)
+    from core.services.clerk_admin import list_users
+
+    result = await list_users(query="x", limit=10, offset=0)
+    assert result["stubbed"] is True
+    assert result["users"] == []
+    assert result["next_offset"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_users_happy_path(monkeypatch):
+    monkeypatch.setattr("core.config.settings.CLERK_SECRET_KEY", "sk_test_xyz")
+
+    body = [{"id": "user_a"}, {"id": "user_b"}]
+    response = _make_response(200, json_body=body)
+
+    with patch(
+        "core.services.clerk_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(response),
+    ):
+        from core.services.clerk_admin import list_users
+
+        result = await list_users(query="", limit=2, offset=0)
+
+    assert len(result["users"]) == 2
+    assert result["users"][0]["id"] == "user_a"
+    assert result["next_offset"] == 2  # got `limit` results → there may be more
+    assert result["stubbed"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_users_no_more_pages_when_under_limit(monkeypatch):
+    monkeypatch.setattr("core.config.settings.CLERK_SECRET_KEY", "sk_test_xyz")
+
+    response = _make_response(200, json_body=[{"id": "user_a"}])
+    with patch(
+        "core.services.clerk_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(response),
+    ):
+        from core.services.clerk_admin import list_users
+
+        result = await list_users(limit=10)
+
+    assert result["next_offset"] is None  # < limit → end of list
+
+
+@pytest.mark.asyncio
+async def test_list_users_timeout_returns_error(monkeypatch):
+    monkeypatch.setattr("core.config.settings.CLERK_SECRET_KEY", "sk_test_xyz")
+
+    with patch(
+        "core.services.clerk_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(httpx.TimeoutException("slow")),
+    ):
+        from core.services.clerk_admin import list_users
+
+        result = await list_users()
+
+    assert result["error"] == "timeout"
+    assert result["users"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_users_5xx_returns_error(monkeypatch):
+    monkeypatch.setattr("core.config.settings.CLERK_SECRET_KEY", "sk_test_xyz")
+
+    response = _make_response(503, json_body={})
+    with patch(
+        "core.services.clerk_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(response),
+    ):
+        from core.services.clerk_admin import list_users
+
+        result = await list_users()
+
+    assert result["error"] == "http_503"
+
+
+@pytest.mark.asyncio
+async def test_get_user_returns_none_on_404(monkeypatch):
+    monkeypatch.setattr("core.config.settings.CLERK_SECRET_KEY", "sk_test_xyz")
+
+    response = _make_response(404, json_body={})
+    with patch(
+        "core.services.clerk_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(response),
+    ):
+        from core.services.clerk_admin import get_user
+
+        result = await get_user("user_missing")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_user_returns_none_when_no_secret_key(monkeypatch):
+    monkeypatch.setattr("core.config.settings.CLERK_SECRET_KEY", None)
+    from core.services.clerk_admin import get_user
+
+    assert await get_user("any") is None
+
+
+@pytest.mark.asyncio
+async def test_get_user_returns_payload_on_200(monkeypatch):
+    monkeypatch.setattr("core.config.settings.CLERK_SECRET_KEY", "sk_test_xyz")
+
+    response = _make_response(200, json_body={"id": "user_a", "first_name": "Alice"})
+    with patch(
+        "core.services.clerk_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(response),
+    ):
+        from core.services.clerk_admin import get_user
+
+        result = await get_user("user_a")
+
+    assert result["id"] == "user_a"
+    assert result["first_name"] == "Alice"

--- a/apps/backend/tests/unit/services/test_cloudwatch_logs.py
+++ b/apps/backend/tests/unit/services/test_cloudwatch_logs.py
@@ -1,0 +1,178 @@
+"""Tests for the cloudwatch_logs admin-side wrapper.
+
+Covers:
+- Per-user filter with structured-log JSON parse.
+- nextToken → cursor pagination (CEO E4).
+- ResourceNotFoundException → missing=true (LocalStack / fresh env).
+- Malformed JSON line falls through (raw_json=None, message preserved).
+- Fleet-scoped recent_errors_fleet returns list[dict].
+- Log group ARN matches the actual /ecs/isol8-{env} (not the wrong
+  /aws/ecs/isol8-{env}-backend that Phase A originally had).
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+os.environ.setdefault("ENVIRONMENT", "dev")
+
+
+@pytest.fixture
+def boto_logs_mock():
+    """Patch the boto3 logs client used by cloudwatch_logs."""
+    client = MagicMock()
+    # ResourceNotFoundException needs to be a real exception class for `except`
+    # to match it; mimic boto3's exceptions namespace.
+    client.exceptions = MagicMock()
+    client.exceptions.ResourceNotFoundException = type("ResourceNotFoundException", (Exception,), {})
+    with patch("core.services.cloudwatch_logs._client", new=client):
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_filter_user_logs_parses_structured_json(boto_logs_mock):
+    from core.services.cloudwatch_logs import filter_user_logs
+
+    boto_logs_mock.filter_log_events.return_value = {
+        "events": [
+            {
+                "timestamp": 1700000000000,
+                "message": '{"user_id":"u1","level":"ERROR","message":"boom","correlation_id":"abc"}',
+            },
+        ],
+    }
+
+    result = await filter_user_logs(user_id="u1", level="ERROR", hours=24, limit=20)
+
+    assert result["missing"] is False
+    assert len(result["events"]) == 1
+    e = result["events"][0]
+    assert e["level"] == "ERROR"
+    assert e["message"] == "boom"
+    assert e["correlation_id"] == "abc"
+    assert e["raw_json"] == {
+        "user_id": "u1",
+        "level": "ERROR",
+        "message": "boom",
+        "correlation_id": "abc",
+    }
+
+
+@pytest.mark.asyncio
+async def test_filter_user_logs_pagination_cursor(boto_logs_mock):
+    from core.services.cloudwatch_logs import filter_user_logs
+
+    boto_logs_mock.filter_log_events.return_value = {
+        "events": [],
+        "nextToken": "next-page-token",
+    }
+
+    result = await filter_user_logs(user_id="u1", level="ERROR", hours=24, limit=20)
+    assert result["cursor"] == "next-page-token"
+
+
+@pytest.mark.asyncio
+async def test_filter_user_logs_threads_cursor_into_request(boto_logs_mock):
+    from core.services.cloudwatch_logs import filter_user_logs
+
+    boto_logs_mock.filter_log_events.return_value = {"events": []}
+
+    await filter_user_logs(user_id="u1", level="ERROR", hours=24, limit=20, cursor="page-2")
+
+    kwargs = boto_logs_mock.filter_log_events.call_args.kwargs
+    assert kwargs["nextToken"] == "page-2"
+
+
+@pytest.mark.asyncio
+async def test_filter_user_logs_uses_correct_log_group(boto_logs_mock):
+    """Phase A fix: log group is /ecs/isol8-{env}, NOT /aws/ecs/isol8-{env}-backend."""
+    from core.services.cloudwatch_logs import filter_user_logs
+
+    boto_logs_mock.filter_log_events.return_value = {"events": []}
+
+    await filter_user_logs(user_id="u1", level="ERROR", hours=24, limit=20)
+
+    kwargs = boto_logs_mock.filter_log_events.call_args.kwargs
+    assert kwargs["logGroupName"] == "/ecs/isol8-dev"
+
+
+@pytest.mark.asyncio
+async def test_filter_user_logs_filter_pattern_includes_user_and_level(boto_logs_mock):
+    from core.services.cloudwatch_logs import filter_user_logs
+
+    boto_logs_mock.filter_log_events.return_value = {"events": []}
+
+    await filter_user_logs(user_id="user_xyz", level="ERROR", hours=24, limit=20)
+
+    kwargs = boto_logs_mock.filter_log_events.call_args.kwargs
+    pattern = kwargs["filterPattern"]
+    assert "user_xyz" in pattern
+    assert "ERROR" in pattern
+
+
+@pytest.mark.asyncio
+async def test_filter_user_logs_handles_malformed_json(boto_logs_mock):
+    from core.services.cloudwatch_logs import filter_user_logs
+
+    boto_logs_mock.filter_log_events.return_value = {
+        "events": [{"timestamp": 1700000000000, "message": "not json at all"}],
+    }
+
+    result = await filter_user_logs(user_id="u1", level="ERROR", hours=24, limit=20)
+    assert result["events"][0]["raw_json"] is None
+    assert result["events"][0]["message"] == "not json at all"
+    assert result["events"][0]["level"] is None
+
+
+@pytest.mark.asyncio
+async def test_filter_user_logs_returns_missing_on_log_group_not_found(boto_logs_mock):
+    from core.services.cloudwatch_logs import filter_user_logs
+
+    boto_logs_mock.filter_log_events.side_effect = boto_logs_mock.exceptions.ResourceNotFoundException()
+
+    result = await filter_user_logs(user_id="u1", level="ERROR", hours=24, limit=20)
+    assert result["events"] == []
+    assert result["cursor"] is None
+    assert result["missing"] is True
+
+
+@pytest.mark.asyncio
+async def test_filter_user_logs_swallows_other_errors_and_returns_empty(boto_logs_mock):
+    """Non-NotFound errors shouldn't crash the admin page — degrade gracefully."""
+    from core.services.cloudwatch_logs import filter_user_logs
+
+    boto_logs_mock.filter_log_events.side_effect = RuntimeError("transient_aws_blip")
+
+    result = await filter_user_logs(user_id="u1", level="ERROR", hours=24, limit=20)
+    assert result["events"] == []
+    assert result["missing"] is False
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_recent_errors_fleet_returns_list(boto_logs_mock):
+    from core.services.cloudwatch_logs import recent_errors_fleet
+
+    boto_logs_mock.filter_log_events.return_value = {
+        "events": [
+            {"timestamp": 1700000000000, "message": '{"user_id":"u1","level":"ERROR","message":"boom"}'},
+            {"timestamp": 1700000001000, "message": '{"user_id":"u2","level":"ERROR","message":"crash"}'},
+        ],
+    }
+
+    result = await recent_errors_fleet(hours=24, limit=10)
+    assert len(result) == 2
+    assert result[0]["user_id"] == "u1"
+    assert result[1]["user_id"] == "u2"
+
+
+@pytest.mark.asyncio
+async def test_recent_errors_fleet_log_group_not_found_returns_empty(boto_logs_mock):
+    from core.services.cloudwatch_logs import recent_errors_fleet
+
+    boto_logs_mock.filter_log_events.side_effect = boto_logs_mock.exceptions.ResourceNotFoundException()
+
+    result = await recent_errors_fleet(hours=24, limit=10)
+    assert result == []

--- a/apps/backend/tests/unit/services/test_cloudwatch_url.py
+++ b/apps/backend/tests/unit/services/test_cloudwatch_url.py
@@ -1,0 +1,93 @@
+"""Tests for the CloudWatch Insights deep-link builder.
+
+Pure URL assembly — no SDK calls. Just verify the URL contains
+the user_id, level, log group, and time range so the AWS Console
+opens with the right query.
+"""
+
+import os
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+os.environ.setdefault("ENVIRONMENT", "dev")
+os.environ.setdefault("AWS_REGION", "us-east-1")
+
+
+def test_url_targets_us_east_1_console():
+    from core.services.cloudwatch_url import build_insights_url
+
+    url = build_insights_url(
+        user_id="user_test",
+        start="2026-04-20T00:00:00Z",
+        end="2026-04-21T00:00:00Z",
+        level="ERROR",
+    )
+
+    assert url.startswith("https://us-east-1.console.aws.amazon.com/cloudwatch/home")
+    assert "region=us-east-1" in url
+
+
+def test_url_includes_user_id_in_query():
+    from core.services.cloudwatch_url import build_insights_url
+
+    url = build_insights_url(
+        user_id="user_xyz_abc",
+        start="2026-04-20T00:00:00Z",
+        end="2026-04-21T00:00:00Z",
+        level="ERROR",
+    )
+    assert "user_xyz_abc" in url
+
+
+def test_url_includes_level_filter():
+    from core.services.cloudwatch_url import build_insights_url
+
+    url = build_insights_url(
+        user_id="u1",
+        start="2026-04-20T00:00:00Z",
+        end="2026-04-21T00:00:00Z",
+        level="WARN",
+    )
+    assert "WARN" in url
+
+
+def test_url_points_at_correct_log_group():
+    """Same Phase A fix — log group is /ecs/isol8-{env}."""
+    from core.services.cloudwatch_url import build_insights_url
+
+    url = build_insights_url(
+        user_id="u1",
+        start="2026-04-20T00:00:00Z",
+        end="2026-04-21T00:00:00Z",
+        level="ERROR",
+    )
+    # URL-encoded /ecs/isol8-dev → %2Fecs%2Fisol8-dev
+    assert "%2Fecs%2Fisol8-dev" in url
+
+
+def test_url_uses_logs_insights_path():
+    from core.services.cloudwatch_url import build_insights_url
+
+    url = build_insights_url(
+        user_id="u1",
+        start="2026-04-20T00:00:00Z",
+        end="2026-04-21T00:00:00Z",
+        level="ERROR",
+    )
+    assert "#logsV2:logs-insights" in url
+
+
+def test_default_level_is_error():
+    from core.services.cloudwatch_url import build_insights_url
+
+    url_default = build_insights_url(
+        user_id="u1",
+        start="2026-04-20T00:00:00Z",
+        end="2026-04-21T00:00:00Z",
+    )
+    url_explicit = build_insights_url(
+        user_id="u1",
+        start="2026-04-20T00:00:00Z",
+        end="2026-04-21T00:00:00Z",
+        level="ERROR",
+    )
+    assert url_default == url_explicit

--- a/apps/backend/tests/unit/services/test_posthog_admin.py
+++ b/apps/backend/tests/unit/services/test_posthog_admin.py
@@ -1,0 +1,210 @@
+"""Tests for the PostHog Persons API admin client.
+
+Covers:
+- Stubbed mode when POSTHOG_PROJECT_API_KEY unset (CEO local-dev requirement).
+- Happy path: persons → events flattened, $session_id surfaced.
+- 404 → missing=True (CEO E5).
+- 5xx / timeout → graceful error response.
+- Auth header sent (Bearer).
+- session_replay_url helper.
+
+Mocks httpx.AsyncClient directly via unittest.mock — respx 0.20.2 has
+a compat issue with newer httpx where even identical URL strings don't
+match, so we patch the client surface instead.
+"""
+
+import os
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+def _make_response(status_code: int, json_body: dict | None = None, text_body: str = "") -> MagicMock:
+    """Build a mock httpx.Response."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json = MagicMock(return_value=json_body or {})
+    response.text = text_body
+    return response
+
+
+@asynccontextmanager
+async def _fake_client(response_or_exc):
+    """Async context manager that yields a fake AsyncClient.
+
+    response_or_exc: either a Response (returned by .get) or an Exception
+    (raised by .get).
+    """
+    client = MagicMock()
+    if isinstance(response_or_exc, BaseException):
+        client.get = AsyncMock(side_effect=response_or_exc)
+    else:
+        client.get = AsyncMock(return_value=response_or_exc)
+    yield client
+
+
+@pytest.mark.asyncio
+async def test_stubs_when_api_key_unset(monkeypatch):
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_API_KEY", "")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_ID", "12345")
+
+    from core.services.posthog_admin import get_person_events
+
+    result = await get_person_events(distinct_id="user_test", limit=10)
+    assert result["stubbed"] is True
+    assert result["events"] == []
+    assert result["missing"] is False
+
+
+@pytest.mark.asyncio
+async def test_stubs_when_project_id_unset(monkeypatch):
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_API_KEY", "phc_xyz")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_ID", "")
+
+    from core.services.posthog_admin import get_person_events
+
+    result = await get_person_events(distinct_id="user_test")
+    assert result["stubbed"] is True
+
+
+@pytest.mark.asyncio
+async def test_happy_path_flattens_persons_to_events(monkeypatch):
+    monkeypatch.setattr("core.config.settings.POSTHOG_HOST", "https://app.posthog.com")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_ID", "12345")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_API_KEY", "phc_xyz")
+
+    body = {
+        "results": [
+            {
+                "events": [
+                    {
+                        "timestamp": "2026-04-21T10:00:00Z",
+                        "event": "$pageview",
+                        "properties": {"$current_url": "/chat", "$session_id": "sess_a"},
+                    },
+                    {
+                        "timestamp": "2026-04-21T10:01:00Z",
+                        "event": "agent_chat_started",
+                        "properties": {"agent_id": "agent_x", "$session_id": "sess_a"},
+                    },
+                ],
+            },
+        ],
+    }
+    response = _make_response(200, json_body=body)
+
+    with patch(
+        "core.services.posthog_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(response),
+    ):
+        from core.services.posthog_admin import get_person_events
+
+        result = await get_person_events(distinct_id="user_test", limit=20)
+
+    assert result["stubbed"] is False
+    assert result["missing"] is False
+    assert result["error"] is None
+    assert len(result["events"]) == 2
+    e0 = result["events"][0]
+    assert e0["event"] == "$pageview"
+    assert e0["session_id"] == "sess_a"
+    assert e0["properties"]["$current_url"] == "/chat"
+
+
+@pytest.mark.asyncio
+async def test_404_returns_missing(monkeypatch):
+    monkeypatch.setattr("core.config.settings.POSTHOG_HOST", "https://app.posthog.com")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_ID", "12345")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_API_KEY", "phc_xyz")
+
+    response = _make_response(404, json_body={})
+    with patch(
+        "core.services.posthog_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(response),
+    ):
+        from core.services.posthog_admin import get_person_events
+
+        result = await get_person_events(distinct_id="user_missing")
+
+    assert result["missing"] is True
+    assert result["events"] == []
+    assert result["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_5xx_returns_error(monkeypatch):
+    monkeypatch.setattr("core.config.settings.POSTHOG_HOST", "https://app.posthog.com")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_ID", "12345")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_API_KEY", "phc_xyz")
+
+    response = _make_response(503, text_body="upstream down")
+    with patch(
+        "core.services.posthog_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(response),
+    ):
+        from core.services.posthog_admin import get_person_events
+
+        result = await get_person_events(distinct_id="user_test")
+
+    assert result["error"] == "http_503"
+    assert result["events"] == []
+    assert result["missing"] is False
+
+
+@pytest.mark.asyncio
+async def test_timeout_returns_error(monkeypatch):
+    monkeypatch.setattr("core.config.settings.POSTHOG_HOST", "https://app.posthog.com")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_ID", "12345")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_API_KEY", "phc_xyz")
+
+    with patch(
+        "core.services.posthog_admin.httpx.AsyncClient",
+        new=lambda *a, **k: _fake_client(httpx.TimeoutException("slow")),
+    ):
+        from core.services.posthog_admin import get_person_events
+
+        result = await get_person_events(distinct_id="user_test")
+
+    assert result["error"] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_authorization_header_includes_bearer_token(monkeypatch):
+    monkeypatch.setattr("core.config.settings.POSTHOG_HOST", "https://app.posthog.com")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_ID", "12345")
+    monkeypatch.setattr("core.config.settings.POSTHOG_PROJECT_API_KEY", "phc_secret_value")
+
+    captured_kwargs = {}
+    response = _make_response(200, json_body={"results": []})
+
+    @asynccontextmanager
+    async def capturing_client(*args, **kwargs):
+        client = MagicMock()
+
+        async def get(url, headers=None, params=None, **kw):
+            captured_kwargs["url"] = url
+            captured_kwargs["headers"] = headers
+            captured_kwargs["params"] = params
+            return response
+
+        client.get = get
+        yield client
+
+    with patch("core.services.posthog_admin.httpx.AsyncClient", new=capturing_client):
+        from core.services.posthog_admin import get_person_events
+
+        await get_person_events(distinct_id="user_test")
+
+    assert captured_kwargs["headers"]["Authorization"] == "Bearer phc_secret_value"
+    assert captured_kwargs["params"]["distinct_id"] == "user_test"
+
+
+def test_session_replay_url(monkeypatch):
+    monkeypatch.setattr("core.config.settings.POSTHOG_HOST", "https://app.posthog.com")
+    from core.services.posthog_admin import session_replay_url
+
+    assert session_replay_url("sess_abc") == "https://app.posthog.com/replay/sess_abc"

--- a/apps/backend/tests/unit/services/test_system_health.py
+++ b/apps/backend/tests/unit/services/test_system_health.py
@@ -1,0 +1,251 @@
+"""Tests for the /admin/health aggregator.
+
+Covers:
+- Fleet counts grouped by container status.
+- Probe cache (30s TTL — second call returns cached value, no upstream hit).
+- Probe timeout / error → {status: "down"} (CEO P2).
+- Background-task state mapping (running / stopped / cancelled / unregistered).
+- get_system_health composes all sources without raising even when probes
+  fail or the recent_errors call fails.
+"""
+
+import asyncio
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+os.environ.setdefault("ENVIRONMENT", "dev")
+
+
+@pytest.fixture(autouse=True)
+def reset_probe_cache():
+    """Each test gets a fresh probe cache."""
+    from core.services import system_health
+
+    system_health._probe_cache["ts"] = 0.0
+    system_health._probe_cache["value"] = None
+    yield
+
+
+@pytest.fixture(autouse=True)
+def reset_background_tasks():
+    from core.services import system_health
+
+    system_health.BACKGROUND_TASKS.clear()
+    yield
+    system_health.BACKGROUND_TASKS.clear()
+
+
+@pytest.mark.asyncio
+async def test_fleet_counts_groups_by_status():
+    from core.services import system_health
+
+    async def fake_get_by_status(status: str):
+        return {
+            "running": [{}, {}, {}],
+            "provisioning": [{}],
+            "stopped": [{}, {}],
+            "error": [],
+        }.get(status, [])
+
+    with patch("core.services.system_health.container_repo.get_by_status", new=fake_get_by_status):
+        counts = await system_health._fleet_counts()
+
+    assert counts == {"running": 3, "provisioning": 1, "stopped": 2, "error": 0, "total": 6}
+
+
+@pytest.mark.asyncio
+async def test_fleet_counts_handles_repo_error_per_status():
+    """One status query failing doesn't break the whole panel — that status counts as 0."""
+    from core.services import system_health
+
+    async def fake_get_by_status(status: str):
+        if status == "stopped":
+            raise RuntimeError("ddb_blip")
+        return [{}, {}]
+
+    with patch("core.services.system_health.container_repo.get_by_status", new=fake_get_by_status):
+        counts = await system_health._fleet_counts()
+
+    assert counts["stopped"] == 0
+    assert counts["running"] == 2
+    assert counts["total"] == 6  # 3 statuses × 2 = 6, the failed status contributes 0
+
+
+@pytest.mark.asyncio
+async def test_probe_cache_returns_cached_value_within_ttl():
+    from core.services import system_health
+
+    call_count = {"clerk": 0, "stripe": 0, "ddb": 0}
+
+    async def fake_clerk():
+        call_count["clerk"] += 1
+        return {"status": "ok", "latency_ms": 10}
+
+    async def fake_stripe():
+        call_count["stripe"] += 1
+        return {"status": "ok", "latency_ms": 20}
+
+    async def fake_ddb():
+        call_count["ddb"] += 1
+        return {"status": "ok", "latency_ms": 30}
+
+    with (
+        patch("core.services.system_health._probe_clerk", new=fake_clerk),
+        patch("core.services.system_health._probe_stripe", new=fake_stripe),
+        patch("core.services.system_health._probe_ddb", new=fake_ddb),
+    ):
+        first = await system_health._all_probes()
+        second = await system_health._all_probes()
+
+    assert first == second
+    # Each probe called exactly once across two _all_probes() calls.
+    assert call_count == {"clerk": 1, "stripe": 1, "ddb": 1}
+
+
+@pytest.mark.asyncio
+async def test_probe_cache_expires_past_ttl():
+    from core.services import system_health
+
+    call_count = {"n": 0}
+
+    async def fake_clerk():
+        call_count["n"] += 1
+        return {"status": "ok"}
+
+    async def fake_other():
+        return {"status": "ok"}
+
+    with (
+        patch("core.services.system_health._probe_clerk", new=fake_clerk),
+        patch("core.services.system_health._probe_stripe", new=fake_other),
+        patch("core.services.system_health._probe_ddb", new=fake_other),
+    ):
+        await system_health._all_probes()
+        # Force the cache to look stale.
+        system_health._probe_cache["ts"] = time.monotonic() - (system_health._PROBE_CACHE_TTL_S + 1)
+        await system_health._all_probes()
+
+    assert call_count["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_all_probes_handles_probe_exception_gracefully():
+    from core.services import system_health
+
+    async def good():
+        return {"status": "ok"}
+
+    async def bad():
+        raise RuntimeError("upstream_blip")
+
+    with (
+        patch("core.services.system_health._probe_clerk", new=good),
+        patch("core.services.system_health._probe_stripe", new=bad),
+        patch("core.services.system_health._probe_ddb", new=good),
+    ):
+        result = await system_health._all_probes()
+
+    assert result["clerk"]["status"] == "ok"
+    assert result["stripe"]["status"] == "down"
+    assert "upstream_blip" in result["stripe"]["error"]
+    assert result["ddb"]["status"] == "ok"
+
+
+def test_background_tasks_status_running_and_stopped():
+    from core.services import system_health
+
+    async def long_running():
+        await asyncio.sleep(60)
+
+    loop = asyncio.new_event_loop()
+    try:
+        running_task = loop.create_task(long_running())
+
+        async def quick():
+            return None
+
+        stopped_task = loop.create_task(quick())
+        loop.run_until_complete(asyncio.sleep(0))  # let stopped_task complete
+
+        system_health.BACKGROUND_TASKS["idle_checker"] = running_task
+        system_health.BACKGROUND_TASKS["scheduled_worker"] = stopped_task
+
+        status = system_health._background_tasks_status()
+        assert status["idle_checker"]["status"] == "running"
+        assert status["scheduled_worker"]["status"] == "stopped"
+    finally:
+        running_task.cancel()
+        loop.close()
+
+
+def test_background_tasks_status_unregistered_when_none():
+    from core.services import system_health
+
+    system_health.BACKGROUND_TASKS["never_registered"] = None  # type: ignore[assignment]
+    status = system_health._background_tasks_status()
+    assert status["never_registered"]["status"] == "unregistered"
+
+
+@pytest.mark.asyncio
+async def test_get_system_health_composes_all_sources():
+    from core.services import system_health
+
+    async def fake_probes():
+        return {"clerk": {"status": "ok"}, "stripe": {"status": "ok"}, "ddb": {"status": "ok"}}
+
+    async def fake_fleet():
+        return {"running": 5, "provisioning": 0, "stopped": 1, "error": 0, "total": 6}
+
+    async def fake_recent_errors(*, hours, limit):
+        return [{"timestamp": "2026-04-21", "user_id": "u1", "message": "boom"}]
+
+    with (
+        patch("core.services.system_health._all_probes", new=fake_probes),
+        patch("core.services.system_health._fleet_counts", new=fake_fleet),
+        patch("core.services.system_health.cloudwatch_logs.recent_errors_fleet", new=fake_recent_errors),
+    ):
+        result = await system_health.get_system_health()
+
+    assert result["upstreams"]["clerk"]["status"] == "ok"
+    assert result["fleet"]["total"] == 6
+    assert isinstance(result["background_tasks"], dict)
+    assert len(result["recent_errors"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_system_health_never_raises_even_when_components_fail():
+    from core.services import system_health
+
+    async def fake_probes():
+        raise RuntimeError("boom_clerk")
+
+    async def fake_fleet():
+        raise RuntimeError("boom_ddb")
+
+    async def fake_recent_errors(*, hours, limit):
+        raise RuntimeError("boom_cwl")
+
+    with (
+        patch("core.services.system_health._all_probes", new=fake_probes),
+        patch("core.services.system_health._fleet_counts", new=fake_fleet),
+        patch("core.services.system_health.cloudwatch_logs.recent_errors_fleet", new=fake_recent_errors),
+    ):
+        result = await system_health.get_system_health()
+
+    # All components fell back to empty defaults — no exception leaked.
+    assert result["upstreams"] == {}
+    assert result["fleet"] == {}
+    assert result["recent_errors"] == []
+
+
+@pytest.mark.asyncio
+async def test_probe_stripe_unconfigured_when_no_secret_key(monkeypatch):
+    monkeypatch.setattr("core.config.settings.STRIPE_SECRET_KEY", "")
+    from core.services.system_health import _probe_stripe
+
+    result = await _probe_stripe()
+    assert result["status"] == "unconfigured"


### PR DESCRIPTION
## Summary

Phase B of the admin dashboard implementation per the merged plan ([`docs/superpowers/plans/2026-04-21-admin-dashboard.md`](../blob/main/docs/superpowers/plans/2026-04-21-admin-dashboard.md)). All backend foundations: DDB repo, audit decorator, CloudWatch wrapper + URL builder, PostHog client, secret redactor, system-health aggregator, Clerk admin client, composition layer. **No router yet** — Phase C wires these into `/api/v1/admin/*`.

Closes Phase B of #351 (8 of 8 tasks).

## What lands

| # | Task | Files | Tests |
|---|---|---|---|
| 6 | `admin_actions_repo` DDB CRUD | `core/repositories/admin_actions_repo.py` | 8 |
| 7 | `@audit_admin_action` decorator (fail-closed CEO S1) | `core/services/admin_audit.py` | 8 |
| 8 | `cloudwatch_logs` reader (CEO E4 pagination) | `core/services/cloudwatch_logs.py` | 10 |
| 9 | `cloudwatch_url` Insights deep-link builder | `core/services/cloudwatch_url.py` | 6 |
| 10 | `posthog_admin` Persons API client (CEO E5 missing) | `core/services/posthog_admin.py` | 8 |
| 11 | `admin_redact` openclaw.json secret allowlist (CEO S3) | `core/services/admin_redact.py` | 10 |
| 12 | `system_health` aggregator (CEO P2 cache) | `core/services/system_health.py` + `main.py` task registration | 10 |
| 13 | `admin_service` composition + `clerk_admin` read client | `core/services/admin_service.py`, `core/services/clerk_admin.py` | 26 |

**86 new backend tests, all green.** Pre-commit ran ruff lint + format on every commit.

## CEO must-fix items addressed (Phase B share)

| Item | Where |
|---|---|
| **S1** Audit fail-closed | `admin_audit.py` decorator — synchronous DDB write before response; on failure logs CRITICAL `ADMIN_AUDIT_PANIC` + tags response `audit_status="panic"` |
| **S3** openclaw.json secret redaction | `admin_redact.redact_openclaw_config` (recursive); applied in `admin_service.get_agent_detail` before return |
| **C1** `admin_service` composes existing services | All upstream calls go through `clerk_admin`, `billing_service`/repos, `gateway_pool` — no logic duplication |
| **P1** Timeout wrappers on parallel fetches | `admin_service._with_timeout` wraps each upstream in `get_overview` (default 2s, monkeypatchable for tests) |
| **P2** 30s cache on `/admin/health` upstream probes | `system_health._all_probes` |
| **E2** OpenClaw RPC timeout | `admin_service.list_user_agents` and `get_agent_detail` wrap `pool.send_rpc` with 3s `asyncio.wait_for` |
| **E3** Container-stopped detection | `admin_service.list_user_agents` returns `container_status="stopped"` (or `"none"`/`"unreachable"`) instead of attempting RPC |
| **E4** CloudWatch pagination | `cloudwatch_logs.filter_user_logs` threads `nextToken` ↔ `cursor` |
| **E5** PostHog 404 = `missing=True` | `posthog_admin.get_person_events` returns `{events: [], missing: True}` instead of error |

## Architecture decisions baked in

- **Module-level functions, not classes.** Matches existing repo style (`update_repo`, `billing_repo`); no class wrapping for `admin_actions_repo`, `clerk_admin`, etc. Easier to mock in tests, no instance state to manage.
- **Synchronous audit writes.** The decorator does NOT use `asyncio.create_task` to fire-and-forget the DDB write. CEO S1 explicitly requires synchronous-before-response so the response can be tagged `audit_status="panic"` on failure. Performance impact: one extra DDB `PutItem` (~10ms) per write endpoint.
- **No new Clerk service file existed.** `billing.py` and `desktop_auth.py` call `api.clerk.com` inline via httpx. `clerk_admin.py` consolidates the admin-side reads (`list_users`, `get_user`); mutation operations get added in Phase C alongside the endpoints that need them.
- **PostHog tests use direct `httpx.AsyncClient` mock**, not `respx`. The pinned `respx==0.20.2` has a route-matching incompat with newer httpx where even literally identical URL strings don't match. Direct mocking is verbose but bulletproof. Same applies to `clerk_admin` tests.
- **`_GATEWAY_RPC_TIMEOUT_S` and `_PARALLEL_TIMEOUT_S` read at call time**, not as default args, so tests can monkeypatch the constants without restructuring the function signatures.
- **`main.py` lifespan now registers `scheduled_worker` and `idle_checker` in `system_health.BACKGROUND_TASKS`** so `/admin/health` surfaces real task state. Cleared on shutdown.

## Tests

```bash
cd apps/backend && CLERK_ISSUER=https://test.clerk.accounts.dev \
  uv run pytest tests/unit/repositories/test_admin_actions_repo.py \
                tests/unit/services/test_admin*.py \
                tests/unit/services/test_clerk_admin.py \
                tests/unit/services/test_cloudwatch_*.py \
                tests/unit/services/test_posthog_admin.py \
                tests/unit/services/test_system_health.py \
                --no-cov
# 86 passed in 3.32s
```

## Test plan (CI / pre-merge)

- [x] All 86 new Phase B tests pass locally
- [x] Pre-commit ruff lint + format clean on every commit
- [ ] Backend CI runs full pytest — depends on CI env vars
- [ ] CI runs ruff lint
- [ ] CI runs ruff format check

## Phase B → C handoff

Phase C builds `apps/backend/routers/admin.py` on top of these services:
- Auth gate `Depends(require_platform_admin)` (already exists, see `core/auth.py:242`)
- Read endpoints: `/admin/me`, `/admin/system/health`, `/admin/users`, `/admin/users/{id}/overview`, `/admin/users/{id}/agents`, `/admin/users/{id}/agents/{agent_id}`, `/admin/users/{id}/posthog`, `/admin/users/{id}/logs`, `/admin/users/{id}/cloudwatch-url`, `/admin/actions`
- Write endpoints (each with `@audit_admin_action(...)` decorator + `Idempotency-Key` middleware per CEO D1): container actions (reprovision/stop/start/resize), billing actions, account actions, config patch, agent actions
- `admin_metrics` middleware emitting `admin_api.call_count` / `latency_ms` / `errors` per CEO O1

Plus the integration test against LocalStack from the plan (Task 23).

## Refs

- Tracking issue: #351
- Plan: `docs/superpowers/plans/2026-04-21-admin-dashboard.md`
- Phase A: #355 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
