### PR TITLE
feat(landing): Download for Mac link in Hero

### DIFF
--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -354,6 +354,8 @@ button:focus-visible { border-radius: 999px; }
 .hero-sub { font-size: 16px; color: #555; line-height: 1.85; max-width: 480px; margin-bottom: 48px; }
 .hero-ctas { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-bottom: 20px; }
 .hero-fine { font-size: 12px; color: #bbb; }
+.hero-download-link { color: inherit; text-decoration: underline; text-underline-offset: 2px; }
+.hero-download-link:hover { color: #333; }
 .hero-right {
   background: #f3efe6; padding: 36px 36px;
   display: flex; flex-direction: column; justify-content: center; gap: 0;

--- a/apps/frontend/src/components/landing/Hero.tsx
+++ b/apps/frontend/src/components/landing/Hero.tsx
@@ -172,7 +172,18 @@ export function Hero() {
             Learn more
           </Link>
         </div>
-        <p className="hero-fine">Free to start · No credit card required</p>
+        <p className="hero-fine">
+          Free to start · No credit card required ·{" "}
+          <a
+            href="https://github.com/Isol8AI/isol8/releases/latest"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hero-download-link"
+            onClick={() => posthog?.capture("landing_download_clicked")}
+          >
+            Download for Mac
+          </a>
+        </p>
       </div>
 
       <div className="hero-right wf-seq" id="wfSeq">


### PR DESCRIPTION
## Summary
- Tertiary \"Download for Mac\" link inlined into the existing \`hero-fine\` copy (\"Free to start · No credit card required · Download for Mac\")
- Points at \`https://github.com/Isol8AI/isol8/releases/latest\` so it tracks the newest published (non-prerelease) desktop release — no version hardcoding
- PostHog event \`landing_download_clicked\` for measuring interest alongside the existing \`landing_cta_clicked\`
- Navbar intentionally untouched — single discovery point for v1; can graduate to a navbar button once we see signal

## Test plan
- [ ] Vercel preview renders the new link on the Hero section
- [ ] Clicking the link navigates to GitHub's latest-release page
- [ ] PostHog event fires (verify in PostHog dashboard after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)