### PR TITLE
feat(admin): Phases D + E + F — admin frontend (foundations + pages + E2E) (#351)

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,38 @@
+# apps/frontend/.env.example
+# Copy to apps/frontend/.env.local and fill in values for local development.
+
+# ---------------------------------------------------------------------------
+# Backend API
+# ---------------------------------------------------------------------------
+
+# Public REST API base URL — must include the /api/v1 suffix.
+# Local: http://localhost:8000/api/v1
+# Dev:   https://api-dev.isol8.co/api/v1
+NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1
+
+# ---------------------------------------------------------------------------
+# Clerk auth (https://dashboard.clerk.com)
+# ---------------------------------------------------------------------------
+
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+
+# ---------------------------------------------------------------------------
+# Admin dashboard (#351, see docs/runbooks/admin-rollout.md)
+# ---------------------------------------------------------------------------
+
+# Comma-separated hosts that serve the /admin/* route group. Anything else
+# returns 404 at the middleware layer (CEO A1 host gate).
+NEXT_PUBLIC_ADMIN_HOSTS=admin.isol8.co,admin-dev.isol8.co,admin.localhost:3000
+
+# PostHog host for the Activity tab's session-replay deep links. Defaults to
+# https://app.posthog.com when unset; override for self-hosted PostHog or
+# the EU cloud (https://eu.posthog.com).
+NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+
+# Server-side admin API base URL — used by Server Components / Server Actions
+# in the admin route group when set. Falls back to NEXT_PUBLIC_API_URL when
+# unset, which is the right default for local development. Set this in
+# Vercel for environments where admin should hit a different origin (e.g. an
+# internal VPC endpoint).
+# API_URL=https://api-dev.isol8.co/api/v1

--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 !tests/e2e/.env.example
 
 # vercel

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import boundaries from "eslint-plugin-boundaries";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -16,6 +17,45 @@ const eslintConfig = defineConfig([
     "playwright-report/**",
     "test-results/**",
   ]),
+  // CEO A2: prevent the public client bundle from importing admin code.
+  // The middleware host gate (CEO A1) keeps unauth'd users out at the edge;
+  // this rule is the build-time backstop so a stray `import {...} from
+  // "@/components/admin/..."` in a public component fails CI instead of
+  // shipping admin React to anonymous visitors.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    plugins: { boundaries },
+    settings: {
+      "boundaries/elements": [
+        {
+          type: "admin",
+          pattern: ["src/app/admin/**/*", "src/components/admin/**/*"],
+          mode: "file",
+        },
+        {
+          type: "public",
+          pattern: ["src/**/*"],
+          mode: "file",
+        },
+      ],
+      "boundaries/include": ["src/**/*"],
+      "boundaries/ignore": ["**/__tests__/**", "tests/**"],
+    },
+    rules: {
+      "boundaries/dependencies": [
+        "error",
+        {
+          default: "disallow",
+          rules: [
+            // Admin code can import anywhere in the app.
+            { from: { type: "admin" }, allow: { to: { type: ["admin", "public"] } } },
+            // Public code may only import other public code — admin is off-limits.
+            { from: { type: "public" }, allow: { to: { type: "public" } } },
+          ],
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -62,6 +62,7 @@
     "dotenv": "^17.2.3",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
+    "eslint-plugin-boundaries": "^6.0.2",
     "jsdom": "^25.0.1",
     "msw": "^2.2.0",
     "stripe": "^17.0.0",

--- a/apps/frontend/src/app/admin/_actions/account.ts
+++ b/apps/frontend/src/app/admin/_actions/account.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { apiUrl } from "@/app/admin/_lib/url";
+
+/**
+ * Server Actions for admin-driven account-level Clerk mutations.
+ *
+ * Each action POSTs to a backend endpoint that brokers the Clerk Backend API
+ * call (suspend/unsuspend/sign-out/resend verification). The backend writes
+ * the audit row before returning, so callers only need to surface the JSON
+ * response back to the user.
+ *
+ * Conventions:
+ *   - Always read the Clerk session token via `auth()` so the backend can
+ *     verify the caller is a platform admin.
+ *   - Always `cache: "no-store"` — admin writes must never be cached.
+ *   - Return the parsed JSON body (or an inline error shape on transport
+ *     failure). Confirmation UX lives in the *caller* via
+ *     `<ConfirmActionDialog>`; these actions deliberately do not prompt.
+ */
+
+interface AdminActionResponse {
+  ok?: boolean;
+  error?: string;
+  status?: number;
+  [key: string]: unknown;
+}
+
+async function adminPost(path: string): Promise<AdminActionResponse> {
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (!token) {
+    return { ok: false, error: "Not authenticated", status: 401 };
+  }
+
+  const base = apiUrl().replace(/\/+$/, "");
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // Non-JSON response (e.g. 204). Fall through with empty body.
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        error:
+          (body && typeof body === "object" && "error" in body
+            ? String((body as { error: unknown }).error)
+            : null) ?? `Request failed with status ${res.status}`,
+        ...(body && typeof body === "object" ? body : {}),
+      };
+    }
+    return {
+      ok: true,
+      status: res.status,
+      ...(body && typeof body === "object" ? body : {}),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Network error",
+    };
+  }
+}
+
+/** Ban the Clerk user, blocking all sign-ins. */
+export async function suspendAccount(userId: string): Promise<AdminActionResponse> {
+  return adminPost(
+    `/admin/users/${encodeURIComponent(userId)}/account/suspend`,
+  );
+}
+
+/** Unban the Clerk user, restoring sign-in capability. */
+export async function reactivateAccount(
+  userId: string,
+): Promise<AdminActionResponse> {
+  return adminPost(
+    `/admin/users/${encodeURIComponent(userId)}/account/reactivate`,
+  );
+}
+
+/** Revoke all active Clerk sessions for the user. */
+export async function forceSignout(userId: string): Promise<AdminActionResponse> {
+  return adminPost(
+    `/admin/users/${encodeURIComponent(userId)}/account/force-signout`,
+  );
+}
+
+/** Re-send the Clerk email verification flow to the user. */
+export async function resendVerification(
+  userId: string,
+): Promise<AdminActionResponse> {
+  return adminPost(
+    `/admin/users/${encodeURIComponent(userId)}/account/resend-verification`,
+  );
+}

--- a/apps/frontend/src/app/admin/_actions/agent.ts
+++ b/apps/frontend/src/app/admin/_actions/agent.ts
@@ -1,0 +1,94 @@
+"use server";
+
+import { randomUUID } from "crypto";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { apiUrl } from "@/app/admin/_lib/url";
+
+/**
+ * Server Actions for the per-agent admin surface.
+ *
+ * Both endpoints proxy a gateway RPC into the user's container; the backend
+ * audits the call and returns a 409 when the container isn't running. We
+ * surface that to the calling client component so it can render an inline
+ * error rather than throwing.
+ */
+
+interface ActionResult {
+  ok: boolean;
+  status: number;
+  data?: unknown;
+  error?: string;
+}
+
+async function adminPost(path: string, body?: object): Promise<ActionResult> {
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (!token) {
+    return { ok: false, status: 401, error: "missing_token" };
+  }
+
+  const base = apiUrl().replace(/\/+$/, "");
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": randomUUID(),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      cache: "no-store",
+    });
+    const text = await res.text();
+    let data: unknown = undefined;
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        data,
+        error:
+          (data && typeof data === "object" && "detail" in data
+            ? String((data as { detail?: unknown }).detail)
+            : undefined) ?? `http_${res.status}`,
+      };
+    }
+    return { ok: true, status: res.status, data };
+  } catch (e) {
+    return {
+      ok: false,
+      status: 0,
+      error: e instanceof Error ? e.message : "network_error",
+    };
+  }
+}
+
+export async function deleteAgent(
+  userId: string,
+  agentId: string,
+): Promise<ActionResult> {
+  return adminPost(
+    `/admin/users/${encodeURIComponent(userId)}/agents/${encodeURIComponent(agentId)}/delete`,
+  );
+}
+
+export async function clearAgentSessions(
+  userId: string,
+  agentId: string,
+): Promise<ActionResult> {
+  return adminPost(
+    `/admin/users/${encodeURIComponent(userId)}/agents/${encodeURIComponent(agentId)}/clear-sessions`,
+  );
+}
+
+export type { ActionResult };

--- a/apps/frontend/src/app/admin/_actions/billing.ts
+++ b/apps/frontend/src/app/admin/_actions/billing.ts
@@ -1,0 +1,104 @@
+"use server";
+
+import { randomUUID } from "crypto";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { apiUrl } from "@/app/admin/_lib/url";
+
+/**
+ * Server Actions for the per-user billing surface (admin dashboard).
+ *
+ * Each action POSTs to a backend `/admin/users/{user_id}/billing/*` route
+ * with a fresh `Idempotency-Key` (CEO D1) — duplicate clicks return the
+ * cached response instead of double-charging or double-cancelling.
+ */
+
+interface ActionResult {
+  ok: boolean;
+  status: number;
+  data?: unknown;
+  error?: string;
+}
+
+async function adminPost(path: string, body?: object): Promise<ActionResult> {
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (!token) {
+    return { ok: false, status: 401, error: "missing_token" };
+  }
+
+  const base = apiUrl().replace(/\/+$/, "");
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": randomUUID(),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      cache: "no-store",
+    });
+    const text = await res.text();
+    let data: unknown = undefined;
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        data,
+        error:
+          (data && typeof data === "object" && "detail" in data
+            ? String((data as { detail?: unknown }).detail)
+            : undefined) ?? `http_${res.status}`,
+      };
+    }
+    return { ok: true, status: res.status, data };
+  } catch (e) {
+    return {
+      ok: false,
+      status: 0,
+      error: e instanceof Error ? e.message : "network_error",
+    };
+  }
+}
+
+export async function cancelSubscription(userId: string): Promise<ActionResult> {
+  return adminPost(`/admin/users/${encodeURIComponent(userId)}/billing/cancel-subscription`);
+}
+
+export async function pauseSubscription(userId: string): Promise<ActionResult> {
+  return adminPost(`/admin/users/${encodeURIComponent(userId)}/billing/pause-subscription`);
+}
+
+export async function issueCredit(
+  userId: string,
+  amountCents: number,
+  reason: string,
+): Promise<ActionResult> {
+  return adminPost(
+    `/admin/users/${encodeURIComponent(userId)}/billing/issue-credit`,
+    { amount_cents: amountCents, reason },
+  );
+}
+
+export async function markInvoiceResolved(
+  userId: string,
+  invoiceId: string,
+): Promise<ActionResult> {
+  return adminPost(
+    `/admin/users/${encodeURIComponent(userId)}/billing/mark-invoice-resolved`,
+    { invoice_id: invoiceId },
+  );
+}
+
+export type { ActionResult };

--- a/apps/frontend/src/app/admin/_actions/config.ts
+++ b/apps/frontend/src/app/admin/_actions/config.ts
@@ -1,0 +1,77 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { apiUrl } from "@/app/admin/_lib/url";
+
+/**
+ * Server Action: PATCH a per-user OpenClaw config (Track 1 silent update).
+ *
+ * Forwards to `PATCH /api/v1/admin/users/{id}/config` with `{patch: dict}`
+ * body. The backend deep-merges the patch into `openclaw.json` on EFS and
+ * notifies the user's container via the file-watcher pipeline. The audit row
+ * (`container.config.patch`) is written before the response returns.
+ *
+ * The caller is responsible for diff-confirmation UX (`<ConfirmActionDialog>`)
+ * — this action just makes the call.
+ */
+
+interface ConfigPatchResponse {
+  ok?: boolean;
+  error?: string;
+  status?: number;
+  [key: string]: unknown;
+}
+
+export async function patchConfig(
+  userId: string,
+  patch: Record<string, unknown>,
+): Promise<ConfigPatchResponse> {
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (!token) {
+    return { ok: false, error: "Not authenticated", status: 401 };
+  }
+
+  const base = apiUrl().replace(/\/+$/, "");
+  const url = `${base}/admin/users/${encodeURIComponent(userId)}/config`;
+
+  try {
+    const res = await fetch(url, {
+      method: "PATCH",
+      cache: "no-store",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ patch }),
+    });
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // Non-JSON response. Fall through with empty body.
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        error:
+          (body && typeof body === "object" && "error" in body
+            ? String((body as { error: unknown }).error)
+            : null) ?? `Request failed with status ${res.status}`,
+        ...(body && typeof body === "object" ? body : {}),
+      };
+    }
+    return {
+      ok: true,
+      status: res.status,
+      ...(body && typeof body === "object" ? body : {}),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Network error",
+    };
+  }
+}

--- a/apps/frontend/src/app/admin/_actions/container.ts
+++ b/apps/frontend/src/app/admin/_actions/container.ts
@@ -1,0 +1,96 @@
+"use server";
+
+import { randomUUID } from "crypto";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { apiUrl } from "@/app/admin/_lib/url";
+
+/**
+ * Server Actions for the per-user container surface (admin dashboard).
+ *
+ * Each action POSTs to a backend `/admin/users/{user_id}/container/*` route
+ * with a fresh `Idempotency-Key` so double-clicks short-circuit on the
+ * backend (CEO D1). The Clerk JWT is fetched server-side via `auth()`; never
+ * exposed to the client. We always return the parsed JSON response (or a
+ * `{error}` shape) so the calling client component can surface errors inline.
+ */
+
+interface ActionResult {
+  ok: boolean;
+  status: number;
+  data?: unknown;
+  error?: string;
+}
+
+async function adminPost(path: string, body?: object): Promise<ActionResult> {
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (!token) {
+    return { ok: false, status: 401, error: "missing_token" };
+  }
+
+  const base = apiUrl().replace(/\/+$/, "");
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": randomUUID(),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      cache: "no-store",
+    });
+    const text = await res.text();
+    let data: unknown = undefined;
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        data,
+        error:
+          (data && typeof data === "object" && "detail" in data
+            ? String((data as { detail?: unknown }).detail)
+            : undefined) ?? `http_${res.status}`,
+      };
+    }
+    return { ok: true, status: res.status, data };
+  } catch (e) {
+    return {
+      ok: false,
+      status: 0,
+      error: e instanceof Error ? e.message : "network_error",
+    };
+  }
+}
+
+export async function reprovisionContainer(userId: string): Promise<ActionResult> {
+  return adminPost(`/admin/users/${encodeURIComponent(userId)}/container/reprovision`);
+}
+
+export async function stopContainer(userId: string): Promise<ActionResult> {
+  return adminPost(`/admin/users/${encodeURIComponent(userId)}/container/stop`);
+}
+
+export async function startContainer(userId: string): Promise<ActionResult> {
+  return adminPost(`/admin/users/${encodeURIComponent(userId)}/container/start`);
+}
+
+export async function resizeContainer(userId: string, tier: string): Promise<ActionResult> {
+  return adminPost(
+    `/admin/users/${encodeURIComponent(userId)}/container/resize`,
+    { tier },
+  );
+}
+
+export type { ActionResult };

--- a/apps/frontend/src/app/admin/_lib/api.ts
+++ b/apps/frontend/src/app/admin/_lib/api.ts
@@ -1,0 +1,316 @@
+import "server-only";
+
+import { apiUrl } from "./url";
+
+// ---------------------------------------------------------------------------
+// Response shapes
+//
+// These mirror the backend Pydantic models in apps/backend/routers/admin.py
+// + apps/backend/core/services/admin_service.py. Fields are intentionally
+// permissive (`unknown` over `any`, optional where the backend may omit) so
+// upstream changes degrade gracefully — Server Components can still render.
+// ---------------------------------------------------------------------------
+
+export interface AdminMe {
+  user_id: string;
+  email: string | null;
+  is_admin: true;
+}
+
+export interface SystemHealth {
+  containers?: {
+    total?: number;
+    running?: number;
+    stopped?: number;
+    failed?: number;
+    [key: string]: unknown;
+  };
+  upstream?: Record<string, { ok: boolean; latency_ms?: number; error?: string }>;
+  background_tasks?: Record<string, { running: boolean; last_run?: string; last_error?: string }>;
+  recent_errors?: Array<{ timestamp: string; source: string; message: string }>;
+  [key: string]: unknown;
+}
+
+export interface AdminAction {
+  action_id?: string;
+  admin_user_id?: string;
+  target_user_id?: string;
+  action: string;
+  timestamp: string;
+  status?: string;
+  payload?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ActionsPage {
+  items: AdminAction[];
+  cursor: string | null;
+}
+
+export interface UserDirectoryRow {
+  clerk_id: string;
+  email: string | null;
+  created_at?: number | string | null;
+  last_sign_in_at?: number | string | null;
+  banned: boolean;
+  container_status: string;
+  plan_tier: string;
+}
+
+export interface UsersPage {
+  users: UserDirectoryRow[];
+  cursor: string | null;
+  stubbed: boolean;
+}
+
+export interface UserOverview {
+  identity: unknown;
+  container: unknown;
+  billing: unknown;
+  usage: unknown;
+}
+
+export interface AgentSummary {
+  agent_id?: string;
+  name?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+export interface AgentsPage {
+  agents: AgentSummary[];
+  cursor: string | null;
+  container_status: string;
+  error?: string;
+}
+
+export interface AgentDetail {
+  agent?: unknown;
+  sessions?: unknown[];
+  skills?: unknown[];
+  config_redacted?: unknown;
+  error?: string;
+  container_status?: string;
+}
+
+export interface PosthogTimeline {
+  events: unknown[];
+  stubbed?: boolean;
+  missing?: boolean;
+  error?: string | null;
+}
+
+export interface LogsPage {
+  events: unknown[];
+  cursor: string | null;
+  missing?: boolean;
+  error?: string | null;
+}
+
+export interface CloudwatchUrlResponse {
+  url: string;
+}
+
+export interface AdminApiError {
+  error: string;
+  status?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal fetcher
+// ---------------------------------------------------------------------------
+
+interface FetchOptions {
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  query?: Record<string, string | number | undefined | null>;
+  body?: unknown;
+}
+
+function buildUrl(path: string, query?: FetchOptions["query"]): string {
+  const base = apiUrl().replace(/\/+$/, "");
+  let url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+  if (query) {
+    const search = new URLSearchParams();
+    for (const [k, v] of Object.entries(query)) {
+      if (v === undefined || v === null || v === "") continue;
+      search.set(k, String(v));
+    }
+    const qs = search.toString();
+    if (qs) url += `?${qs}`;
+  }
+  return url;
+}
+
+/**
+ * Single-shot authenticated fetcher used by every admin API helper.
+ *
+ * Always sets `cache: "no-store"` — admin data must never be cached. Network
+ * errors and non-2xx responses are caught and surfaced via `T | null` so
+ * callers (Server Components) can render an inline error banner instead of
+ * blowing up the route. JSON parse failures degrade the same way.
+ */
+async function adminFetch<T>(
+  token: string,
+  path: string,
+  opts: FetchOptions = {},
+): Promise<T | null> {
+  try {
+    const url = buildUrl(path, opts.query);
+    const init: RequestInit = {
+      method: opts.method ?? "GET",
+      cache: "no-store",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    };
+    if (opts.body !== undefined) {
+      init.body = JSON.stringify(opts.body);
+    }
+    const res = await fetch(url, init);
+    if (!res.ok) {
+      // 403 from /me is a normal "not an admin" signal — return null and let
+      // the caller (the layout) redirect appropriately.
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auth + system
+// ---------------------------------------------------------------------------
+
+export async function getAdminMe(token: string): Promise<AdminMe | null> {
+  return adminFetch<AdminMe>(token, "/admin/me");
+}
+
+export async function getSystemHealth(token: string): Promise<SystemHealth | null> {
+  return adminFetch<SystemHealth>(token, "/admin/system/health");
+}
+
+export interface ActionsParams {
+  target_user_id?: string;
+  admin_user_id?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export async function getActions(
+  token: string,
+  params: ActionsParams = {},
+): Promise<ActionsPage> {
+  const result = await adminFetch<ActionsPage>(token, "/admin/actions", {
+    query: {
+      target_user_id: params.target_user_id,
+      admin_user_id: params.admin_user_id,
+      limit: params.limit,
+      cursor: params.cursor,
+    },
+  });
+  return result ?? { items: [], cursor: null };
+}
+
+// ---------------------------------------------------------------------------
+// Users + per-user reads
+// ---------------------------------------------------------------------------
+
+export async function listUsers(
+  token: string,
+  q?: string,
+  cursor?: string,
+  limit?: number,
+): Promise<UsersPage> {
+  const result = await adminFetch<UsersPage>(token, "/admin/users", {
+    query: { q, cursor, limit },
+  });
+  return result ?? { users: [], cursor: null, stubbed: false };
+}
+
+export async function getOverview(
+  token: string,
+  userId: string,
+): Promise<UserOverview | null> {
+  return adminFetch<UserOverview>(token, `/admin/users/${encodeURIComponent(userId)}/overview`);
+}
+
+export async function listAgents(
+  token: string,
+  userId: string,
+  cursor?: string,
+  limit?: number,
+): Promise<AgentsPage> {
+  const result = await adminFetch<AgentsPage>(
+    token,
+    `/admin/users/${encodeURIComponent(userId)}/agents`,
+    { query: { cursor, limit } },
+  );
+  return result ?? { agents: [], cursor: null, container_status: "unknown" };
+}
+
+export async function getAgentDetail(
+  token: string,
+  userId: string,
+  agentId: string,
+): Promise<AgentDetail | null> {
+  return adminFetch<AgentDetail>(
+    token,
+    `/admin/users/${encodeURIComponent(userId)}/agents/${encodeURIComponent(agentId)}`,
+  );
+}
+
+export async function getPosthog(
+  token: string,
+  userId: string,
+  limit?: number,
+): Promise<PosthogTimeline> {
+  const result = await adminFetch<PosthogTimeline>(
+    token,
+    `/admin/users/${encodeURIComponent(userId)}/posthog`,
+    { query: { limit } },
+  );
+  return result ?? { events: [], stubbed: false, missing: true, error: null };
+}
+
+export interface LogsOptions {
+  level?: string;
+  hours?: number;
+  limit?: number;
+  cursor?: string;
+}
+
+export async function getLogs(
+  token: string,
+  userId: string,
+  opts: LogsOptions = {},
+): Promise<LogsPage> {
+  const result = await adminFetch<LogsPage>(
+    token,
+    `/admin/users/${encodeURIComponent(userId)}/logs`,
+    {
+      query: {
+        level: opts.level,
+        hours: opts.hours,
+        limit: opts.limit,
+        cursor: opts.cursor,
+      },
+    },
+  );
+  return result ?? { events: [], cursor: null, missing: true, error: null };
+}
+
+export async function getCloudwatchUrl(
+  token: string,
+  userId: string,
+  start: string,
+  end: string,
+  level: string,
+): Promise<CloudwatchUrlResponse | null> {
+  return adminFetch<CloudwatchUrlResponse>(
+    token,
+    `/admin/users/${encodeURIComponent(userId)}/cloudwatch-url`,
+    { query: { start, end, level } },
+  );
+}

--- a/apps/frontend/src/app/admin/_lib/url.ts
+++ b/apps/frontend/src/app/admin/_lib/url.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+/**
+ * Resolve the backend API base URL for the admin server-side fetcher.
+ *
+ * Prefers `API_URL` (server-only var, never shipped to the client bundle)
+ * and falls back to `NEXT_PUBLIC_API_URL` so existing dev environments that
+ * only set the public var keep working. Both are expected to already include
+ * the `/api/v1` path segment, matching the existing `useApi` convention
+ * (see `src/lib/api.ts`).
+ *
+ * Exported as a function (rather than a top-level constant) so unit tests can
+ * override `process.env` and re-invoke without module-level evaluation.
+ */
+export function apiUrl(): string {
+  return (
+    process.env.API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "http://localhost:8000/api/v1"
+  );
+}

--- a/apps/frontend/src/app/admin/health/page.tsx
+++ b/apps/frontend/src/app/admin/health/page.tsx
@@ -1,0 +1,276 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { getSystemHealth } from "@/app/admin/_lib/api";
+
+export const metadata = { title: "Health \u00b7 Admin" };
+
+// ---------------------------------------------------------------------------
+// Local response shape — the shared `SystemHealth` type in
+// `_lib/api.ts` is intentionally permissive (`unknown`/index signature) so the
+// SC can degrade if the backend evolves. We narrow here so the rendering code
+// stays readable without sprinkling casts everywhere.
+// ---------------------------------------------------------------------------
+
+type UpstreamProbe = {
+  status?: string;
+  latency_ms?: number;
+  error?: string;
+  http_status?: number;
+};
+
+type FleetCounts = {
+  running?: number;
+  provisioning?: number;
+  stopped?: number;
+  error?: number;
+  total?: number;
+};
+
+type BackgroundTaskState = {
+  status?: string;
+  error?: string | null;
+};
+
+type RecentError = {
+  timestamp?: string;
+  user_id?: string | null;
+  message?: string;
+  correlation_id?: string | null;
+};
+
+type HealthShape = {
+  upstreams?: Record<string, UpstreamProbe>;
+  fleet?: FleetCounts;
+  background_tasks?: Record<string, BackgroundTaskState>;
+  recent_errors?: RecentError[];
+};
+
+const UPSTREAM_LABELS: Record<string, string> = {
+  clerk: "Clerk",
+  stripe: "Stripe",
+  ddb: "DynamoDB",
+};
+
+const UPSTREAM_ORDER = ["clerk", "stripe", "ddb"];
+
+function statusChipClasses(status?: string): string {
+  switch (status) {
+    case "ok":
+      return "bg-emerald-500/15 text-emerald-300 border-emerald-500/30";
+    case "degraded":
+      return "bg-amber-500/15 text-amber-300 border-amber-500/30";
+    case "down":
+      return "bg-red-500/15 text-red-300 border-red-500/30";
+    case "unconfigured":
+      return "bg-zinc-500/15 text-zinc-300 border-zinc-500/30";
+    default:
+      return "bg-zinc-500/15 text-zinc-300 border-zinc-500/30";
+  }
+}
+
+function taskBadgeClasses(status?: string): string {
+  switch (status) {
+    case "running":
+      return "bg-emerald-500/15 text-emerald-300";
+    case "stopped":
+    case "cancelled":
+      return "bg-amber-500/15 text-amber-300";
+    case "unregistered":
+      return "bg-zinc-500/15 text-zinc-300";
+    default:
+      return "bg-zinc-500/15 text-zinc-300";
+  }
+}
+
+function truncate(input: string, max: number): string {
+  if (input.length <= max) return input;
+  return `${input.slice(0, max)}\u2026`;
+}
+
+const FLEET_TILES: Array<{ key: keyof FleetCounts; label: string; tone: string }> = [
+  { key: "running", label: "Running", tone: "text-emerald-300" },
+  { key: "provisioning", label: "Provisioning", tone: "text-sky-300" },
+  { key: "stopped", label: "Stopped", tone: "text-zinc-300" },
+  { key: "error", label: "Error", tone: "text-red-300" },
+];
+
+export default async function HealthPage() {
+  const { getToken } = await auth();
+  const token = await getToken();
+  // The admin layout already enforces an authenticated admin session, so
+  // `token` should always be present here. Defensive null-handling keeps the
+  // SC happy in tests.
+  const health = token ? ((await getSystemHealth(token)) as HealthShape | null) : null;
+
+  if (!health) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-semibold text-zinc-100">System health</h1>
+        <ErrorBanner error="System health endpoint unreachable" variant="error" />
+      </div>
+    );
+  }
+
+  const upstreams = health.upstreams ?? {};
+  const fleet = health.fleet ?? {};
+  const tasks = health.background_tasks ?? {};
+  const recentErrors = (health.recent_errors ?? []).slice(0, 10);
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-semibold text-zinc-100">System health</h1>
+
+      {/* Upstream probes */}
+      <section aria-labelledby="upstreams-heading" className="space-y-3">
+        <h2 id="upstreams-heading" className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          Upstreams
+        </h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {UPSTREAM_ORDER.map((key) => {
+            const probe = upstreams[key] ?? {};
+            const label = UPSTREAM_LABELS[key] ?? key;
+            return (
+              <div
+                key={key}
+                className={`flex items-center justify-between rounded-md border px-4 py-3 ${statusChipClasses(probe.status)}`}
+              >
+                <div className="flex flex-col">
+                  <span className="text-sm font-semibold">{label}</span>
+                  <span className="text-xs uppercase tracking-wide opacity-80">
+                    {probe.status ?? "unknown"}
+                  </span>
+                </div>
+                <div className="text-right text-xs opacity-80">
+                  {probe.latency_ms !== undefined ? (
+                    <span className="font-mono">{probe.latency_ms}ms</span>
+                  ) : null}
+                  {probe.error ? (
+                    <div title={probe.error} className="mt-0.5 max-w-[10rem] truncate font-mono">
+                      {probe.error}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Fleet tiles */}
+      <section aria-labelledby="fleet-heading" className="space-y-3">
+        <h2 id="fleet-heading" className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          Container fleet
+        </h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {FLEET_TILES.map((tile) => (
+            <div
+              key={tile.key}
+              className="rounded-md border border-white/10 bg-white/[0.02] p-4"
+            >
+              <div className={`text-2xl font-semibold ${tile.tone}`}>
+                {fleet[tile.key] ?? 0}
+              </div>
+              <div className="mt-1 text-xs uppercase tracking-wide text-zinc-400">
+                {tile.label}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="text-xs text-zinc-500">
+          Total containers: <span className="font-mono text-zinc-300">{fleet.total ?? 0}</span>
+        </div>
+      </section>
+
+      {/* Background tasks */}
+      <section aria-labelledby="tasks-heading" className="space-y-3">
+        <h2 id="tasks-heading" className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          Background tasks
+        </h2>
+        {Object.keys(tasks).length === 0 ? (
+          <p className="text-sm text-zinc-500">No background tasks registered.</p>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-white/10 bg-white/[0.02]">
+            {Object.entries(tasks).map(([name, state], idx) => (
+              <div
+                key={name}
+                className={`flex items-center justify-between px-4 py-2 text-sm ${
+                  idx > 0 ? "border-t border-white/5" : ""
+                }`}
+                title={state.error ?? undefined}
+              >
+                <span className="font-mono text-zinc-200">{name}</span>
+                <div className="flex items-center gap-3">
+                  {state.error ? (
+                    <span className="max-w-[20rem] truncate font-mono text-xs text-red-300">
+                      {state.error}
+                    </span>
+                  ) : null}
+                  <span
+                    className={`rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${taskBadgeClasses(state.status)}`}
+                  >
+                    {state.status ?? "unknown"}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Recent errors */}
+      <section aria-labelledby="recent-errors-heading" className="space-y-3">
+        <h2 id="recent-errors-heading" className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          Recent errors (last 24h)
+        </h2>
+        {recentErrors.length === 0 ? (
+          <p className="text-sm text-zinc-500">No recent errors logged.</p>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-white/10">
+            <table className="w-full table-fixed text-xs">
+              <thead className="bg-zinc-900 text-left text-zinc-400">
+                <tr>
+                  <th className="w-48 px-3 py-2 font-medium">Timestamp</th>
+                  <th className="w-40 px-3 py-2 font-medium">User</th>
+                  <th className="px-3 py-2 font-medium">Message</th>
+                  <th className="w-48 px-3 py-2 font-medium">Correlation ID</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentErrors.map((err, i) => (
+                  <tr
+                    key={`${err.timestamp ?? "ts"}-${i}`}
+                    className="border-t border-white/5 align-top"
+                  >
+                    <td className="px-3 py-2 font-mono text-zinc-300">
+                      {err.timestamp ?? "\u2014"}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-zinc-300">
+                      {err.user_id ? (
+                        <Link
+                          href={`/admin/users/${encodeURIComponent(err.user_id)}`}
+                          className="text-sky-300 hover:underline"
+                        >
+                          {truncate(err.user_id, 16)}
+                        </Link>
+                      ) : (
+                        <span className="text-zinc-500">{"\u2014"}</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-zinc-200" title={err.message ?? ""}>
+                      {truncate(err.message ?? "", 120)}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-zinc-400">
+                      {err.correlation_id ?? "\u2014"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/layout.tsx
+++ b/apps/frontend/src/app/admin/layout.tsx
@@ -1,0 +1,70 @@
+import { redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import Link from "next/link";
+
+import { getAdminMe } from "./_lib/api";
+
+/**
+ * Admin tree gate (Server Component).
+ *
+ * Order of checks:
+ *   1. Clerk auth — redirect to /sign-in if not signed in.
+ *   2. Backend `/admin/me` — single source of truth for admin membership.
+ *      Anything other than `is_admin: true` redirects to /admin/not-authorized.
+ *
+ * The whole admin route segment sits behind this layout, so individual pages
+ * don't need their own gate. Pair with the host-based 404 in
+ * `src/middleware.ts` for defense in depth (CEO A1).
+ */
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { userId, getToken } = await auth();
+  if (!userId) {
+    redirect("/sign-in");
+  }
+
+  const token = await getToken();
+  if (!token) {
+    redirect("/sign-in");
+  }
+
+  const me = await getAdminMe(token);
+  if (!me?.is_admin) {
+    redirect("/admin/not-authorized");
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <header className="border-b border-zinc-800 bg-zinc-900">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-8">
+            <Link href="/admin" className="text-lg font-semibold text-zinc-100">
+              isol8 admin
+            </Link>
+            <nav className="flex items-center gap-1 text-sm">
+              <Link
+                href="/admin/users"
+                className="rounded-md px-3 py-1.5 text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+              >
+                Users
+              </Link>
+              <Link
+                href="/admin/health"
+                className="rounded-md px-3 py-1.5 text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+              >
+                Health
+              </Link>
+            </nav>
+          </div>
+          <div className="text-xs text-zinc-500">
+            {me.email ?? me.user_id}
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto max-w-7xl px-6 py-8">{children}</main>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/not-authorized/page.tsx
+++ b/apps/frontend/src/app/admin/not-authorized/page.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+/**
+ * Rendered when the admin layout's `/admin/me` probe returns non-admin.
+ * Intentionally minimal — no admin UI chrome, no surface area for probing.
+ */
+export default function NotAuthorizedPage() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+      <h1 className="text-2xl font-semibold text-zinc-100">403 — Not authorized</h1>
+      <p className="max-w-md text-zinc-400">You are not a platform admin.</p>
+      <Link
+        href="/"
+        className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-zinc-200 hover:bg-zinc-800"
+      >
+        Back to home
+      </Link>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/page.tsx
+++ b/apps/frontend/src/app/admin/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+
+/**
+ * `/admin` is just a default landing — funnel everyone to the user directory
+ * (the most common entry point).
+ */
+export default function AdminIndexPage() {
+  redirect("/admin/users");
+}

--- a/apps/frontend/src/app/admin/users/UsersClientHeader.tsx
+++ b/apps/frontend/src/app/admin/users/UsersClientHeader.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import { UserSearchInput } from "@/components/admin/UserSearchInput";
+
+export interface UsersClientHeaderProps {
+  defaultValue?: string;
+}
+
+/**
+ * Thin "use client" wrapper that owns the debounced search callback for the
+ * users directory. Lives next to the parent Server Component so the page
+ * itself can stay server-rendered. On every debounced change it pushes a new
+ * URL — server-rendered table re-fetches with the new query.
+ */
+export function UsersClientHeader({ defaultValue }: UsersClientHeaderProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = React.useTransition();
+  const lastQueryRef = React.useRef(defaultValue ?? "");
+
+  const handleSearch = React.useCallback(
+    (query: string) => {
+      const trimmed = query.trim();
+      if (trimmed === lastQueryRef.current) return;
+      lastQueryRef.current = trimmed;
+      const target = trimmed
+        ? `/admin/users?q=${encodeURIComponent(trimmed)}`
+        : "/admin/users";
+      startTransition(() => {
+        router.push(target);
+      });
+    },
+    [router],
+  );
+
+  return (
+    <UserSearchInput
+      defaultValue={defaultValue}
+      onSearch={handleSearch}
+      isLoading={isPending}
+    />
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/UserTabs.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/UserTabs.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+export interface UserTab {
+  label: string;
+  /** Path segment after `/admin/users/{id}`. Empty string = Overview. */
+  segment: string;
+}
+
+export interface UserTabsProps {
+  userId: string;
+  tabs: UserTab[];
+}
+
+/**
+ * Tab strip for the per-user admin pages. Active tab is detected via
+ * `usePathname()` so this stays a tiny client component while the surrounding
+ * layout + page bodies remain server-rendered.
+ */
+export function UserTabs({ userId, tabs }: UserTabsProps) {
+  const pathname = usePathname() ?? "";
+  const base = `/admin/users/${encodeURIComponent(userId)}`;
+  // Overview matches the bare base path; sub-tabs match `${base}/${segment}`.
+  const matchSegment = pathname === base || pathname === `${base}/`
+    ? ""
+    : pathname.startsWith(`${base}/`)
+      ? pathname.slice(base.length + 1).split("/")[0] ?? ""
+      : "";
+
+  return (
+    <nav
+      role="tablist"
+      aria-label="User detail sections"
+      className="flex items-center gap-1 border-b border-white/10"
+    >
+      {tabs.map((tab) => {
+        const href = tab.segment ? `${base}/${tab.segment}` : base;
+        const active = tab.segment === matchSegment;
+        return (
+          <Link
+            key={tab.segment || "overview"}
+            href={href}
+            role="tab"
+            aria-selected={active}
+            className={cn(
+              "px-4 py-2 text-sm transition-colors",
+              "border-b-2",
+              active
+                ? "border-sky-400 text-zinc-100"
+                : "border-transparent text-zinc-400 hover:border-zinc-700 hover:text-zinc-200",
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/actions/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/actions/page.tsx
@@ -1,0 +1,145 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+
+import { getActions, type AdminAction } from "@/app/admin/_lib/api";
+import { AuditRow, type AuditEntry } from "@/components/admin/AuditRow";
+import { EmptyState } from "@/components/admin/EmptyState";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+
+export const metadata = { title: "Actions \u00b7 Admin" };
+
+// ---------------------------------------------------------------------------
+// AdminAction (intentionally permissive in `_lib/api.ts`) → AuditEntry
+// (the strict shape `<AuditRow>` expects). Defaults to safe values when the
+// backend hasn't filled a field.
+// ---------------------------------------------------------------------------
+
+function asAuditEntry(raw: AdminAction): AuditEntry {
+  // Backend uses `timestamp_action_id` as the composite sort key, but the
+  // permissive type uses both `timestamp` and `action_id`. Compose the
+  // composite if it isn't already present.
+  const compositeKey =
+    typeof (raw as Record<string, unknown>).timestamp_action_id === "string"
+      ? ((raw as Record<string, unknown>).timestamp_action_id as string)
+      : raw.timestamp && raw.action_id
+        ? `${raw.timestamp}#${raw.action_id}`
+        : (raw.timestamp ?? "");
+
+  const result =
+    raw.status === "error" || raw.status === "success"
+      ? raw.status
+      : ((raw as Record<string, unknown>).result === "error" ||
+            (raw as Record<string, unknown>).result === "success"
+          ? ((raw as Record<string, unknown>).result as "success" | "error")
+          : "success");
+
+  const auditStatus =
+    (raw as Record<string, unknown>).audit_status === "panic" ||
+    (raw as Record<string, unknown>).audit_status === "written"
+      ? ((raw as Record<string, unknown>).audit_status as
+          | "written"
+          | "panic")
+      : "written";
+
+  const httpStatus =
+    typeof (raw as Record<string, unknown>).http_status === "number"
+      ? ((raw as Record<string, unknown>).http_status as number)
+      : 0;
+
+  const elapsedMs =
+    typeof (raw as Record<string, unknown>).elapsed_ms === "number"
+      ? ((raw as Record<string, unknown>).elapsed_ms as number)
+      : 0;
+
+  const errorMessage =
+    typeof (raw as Record<string, unknown>).error_message === "string"
+      ? ((raw as Record<string, unknown>).error_message as string)
+      : undefined;
+
+  return {
+    admin_user_id: raw.admin_user_id ?? "",
+    timestamp_action_id: compositeKey,
+    target_user_id: raw.target_user_id ?? "",
+    action: raw.action ?? "",
+    result,
+    audit_status: auditStatus,
+    http_status: httpStatus,
+    elapsed_ms: elapsedMs,
+    error_message: errorMessage,
+  };
+}
+
+interface ActionsPageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function parseCursor(input: string | string[] | undefined): string | undefined {
+  const v = Array.isArray(input) ? input[0] : input;
+  return v && v.length > 0 ? v : undefined;
+}
+
+export default async function ActionsPage({
+  params,
+  searchParams,
+}: ActionsPageProps) {
+  const { id } = await params;
+  const sp = await searchParams;
+  const cursor = parseCursor(sp.cursor);
+
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (!token) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-xl font-semibold text-zinc-100">Actions</h1>
+        <ErrorBanner error="Missing Clerk session token." />
+      </div>
+    );
+  }
+
+  const result = await getActions(token, {
+    target_user_id: id,
+    limit: 100,
+    cursor,
+  });
+
+  const entries = (result.items ?? []).map(asAuditEntry);
+
+  const nextCursorHref = result.cursor
+    ? `/admin/users/${encodeURIComponent(id)}/actions?cursor=${encodeURIComponent(result.cursor)}`
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold text-zinc-100">Admin actions</h1>
+
+      {entries.length === 0 ? (
+        <EmptyState
+          title="No admin actions"
+          body="No admin has taken any action against this user yet."
+        />
+      ) : (
+        <div className="space-y-1.5">
+          {entries.map((entry) => (
+            <AuditRow
+              key={`${entry.timestamp_action_id}-${entry.action}`}
+              entry={entry}
+            />
+          ))}
+        </div>
+      )}
+
+      {nextCursorHref ? (
+        <div className="flex justify-center">
+          <Link
+            href={nextCursorHref}
+            className="rounded-md border border-white/10 bg-white/[0.04] px-4 py-2 text-sm text-zinc-100 hover:bg-white/[0.08]"
+          >
+            Load more
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/activity/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/activity/page.tsx
@@ -1,0 +1,240 @@
+import { auth } from "@clerk/nextjs/server";
+
+import {
+  getCloudwatchUrl,
+  getLogs,
+  getPosthog,
+} from "@/app/admin/_lib/api";
+import { EmptyState } from "@/components/admin/EmptyState";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { LogRow, type LogEntry } from "@/components/admin/LogRow";
+
+export const metadata = { title: "Activity \u00b7 Admin" };
+
+// ---------------------------------------------------------------------------
+// Local response narrowings
+//
+// `_lib/api.ts` types `events: unknown[]` so the SC degrades if the backend
+// shape evolves. We narrow per-render to keep call sites readable.
+// ---------------------------------------------------------------------------
+
+interface PosthogEvent {
+  timestamp?: string;
+  event?: string;
+  properties?: Record<string, unknown>;
+  session_id?: string | null;
+}
+
+const POSTHOG_HOST_DEFAULT = "https://app.posthog.com";
+
+function posthogHost(): string {
+  return process.env.NEXT_PUBLIC_POSTHOG_HOST || POSTHOG_HOST_DEFAULT;
+}
+
+function asLogEntry(raw: unknown): LogEntry {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  return {
+    timestamp: typeof r.timestamp === "string" ? r.timestamp : "",
+    level:
+      typeof r.level === "string" || r.level === null
+        ? (r.level as LogEntry["level"])
+        : null,
+    message: typeof r.message === "string" ? r.message : "",
+    correlation_id:
+      typeof r.correlation_id === "string" ? r.correlation_id : null,
+    raw_json:
+      r.raw_json && typeof r.raw_json === "object"
+        ? (r.raw_json as Record<string, unknown>)
+        : null,
+  };
+}
+
+function asPosthogEvent(raw: unknown): PosthogEvent {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  return {
+    timestamp: typeof r.timestamp === "string" ? r.timestamp : undefined,
+    event: typeof r.event === "string" ? r.event : undefined,
+    properties:
+      r.properties && typeof r.properties === "object"
+        ? (r.properties as Record<string, unknown>)
+        : undefined,
+    session_id:
+      typeof r.session_id === "string" ? r.session_id : null,
+  };
+}
+
+// PostHog property previews — render the whole object as JSON inside <details>
+// for now. Cheap and good enough: admins typically only care about `path`,
+// `current_url`, `$browser`, etc. and can scan the JSON. A polished property
+// table can come later without breaking the data shape.
+function PropertiesDetails({
+  properties,
+}: {
+  properties?: Record<string, unknown>;
+}) {
+  if (!properties || Object.keys(properties).length === 0) return null;
+  return (
+    <details className="mt-1 text-xs text-zinc-400">
+      <summary className="cursor-pointer select-none text-zinc-500 hover:text-zinc-300">
+        Properties
+      </summary>
+      <pre className="mt-2 max-h-64 overflow-auto rounded-md border border-white/5 bg-black/30 p-2 font-mono text-[11px] text-zinc-300">
+        {JSON.stringify(properties, null, 2)}
+      </pre>
+    </details>
+  );
+}
+
+interface ActivityPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ActivityPage({ params }: ActivityPageProps) {
+  const { id } = await params;
+  const { getToken } = await auth();
+  const token = await getToken();
+  // Layout already gates admin access, but typeguard for the Server Action API.
+  if (!token) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-xl font-semibold text-zinc-100">Activity</h1>
+        <ErrorBanner error="Missing Clerk session token." />
+      </div>
+    );
+  }
+
+  // 24-hour CloudWatch window for both the inline error preview AND the
+  // "open in CloudWatch" deep link button.
+  const end = new Date();
+  const start = new Date(end.getTime() - 86_400_000);
+  const startIso = start.toISOString();
+  const endIso = end.toISOString();
+
+  const [posthog, logs, cwUrl] = await Promise.all([
+    getPosthog(token, id),
+    getLogs(token, id, { level: "ERROR", hours: 24, limit: 20 }),
+    getCloudwatchUrl(token, id, startIso, endIso, "ERROR"),
+  ]);
+
+  const logEntries = (logs.events ?? []).map(asLogEntry);
+  const posthogEvents = (posthog.events ?? []).map(asPosthogEvent);
+
+  return (
+    <div className="space-y-10">
+      <h1 className="text-xl font-semibold text-zinc-100">Activity</h1>
+
+      {/* --- Recent error logs ----------------------------------------- */}
+      <section aria-labelledby="recent-logs-heading" className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <h2
+            id="recent-logs-heading"
+            className="text-sm font-medium uppercase tracking-wide text-zinc-400"
+          >
+            Recent error logs (last 24h)
+          </h2>
+          {cwUrl?.url ? (
+            <a
+              href={cwUrl.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-sky-300 hover:underline"
+            >
+              {"Open full search in CloudWatch \u2192"}
+            </a>
+          ) : null}
+        </div>
+
+        {logs.error ? (
+          <ErrorBanner error={logs.error} source="CloudWatch" />
+        ) : null}
+
+        {logs.missing ? (
+          <EmptyState
+            title="No log group"
+            body="The backend log group is not yet created. Run a request to populate it."
+          />
+        ) : logEntries.length === 0 ? (
+          <EmptyState
+            title="No errors in the last 24h"
+            body="The user hasn't hit any backend errors recently."
+          />
+        ) : (
+          <div className="space-y-1.5">
+            {logEntries.slice(0, 20).map((entry, i) => (
+              <LogRow
+                key={`${entry.timestamp}-${entry.correlation_id ?? i}`}
+                entry={entry}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* --- PostHog timeline ------------------------------------------ */}
+      <section aria-labelledby="posthog-heading" className="space-y-3">
+        <h2
+          id="posthog-heading"
+          className="text-sm font-medium uppercase tracking-wide text-zinc-400"
+        >
+          PostHog timeline
+        </h2>
+
+        {posthog.stubbed ? (
+          <ErrorBanner
+            error="POSTHOG_PROJECT_API_KEY not configured."
+            variant="warning"
+            source="PostHog"
+          />
+        ) : null}
+
+        {posthog.error ? (
+          <ErrorBanner error={posthog.error} source="PostHog" />
+        ) : null}
+
+        {!posthog.stubbed && posthog.missing ? (
+          <EmptyState
+            title="No PostHog activity recorded"
+            body="This user may not have visited the frontend yet."
+          />
+        ) : !posthog.stubbed && posthogEvents.length === 0 ? (
+          <EmptyState
+            title="No recent events"
+            body="No PostHog events captured for this user in the recent window."
+          />
+        ) : (
+          <ul className="space-y-1.5">
+            {posthogEvents.map((evt, i) => (
+              <li
+                key={`${evt.timestamp ?? "ts"}-${i}`}
+                className="rounded-md border border-white/5 bg-white/[0.02] px-3 py-2 text-xs"
+              >
+                <div className="flex items-center gap-3">
+                  <time
+                    className="font-mono text-zinc-400"
+                    dateTime={evt.timestamp ?? ""}
+                  >
+                    {evt.timestamp ?? "\u2014"}
+                  </time>
+                  <span className="font-semibold text-zinc-100">
+                    {evt.event ?? "(unnamed)"}
+                  </span>
+                  {evt.session_id ? (
+                    <a
+                      href={`${posthogHost()}/replay/${encodeURIComponent(evt.session_id)}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-auto text-sky-300 hover:underline"
+                    >
+                      {"Watch session \u2192"}
+                    </a>
+                  ) : null}
+                </div>
+                <PropertiesDetails properties={evt.properties} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/AgentActionsFooter.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/AgentActionsFooter.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import { ConfirmActionDialog } from "@/components/admin/ConfirmActionDialog";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { Button } from "@/components/ui/button";
+import { clearAgentSessions, deleteAgent } from "@/app/admin/_actions/agent";
+
+export interface AgentActionsFooterProps {
+  userId: string;
+  agentId: string;
+}
+
+/**
+ * Client island for the destructive agent actions. Lives next to the parent
+ * SC so the page itself stays server-rendered. Both actions are wrapped in
+ * the typed-confirmation dialog (CEO S5) — the dialog enforces the typed
+ * phrase and the 3-attempt lockout. We surface backend errors inline rather
+ * than throwing so the SC stays mounted.
+ */
+export function AgentActionsFooter({ userId, agentId }: AgentActionsFooterProps) {
+  const router = useRouter();
+  const [error, setError] = React.useState<string | null>(null);
+  const [notice, setNotice] = React.useState<string | null>(null);
+
+  // Plain async handlers — React Compiler memoizes them and avoids the
+  // "preserve manual memoization" linter friction useCallback would trigger.
+  async function handleDelete() {
+    setError(null);
+    setNotice(null);
+    const result = await deleteAgent(userId, agentId);
+    if (!result.ok) {
+      setError(result.error ?? "delete_failed");
+      return;
+    }
+    // Successful delete invalidates the detail route — bounce back to the list.
+    router.push(`/admin/users/${encodeURIComponent(userId)}/agents`);
+    router.refresh();
+  }
+
+  async function handleClear() {
+    setError(null);
+    setNotice(null);
+    const result = await clearAgentSessions(userId, agentId);
+    if (!result.ok) {
+      setError(result.error ?? "clear_sessions_failed");
+      return;
+    }
+    setNotice("Sessions cleared.");
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+      <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+        Destructive actions
+      </h2>
+      {error ? <ErrorBanner error={error} variant="error" /> : null}
+      {notice ? <ErrorBanner error={notice} variant="info" /> : null}
+      <div className="flex flex-wrap gap-2">
+        <ConfirmActionDialog
+          confirmText={agentId}
+          actionLabel="Delete agent"
+          destructive
+          onConfirm={handleDelete}
+        >
+          <Button type="button" variant="destructive" size="sm">
+            Delete agent
+          </Button>
+        </ConfirmActionDialog>
+
+        <ConfirmActionDialog
+          confirmText={agentId}
+          actionLabel="Clear sessions"
+          onConfirm={handleClear}
+        >
+          <Button type="button" variant="outline" size="sm">
+            Clear sessions
+          </Button>
+        </ConfirmActionDialog>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/page.tsx
@@ -1,0 +1,323 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+
+import { CodeBlock } from "@/components/admin/CodeBlock";
+import { EmptyState } from "@/components/admin/EmptyState";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { getAgentDetail } from "@/app/admin/_lib/api";
+
+import { AgentActionsFooter } from "./AgentActionsFooter";
+
+export const metadata = { title: "Agent detail \u00b7 Admin" };
+
+interface PageProps {
+  params: Promise<{ id: string; agent_id: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Local narrowing of `AgentDetail` (intentionally permissive in the shared
+// client). We pluck typed fields out per-section so the JSX below stays
+// readable.
+// ---------------------------------------------------------------------------
+
+interface AgentMeta {
+  agent_id?: string;
+  name?: string;
+  owner_id?: string;
+  model?: string;
+  tier?: string;
+  last_active?: string;
+}
+
+interface SkillRow {
+  name: string;
+  version: string;
+  source: string;
+}
+
+interface SessionRow {
+  timestamp: string;
+  status: string;
+  excerpt: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function toAgentMeta(raw: unknown): AgentMeta {
+  const r = asRecord(raw);
+  return {
+    agent_id: asString(r.agent_id) ?? asString(r.id),
+    name: asString(r.name) ?? asString(r.display_name),
+    owner_id: asString(r.owner_id) ?? asString(r.user_id),
+    model: asString(r.model) ?? asString(r.model_id),
+    tier: asString(r.tier) ?? asString(r.plan_tier),
+    last_active: asString(r.last_active) ?? asString(r.updated_at),
+  };
+}
+
+function toSkillRow(raw: unknown): SkillRow {
+  const r = asRecord(raw);
+  return {
+    name: asString(r.name) ?? asString(r.id) ?? "\u2014",
+    version: asString(r.version) ?? "\u2014",
+    source: asString(r.source) ?? asString(r.origin) ?? "\u2014",
+  };
+}
+
+function toSessionRow(raw: unknown): SessionRow {
+  const r = asRecord(raw);
+  return {
+    timestamp:
+      asString(r.timestamp) ??
+      asString(r.created_at) ??
+      asString(r.started_at) ??
+      "\u2014",
+    status: asString(r.status) ?? asString(r.state) ?? "\u2014",
+    excerpt:
+      asString(r.last_message_excerpt) ??
+      asString(r.excerpt) ??
+      asString(r.preview) ??
+      "",
+  };
+}
+
+export default async function AdminAgentDetailPage({ params }: PageProps) {
+  const { id, agent_id: agentId } = await params;
+
+  const { getToken } = await auth();
+  const token = await getToken();
+  const detail = token ? await getAgentDetail(token, id, agentId) : null;
+
+  if (!detail) {
+    return (
+      <div className="space-y-6">
+        <Header userId={id} agentId={agentId} title={agentId} />
+        <ErrorBanner error="Agent detail unreachable" variant="error" />
+      </div>
+    );
+  }
+
+  if (detail.error === "container_not_running") {
+    return (
+      <div className="space-y-6">
+        <Header userId={id} agentId={agentId} title={agentId} />
+        <EmptyState
+          title="Container is stopped"
+          body="Start the user's container to view this agent's detail."
+          action={{
+            label: "Open container tab",
+            href: `/admin/users/${encodeURIComponent(id)}/container`,
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (detail.error) {
+    return (
+      <div className="space-y-6">
+        <Header userId={id} agentId={agentId} title={agentId} />
+        <ErrorBanner error={detail.error} source="OpenClaw" variant="error" />
+      </div>
+    );
+  }
+
+  const meta = toAgentMeta(detail.agent);
+  const skills = asArray(detail.skills).map(toSkillRow);
+  const sessions = asArray(detail.sessions).slice(0, 20).map(toSessionRow);
+  const config = detail.config_redacted;
+
+  return (
+    <div className="space-y-6">
+      <Header
+        userId={id}
+        agentId={agentId}
+        title={meta.name ?? agentId}
+        subtitle={meta.model}
+        lastActive={meta.last_active}
+      />
+
+      {/* Identity */}
+      <section className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          Identity
+        </h2>
+        <dl className="grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+          <DefRow label="Agent ID" value={meta.agent_id ?? agentId} mono />
+          <DefRow label="Owner ID" value={meta.owner_id ?? id} mono />
+          <DefRow label="Model" value={meta.model ?? "\u2014"} mono />
+          <DefRow label="Tier" value={meta.tier ?? "\u2014"} />
+        </dl>
+      </section>
+
+      {/* Skills */}
+      <section className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          Skills
+        </h2>
+        {skills.length === 0 ? (
+          <p className="text-sm text-zinc-500">No skills installed.</p>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-white/5">
+            <table className="w-full table-fixed text-xs">
+              <thead className="bg-zinc-900 text-left text-zinc-400">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Name</th>
+                  <th className="w-32 px-3 py-2 font-medium">Version</th>
+                  <th className="w-40 px-3 py-2 font-medium">Source</th>
+                </tr>
+              </thead>
+              <tbody>
+                {skills.map((skill, i) => (
+                  <tr key={`${skill.name}-${i}`} className="border-t border-white/5">
+                    <td className="truncate px-3 py-2 text-zinc-200" title={skill.name}>
+                      {skill.name}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-zinc-300">{skill.version}</td>
+                    <td className="px-3 py-2 font-mono text-zinc-400">{skill.source}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Config */}
+      <section className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          openclaw.json (secrets redacted)
+        </h2>
+        {config === undefined || config === null ? (
+          <p className="text-sm text-zinc-500">Config unavailable.</p>
+        ) : (
+          <CodeBlock
+            value={
+              typeof config === "string"
+                ? config
+                : (config as object)
+            }
+            language="json"
+            maxHeight={500}
+          />
+        )}
+      </section>
+
+      {/* Recent sessions */}
+      <section className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          Recent sessions (top 20)
+        </h2>
+        {sessions.length === 0 ? (
+          <p className="text-sm text-zinc-500">No recent sessions.</p>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-white/5">
+            <table className="w-full table-fixed text-xs">
+              <thead className="bg-zinc-900 text-left text-zinc-400">
+                <tr>
+                  <th className="w-48 px-3 py-2 font-medium">Timestamp</th>
+                  <th className="w-28 px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Last message</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sessions.map((session, i) => (
+                  <tr key={`${session.timestamp}-${i}`} className="border-t border-white/5 align-top">
+                    <td className="px-3 py-2 font-mono text-zinc-300">{session.timestamp}</td>
+                    <td className="px-3 py-2 text-zinc-300">{session.status}</td>
+                    <td className="px-3 py-2 text-zinc-200" title={session.excerpt}>
+                      {session.excerpt
+                        ? session.excerpt.length > 120
+                          ? `${session.excerpt.slice(0, 120)}\u2026`
+                          : session.excerpt
+                        : "\u2014"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Destructive actions footer */}
+      <AgentActionsFooter userId={id} agentId={agentId} />
+    </div>
+  );
+}
+
+function Header({
+  userId,
+  agentId,
+  title,
+  subtitle,
+  lastActive,
+}: {
+  userId: string;
+  agentId: string;
+  title: string;
+  subtitle?: string;
+  lastActive?: string;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="space-y-1">
+        <p className="text-xs uppercase tracking-wide text-zinc-500">
+          <Link
+            href={`/admin/users/${encodeURIComponent(userId)}/agents`}
+            className="text-sky-300 hover:underline"
+          >
+            Agents
+          </Link>
+          <span className="mx-2 text-zinc-600">/</span>
+          <span className="font-mono text-zinc-400">{agentId}</span>
+        </p>
+        <h1 className="text-2xl font-semibold text-zinc-100">{title}</h1>
+        {subtitle ? (
+          <p className="font-mono text-xs text-zinc-400">{subtitle}</p>
+        ) : null}
+      </div>
+      <div className="text-right text-xs text-zinc-500">
+        {lastActive ? (
+          <>
+            <span className="block uppercase tracking-wide">Last active</span>
+            <span className="font-mono text-zinc-300">{lastActive}</span>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function DefRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <dt className="w-28 shrink-0 text-xs uppercase tracking-wide text-zinc-500">
+        {label}
+      </dt>
+      <dd className={mono ? "truncate font-mono text-zinc-200" : "truncate text-zinc-200"} title={value}>
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/agents/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/agents/page.tsx
@@ -1,0 +1,190 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+
+import { EmptyState } from "@/components/admin/EmptyState";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { listAgents, type AgentSummary } from "@/app/admin/_lib/api";
+
+export const metadata = { title: "Agents \u00b7 Admin" };
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ cursor?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Local narrowing — `AgentSummary` from the shared API client is intentionally
+// permissive (`unknown`/index signature). The list view reads a small set of
+// well-known fields; we pick them out here so the JSX doesn't need casts.
+// ---------------------------------------------------------------------------
+interface AgentRow {
+  agent_id: string;
+  name: string;
+  model: string;
+  skills_count: number;
+  last_active: string | null;
+  sessions_count: number;
+}
+
+function pickString(source: AgentSummary, ...keys: string[]): string | null {
+  for (const k of keys) {
+    const v = source[k];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return null;
+}
+
+function pickNumber(source: AgentSummary, ...keys: string[]): number | null {
+  for (const k of keys) {
+    const v = source[k];
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+    if (Array.isArray(v)) return v.length;
+  }
+  return null;
+}
+
+function toRow(raw: AgentSummary, fallbackId: string): AgentRow {
+  const id = pickString(raw, "agent_id", "id") ?? fallbackId;
+  return {
+    agent_id: id,
+    name: pickString(raw, "name", "display_name") ?? id,
+    model: pickString(raw, "model", "model_id") ?? "\u2014",
+    skills_count: pickNumber(raw, "skills_count", "skills") ?? 0,
+    last_active: pickString(raw, "last_active", "last_active_at", "updated_at"),
+    sessions_count: pickNumber(raw, "sessions_count", "sessions") ?? 0,
+  };
+}
+
+export default async function AdminUserAgentsPage({ params, searchParams }: PageProps) {
+  const { id } = await params;
+  const { cursor } = await searchParams;
+
+  const { getToken } = await auth();
+  const token = await getToken();
+  const result = token
+    ? await listAgents(token, id, cursor, 50)
+    : { agents: [], cursor: null, container_status: "unknown" as string };
+
+  // Container in a non-running state — render explanatory empty/error states
+  // rather than an empty table (CEO U1).
+  if (result.container_status === "stopped") {
+    return (
+      <div className="space-y-6">
+        <Header />
+        <EmptyState
+          title="Container is stopped"
+          body="The user's container is not running. Start it first to see their agents."
+          action={{
+            label: "Open container tab",
+            href: `/admin/users/${encodeURIComponent(id)}/container`,
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (result.container_status === "none") {
+    return (
+      <div className="space-y-6">
+        <Header />
+        <EmptyState
+          title="No container provisioned"
+          body="This user hasn't provisioned a container yet."
+        />
+      </div>
+    );
+  }
+
+  if (result.container_status === "timeout" || result.container_status === "error") {
+    return (
+      <div className="space-y-6">
+        <Header />
+        <ErrorBanner
+          error={result.error || "Gateway RPC failed"}
+          source="OpenClaw"
+          variant="error"
+        />
+      </div>
+    );
+  }
+
+  if (result.agents.length === 0) {
+    return (
+      <div className="space-y-6">
+        <Header />
+        <EmptyState title="No agents yet" body="The user hasn't created any agents." />
+      </div>
+    );
+  }
+
+  const rows = result.agents.map((raw, i) => toRow(raw, `agent-${i}`));
+
+  return (
+    <div className="space-y-6">
+      <Header />
+      <div className="overflow-hidden rounded-md border border-white/10">
+        <table className="w-full table-fixed text-sm">
+          <thead className="bg-zinc-900 text-left text-xs uppercase tracking-wide text-zinc-400">
+            <tr>
+              <th className="px-3 py-2 font-medium">Name</th>
+              <th className="w-48 px-3 py-2 font-medium">Model</th>
+              <th className="w-20 px-3 py-2 font-medium">Skills</th>
+              <th className="w-44 px-3 py-2 font-medium">Last active</th>
+              <th className="w-24 px-3 py-2 font-medium">Sessions</th>
+              <th className="w-20 px-3 py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={row.agent_id}
+                className="border-t border-white/5 align-top text-zinc-200"
+              >
+                <td className="truncate px-3 py-2" title={row.name}>
+                  {row.name}
+                </td>
+                <td className="truncate px-3 py-2 font-mono text-xs text-zinc-300" title={row.model}>
+                  {row.model}
+                </td>
+                <td className="px-3 py-2 font-mono text-xs text-zinc-300">
+                  {row.skills_count}
+                </td>
+                <td className="px-3 py-2 font-mono text-xs text-zinc-400">
+                  {row.last_active ?? "\u2014"}
+                </td>
+                <td className="px-3 py-2 font-mono text-xs text-zinc-300">
+                  {row.sessions_count}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  <Link
+                    href={`/admin/users/${encodeURIComponent(id)}/agents/${encodeURIComponent(row.agent_id)}`}
+                    className="text-sky-300 hover:underline"
+                  >
+                    View
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {result.cursor ? (
+        <div className="flex justify-center">
+          <Link
+            href={`/admin/users/${encodeURIComponent(id)}/agents?cursor=${encodeURIComponent(result.cursor)}`}
+            className="rounded-md border border-white/10 bg-white/[0.02] px-4 py-2 text-sm text-zinc-200 hover:bg-white/[0.04]"
+          >
+            Load more
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// User-id breadcrumb is provided by the parent layout — render only the
+// section heading here so the title doesn't duplicate.
+function Header() {
+  return <h1 className="text-xl font-semibold text-zinc-100">Agents</h1>;
+}

--- a/apps/frontend/src/app/admin/users/[id]/billing/BillingActionsPanel.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/billing/BillingActionsPanel.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import { ConfirmActionDialog } from "@/components/admin/ConfirmActionDialog";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  cancelSubscription,
+  issueCredit,
+  markInvoiceResolved,
+  pauseSubscription,
+} from "@/app/admin/_actions/billing";
+
+export interface BillingActionsPanelProps {
+  userId: string;
+  /** Primary email for the user — required because the destructive confirms type-check against it. */
+  email: string | null;
+}
+
+/**
+ * Client island for the per-user billing actions. Each destructive action is
+ * gated by the typed-confirmation dialog (CEO S5). The credit + invoice
+ * actions need a small inline form; we render the input as a sibling of the
+ * trigger and snapshot its value when the user opens the dialog.
+ */
+export function BillingActionsPanel({ userId, email }: BillingActionsPanelProps) {
+  const router = useRouter();
+  const [error, setError] = React.useState<string | null>(null);
+  const [notice, setNotice] = React.useState<string | null>(null);
+
+  const [creditAmount, setCreditAmount] = React.useState("");
+  const [creditReason, setCreditReason] = React.useState("");
+  const [invoiceId, setInvoiceId] = React.useState("");
+
+  // Without an email we can't enforce the typed-confirmation gate the way the
+  // spec requires. Surface the constraint instead of silently degrading.
+  const noEmailWarning =
+    email && email.length > 0 ? null : (
+      <ErrorBanner
+        error="No primary email on file — destructive subscription actions are disabled until Clerk reports one."
+        variant="warning"
+      />
+    );
+
+  function clearStatus() {
+    setError(null);
+    setNotice(null);
+  }
+
+  function applyResult(label: string, ok: boolean, errMsg?: string) {
+    if (ok) {
+      setNotice(`${label} succeeded.`);
+      router.refresh();
+    } else {
+      setError(`${label} failed: ${errMsg ?? "unknown_error"}`);
+    }
+  }
+
+  // Handlers are plain async functions — React Compiler handles memoization
+  // automatically and keeps the local closures readable (no manual deps array
+  // to maintain when state references change).
+  async function handleCancel() {
+    clearStatus();
+    const result = await cancelSubscription(userId);
+    applyResult("Cancel subscription", result.ok, result.error);
+  }
+
+  async function handlePause() {
+    clearStatus();
+    const result = await pauseSubscription(userId);
+    applyResult("Pause subscription", result.ok, result.error);
+  }
+
+  async function handleCredit() {
+    clearStatus();
+    const cents = Math.round(Number(creditAmount));
+    if (!Number.isFinite(cents) || cents <= 0) {
+      setError("Issue credit failed: amount must be a positive integer (cents).");
+      return;
+    }
+    if (creditReason.trim().length === 0) {
+      setError("Issue credit failed: reason is required.");
+      return;
+    }
+    const result = await issueCredit(userId, cents, creditReason.trim());
+    if (result.ok) {
+      setNotice("Credit issued.");
+      setCreditAmount("");
+      setCreditReason("");
+      router.refresh();
+    } else {
+      setError(`Issue credit failed: ${result.error ?? "unknown_error"}`);
+    }
+  }
+
+  async function handleInvoice() {
+    clearStatus();
+    const id = invoiceId.trim();
+    if (id.length === 0) {
+      setError("Mark invoice resolved failed: invoice_id is required.");
+      return;
+    }
+    const result = await markInvoiceResolved(userId, id);
+    if (result.ok) {
+      setNotice(`Invoice ${id} marked resolved.`);
+      setInvoiceId("");
+      router.refresh();
+    } else {
+      setError(`Mark invoice resolved failed: ${result.error ?? "unknown_error"}`);
+    }
+  }
+
+  const subscriptionConfirm = email ?? `${userId}-no-email`;
+  const subscriptionDisabled = !email;
+
+  return (
+    <div className="space-y-4 rounded-md border border-white/10 bg-white/[0.02] p-4">
+      <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+        Billing actions
+      </h2>
+      {noEmailWarning}
+      {error ? <ErrorBanner error={error} variant="error" /> : null}
+      {notice ? <ErrorBanner error={notice} variant="info" /> : null}
+
+      {/* Subscription lifecycle */}
+      <div className="flex flex-wrap gap-2">
+        <ConfirmActionDialog
+          confirmText={subscriptionConfirm}
+          actionLabel="Cancel subscription"
+          destructive
+          onConfirm={handleCancel}
+        >
+          <Button type="button" variant="destructive" size="sm" disabled={subscriptionDisabled}>
+            Cancel subscription
+          </Button>
+        </ConfirmActionDialog>
+        <ConfirmActionDialog
+          confirmText={subscriptionConfirm}
+          actionLabel="Pause subscription"
+          onConfirm={handlePause}
+        >
+          <Button type="button" variant="outline" size="sm" disabled={subscriptionDisabled}>
+            Pause subscription
+          </Button>
+        </ConfirmActionDialog>
+      </div>
+
+      {/* Issue credit */}
+      <div className="space-y-2 rounded-md border border-white/5 bg-white/[0.01] p-3">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-zinc-500">
+          Issue credit
+        </h3>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-[160px_1fr_auto]">
+          <Input
+            type="number"
+            min={1}
+            step={1}
+            placeholder="amount (cents)"
+            value={creditAmount}
+            onChange={(e) => setCreditAmount(e.target.value)}
+            aria-label="Credit amount in cents"
+          />
+          <Input
+            type="text"
+            placeholder="reason (audited)"
+            value={creditReason}
+            onChange={(e) => setCreditReason(e.target.value)}
+            aria-label="Credit reason"
+          />
+          <ConfirmActionDialog
+            confirmText={userId}
+            actionLabel="Issue credit"
+            onConfirm={handleCredit}
+          >
+            <Button
+              type="button"
+              variant="default"
+              size="sm"
+              disabled={creditAmount.length === 0 || creditReason.trim().length === 0}
+            >
+              Issue credit
+            </Button>
+          </ConfirmActionDialog>
+        </div>
+      </div>
+
+      {/* Mark invoice resolved */}
+      <div className="space-y-2 rounded-md border border-white/5 bg-white/[0.01] p-3">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-zinc-500">
+          Mark invoice resolved
+        </h3>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto]">
+          <Input
+            type="text"
+            placeholder="in_..."
+            value={invoiceId}
+            onChange={(e) => setInvoiceId(e.target.value)}
+            aria-label="Stripe invoice id"
+          />
+          <ConfirmActionDialog
+            confirmText={userId}
+            actionLabel="Mark invoice resolved"
+            onConfirm={handleInvoice}
+          >
+            <Button
+              type="button"
+              variant="default"
+              size="sm"
+              disabled={invoiceId.trim().length === 0}
+            >
+              Mark resolved
+            </Button>
+          </ConfirmActionDialog>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/billing/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/billing/page.tsx
@@ -1,0 +1,242 @@
+import { auth } from "@clerk/nextjs/server";
+
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { getOverview } from "@/app/admin/_lib/api";
+
+import { BillingActionsPanel } from "./BillingActionsPanel";
+
+export const metadata = { title: "Billing \u00b7 Admin" };
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Local narrowing of the (intentionally permissive) overview slices.
+// ---------------------------------------------------------------------------
+
+interface BillingSlice {
+  plan_tier?: string;
+  stripe_customer_id?: string;
+  stripe_subscription_id?: string;
+  subscription_status?: string;
+  current_period_end?: string;
+  current_invoice?: {
+    id?: string;
+    amount_due_cents?: number;
+    status?: string;
+    hosted_invoice_url?: string;
+  };
+  error?: string;
+  source?: string;
+}
+
+interface IdentitySlice {
+  email_addresses?: Array<{ email_address?: string }>;
+  primary_email_address_id?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function pickBilling(raw: unknown): BillingSlice {
+  const r = asRecord(raw);
+  const inv = asRecord(r.current_invoice);
+  return {
+    plan_tier: asString(r.plan_tier),
+    stripe_customer_id: asString(r.stripe_customer_id),
+    stripe_subscription_id: asString(r.stripe_subscription_id),
+    subscription_status: asString(r.subscription_status) ?? asString(r.status),
+    current_period_end: asString(r.current_period_end),
+    current_invoice:
+      Object.keys(inv).length === 0
+        ? undefined
+        : {
+            id: asString(inv.id),
+            amount_due_cents: asNumber(inv.amount_due_cents),
+            status: asString(inv.status),
+            hosted_invoice_url: asString(inv.hosted_invoice_url),
+          },
+    error: asString(r.error),
+    source: asString(r.source),
+  };
+}
+
+function pickIdentityEmail(raw: unknown): string | null {
+  const r = asRecord(raw) as IdentitySlice;
+  const list = r.email_addresses ?? [];
+  if (!Array.isArray(list) || list.length === 0) return null;
+  const first = list[0];
+  return asString(first?.email_address) ?? null;
+}
+
+function formatCents(cents: number | undefined): string {
+  if (cents === undefined) return "\u2014";
+  const dollars = (cents / 100).toFixed(2);
+  return `$${dollars}`;
+}
+
+export default async function AdminUserBillingPage({ params }: PageProps) {
+  const { id } = await params;
+
+  const { getToken } = await auth();
+  const token = await getToken();
+  const overview = token ? await getOverview(token, id) : null;
+
+  if (!overview) {
+    return (
+      <div className="space-y-6">
+        <Header />
+        <ErrorBanner error="Billing overview unreachable" variant="error" />
+      </div>
+    );
+  }
+
+  const billing = pickBilling(overview.billing);
+  const email = pickIdentityEmail(overview.identity);
+  const billingError = billing.error;
+
+  return (
+    <div className="space-y-6">
+      <Header />
+
+      {billingError ? (
+        <ErrorBanner
+          error={billingError}
+          source={billing.source ?? "Stripe"}
+          variant="error"
+        />
+      ) : null}
+
+      {/* Billing card */}
+      <section className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          Subscription
+        </h2>
+        <dl className="grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+          <DefRow label="Plan tier" value={billing.plan_tier ?? "\u2014"} />
+          <DefRow
+            label="Status"
+            value={billing.subscription_status ?? "\u2014"}
+          />
+          <DefRow
+            label="Stripe customer"
+            value={billing.stripe_customer_id ?? "\u2014"}
+            mono
+            href={
+              billing.stripe_customer_id
+                ? `https://dashboard.stripe.com/customers/${encodeURIComponent(billing.stripe_customer_id)}`
+                : undefined
+            }
+          />
+          <DefRow
+            label="Stripe subscription"
+            value={billing.stripe_subscription_id ?? "\u2014"}
+            mono
+            href={
+              billing.stripe_subscription_id
+                ? `https://dashboard.stripe.com/subscriptions/${encodeURIComponent(billing.stripe_subscription_id)}`
+                : undefined
+            }
+          />
+          <DefRow
+            label="Period end"
+            value={billing.current_period_end ?? "\u2014"}
+            mono
+          />
+        </dl>
+      </section>
+
+      {/* Current invoice */}
+      <section className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+          Current invoice
+        </h2>
+        {billing.current_invoice ? (
+          <dl className="grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+            <DefRow
+              label="Invoice ID"
+              value={billing.current_invoice.id ?? "\u2014"}
+              mono
+              href={billing.current_invoice.hosted_invoice_url}
+            />
+            <DefRow
+              label="Status"
+              value={billing.current_invoice.status ?? "\u2014"}
+            />
+            <DefRow
+              label="Amount due"
+              value={formatCents(billing.current_invoice.amount_due_cents)}
+              mono
+            />
+          </dl>
+        ) : (
+          <p className="text-sm text-zinc-500">No active invoice.</p>
+        )}
+      </section>
+
+      {/* Actions */}
+      <BillingActionsPanel userId={id} email={email} />
+    </div>
+  );
+}
+
+// User-id breadcrumb is provided by the parent layout — render only the
+// section heading here so the title doesn't duplicate.
+function Header() {
+  return <h1 className="text-xl font-semibold text-zinc-100">Billing</h1>;
+}
+
+function DefRow({
+  label,
+  value,
+  mono,
+  href,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  href?: string;
+}) {
+  const content = (
+    <span
+      className={mono ? "truncate font-mono text-zinc-200" : "truncate text-zinc-200"}
+      title={value}
+    >
+      {value}
+    </span>
+  );
+  return (
+    <div className="flex items-baseline gap-3">
+      <dt className="w-36 shrink-0 text-xs uppercase tracking-wide text-zinc-500">
+        {label}
+      </dt>
+      <dd className="min-w-0 flex-1">
+        {href ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block truncate text-sky-300 hover:underline"
+            title={value}
+          >
+            {content}
+          </a>
+        ) : (
+          content
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/container/ContainerActionsPanel.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/container/ContainerActionsPanel.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import { ConfirmActionDialog } from "@/components/admin/ConfirmActionDialog";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { Button } from "@/components/ui/button";
+import {
+  reprovisionContainer,
+  resizeContainer,
+  startContainer,
+  stopContainer,
+} from "@/app/admin/_actions/container";
+
+const TIERS = ["free", "starter", "pro", "enterprise"] as const;
+type Tier = (typeof TIERS)[number];
+
+export interface ContainerActionsPanelProps {
+  userId: string;
+  /** Current plan tier — pre-selects the resize dropdown so the operator only changes one thing. */
+  currentTier?: string;
+}
+
+/**
+ * Client island for the per-user container lifecycle actions. The four
+ * non-resize actions all use the user_id as the typed-confirm phrase
+ * (CEO S5). Resize additionally requires picking a target tier in a small
+ * inline form before opening the confirm dialog.
+ */
+export function ContainerActionsPanel({ userId, currentTier }: ContainerActionsPanelProps) {
+  const router = useRouter();
+  const [error, setError] = React.useState<string | null>(null);
+  const [notice, setNotice] = React.useState<string | null>(null);
+  const [tier, setTier] = React.useState<Tier>(() => {
+    if (currentTier && (TIERS as readonly string[]).includes(currentTier)) {
+      return currentTier as Tier;
+    }
+    return "starter";
+  });
+
+  function clearStatus() {
+    setError(null);
+    setNotice(null);
+  }
+
+  function applyResult(label: string, ok: boolean, errMsg?: string) {
+    if (ok) {
+      setNotice(`${label} succeeded.`);
+      router.refresh();
+    } else {
+      setError(`${label} failed: ${errMsg ?? "unknown_error"}`);
+    }
+  }
+
+  // Handlers are plain async functions — React Compiler memoizes them. Manual
+  // useCallback would require listing applyResult/clearStatus in deps which
+  // tangles with the linter's "preserve manual memoization" rule.
+  async function handleReprovision() {
+    clearStatus();
+    const result = await reprovisionContainer(userId);
+    applyResult("Reprovision", result.ok, result.error);
+  }
+
+  async function handleStop() {
+    clearStatus();
+    const result = await stopContainer(userId);
+    applyResult("Stop", result.ok, result.error);
+  }
+
+  async function handleStart() {
+    clearStatus();
+    const result = await startContainer(userId);
+    applyResult("Start", result.ok, result.error);
+  }
+
+  async function handleResize() {
+    clearStatus();
+    const result = await resizeContainer(userId, tier);
+    applyResult(`Resize to ${tier}`, result.ok, result.error);
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+      <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+        Container actions
+      </h2>
+      {error ? <ErrorBanner error={error} variant="error" /> : null}
+      {notice ? <ErrorBanner error={notice} variant="info" /> : null}
+
+      {/* Lifecycle */}
+      <div className="flex flex-wrap gap-2">
+        <ConfirmActionDialog
+          confirmText={userId}
+          actionLabel="Reprovision container"
+          destructive
+          onConfirm={handleReprovision}
+        >
+          <Button type="button" variant="destructive" size="sm">
+            Reprovision
+          </Button>
+        </ConfirmActionDialog>
+        <ConfirmActionDialog
+          confirmText={userId}
+          actionLabel="Stop container"
+          destructive
+          onConfirm={handleStop}
+        >
+          <Button type="button" variant="destructive" size="sm">
+            Stop
+          </Button>
+        </ConfirmActionDialog>
+        <ConfirmActionDialog
+          confirmText={userId}
+          actionLabel="Start container"
+          onConfirm={handleStart}
+        >
+          <Button type="button" variant="outline" size="sm">
+            Start
+          </Button>
+        </ConfirmActionDialog>
+      </div>
+
+      {/* Resize */}
+      <div className="space-y-2 rounded-md border border-white/5 bg-white/[0.01] p-3">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-zinc-500">
+          Resize container
+        </h3>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="text-xs text-zinc-400" htmlFor="resize-tier">
+            Target tier
+          </label>
+          <select
+            id="resize-tier"
+            value={tier}
+            onChange={(e) => setTier(e.target.value as Tier)}
+            className="h-9 rounded-md border border-input bg-background px-3 text-sm text-zinc-100"
+          >
+            {TIERS.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+          <ConfirmActionDialog
+            confirmText={userId}
+            actionLabel={`Resize to ${tier}`}
+            onConfirm={handleResize}
+          >
+            <Button type="button" variant="default" size="sm">
+              Resize
+            </Button>
+          </ConfirmActionDialog>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/container/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/container/page.tsx
@@ -1,0 +1,224 @@
+import { auth } from "@clerk/nextjs/server";
+
+import { EmptyState } from "@/components/admin/EmptyState";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { getOverview } from "@/app/admin/_lib/api";
+
+import { ContainerActionsPanel } from "./ContainerActionsPanel";
+
+export const metadata = { title: "Container \u00b7 Admin" };
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+interface ContainerSlice {
+  status?: string;
+  task_arn?: string;
+  service_name?: string;
+  cluster_name?: string;
+  cluster_arn?: string;
+  access_point_id?: string;
+  plan_tier?: string;
+  created_at?: string;
+  updated_at?: string;
+  error?: string;
+  source?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function pickContainer(raw: unknown): { container: ContainerSlice | null; raw: Record<string, unknown> } {
+  const r = asRecord(raw);
+  if (Object.keys(r).length === 0) return { container: null, raw: r };
+  // Backend may return `{ error, source }` on timeout — surface as a slice
+  // with no other fields so the page can still render the error banner.
+  return {
+    container: {
+      status: asString(r.status),
+      task_arn: asString(r.task_arn),
+      service_name: asString(r.service_name),
+      cluster_name: asString(r.cluster_name),
+      cluster_arn: asString(r.cluster_arn),
+      access_point_id: asString(r.access_point_id),
+      plan_tier: asString(r.plan_tier),
+      created_at: asString(r.created_at),
+      updated_at: asString(r.updated_at),
+      error: asString(r.error),
+      source: asString(r.source),
+    },
+    raw: r,
+  };
+}
+
+function statusChipClasses(status?: string): string {
+  switch (status) {
+    case "running":
+      return "bg-emerald-500/15 text-emerald-300 border-emerald-500/30";
+    case "provisioning":
+    case "starting":
+      return "bg-sky-500/15 text-sky-300 border-sky-500/30";
+    case "stopped":
+    case "scaled_to_zero":
+      return "bg-amber-500/15 text-amber-300 border-amber-500/30";
+    case "error":
+    case "failed":
+    case "unreachable":
+      return "bg-red-500/15 text-red-300 border-red-500/30";
+    default:
+      return "bg-zinc-500/15 text-zinc-300 border-zinc-500/30";
+  }
+}
+
+/**
+ * Build an ECS console deep-link for the user's container task.
+ *
+ * The cluster name component of the URL is best-effort: backend rows store
+ * just `cluster_arn` in some cases. We extract the trailing segment when an
+ * ARN is present and fall back to a generic console link otherwise so the
+ * operator can still pivot.
+ */
+function buildEcsConsoleUrl(c: ContainerSlice): string | null {
+  if (!c.task_arn) return null;
+  const region = "us-east-1";
+  const cluster =
+    c.cluster_name ??
+    (c.cluster_arn ? c.cluster_arn.split("/").pop() : undefined);
+  if (cluster && c.service_name) {
+    return `https://${region}.console.aws.amazon.com/ecs/v2/clusters/${encodeURIComponent(cluster)}/services/${encodeURIComponent(c.service_name)}/tasks?region=${region}`;
+  }
+  return `https://${region}.console.aws.amazon.com/ecs/v2/clusters?region=${region}`;
+}
+
+export default async function AdminUserContainerPage({ params }: PageProps) {
+  const { id } = await params;
+
+  const { getToken } = await auth();
+  const token = await getToken();
+  const overview = token ? await getOverview(token, id) : null;
+
+  if (!overview) {
+    return (
+      <div className="space-y-6">
+        <Header />
+        <ErrorBanner error="Container overview unreachable" variant="error" />
+      </div>
+    );
+  }
+
+  const { container } = pickContainer(overview.container);
+
+  if (!container) {
+    return (
+      <div className="space-y-6">
+        <Header />
+        <EmptyState
+          title="No container"
+          body="This user has no provisioned container."
+        />
+      </div>
+    );
+  }
+
+  const ecsUrl = buildEcsConsoleUrl(container);
+
+  return (
+    <div className="space-y-6">
+      <Header />
+
+      {container.error ? (
+        <ErrorBanner
+          error={container.error}
+          source={container.source ?? "DynamoDB"}
+          variant="error"
+        />
+      ) : null}
+
+      {/* Container metadata */}
+      <section className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
+            Container
+          </h2>
+          <span
+            className={`rounded border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusChipClasses(container.status)}`}
+          >
+            {container.status ?? "unknown"}
+          </span>
+        </div>
+        <dl className="grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+          <DefRow label="Plan tier" value={container.plan_tier ?? "\u2014"} />
+          <DefRow label="Service name" value={container.service_name ?? "\u2014"} mono />
+          <DefRow
+            label="Task ARN"
+            value={container.task_arn ?? "\u2014"}
+            mono
+            href={ecsUrl ?? undefined}
+          />
+          <DefRow
+            label="Access point"
+            value={container.access_point_id ?? "\u2014"}
+            mono
+          />
+          <DefRow label="Created" value={container.created_at ?? "\u2014"} mono />
+          <DefRow label="Updated" value={container.updated_at ?? "\u2014"} mono />
+        </dl>
+      </section>
+
+      {/* Actions */}
+      <ContainerActionsPanel userId={id} currentTier={container.plan_tier} />
+    </div>
+  );
+}
+
+// User-id breadcrumb is provided by the parent layout — render only the
+// section heading here so the title doesn't duplicate.
+function Header() {
+  return <h1 className="text-xl font-semibold text-zinc-100">Container</h1>;
+}
+
+function DefRow({
+  label,
+  value,
+  mono,
+  href,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  href?: string;
+}) {
+  const cls = mono ? "truncate font-mono text-zinc-200" : "truncate text-zinc-200";
+  return (
+    <div className="flex items-baseline gap-3">
+      <dt className="w-32 shrink-0 text-xs uppercase tracking-wide text-zinc-500">
+        {label}
+      </dt>
+      <dd className="min-w-0 flex-1">
+        {href ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`block ${cls} text-sky-300 hover:underline`}
+            title={value}
+          >
+            {value}
+          </a>
+        ) : (
+          <span className={cls} title={value}>
+            {value}
+          </span>
+        )}
+      </dd>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/layout.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/layout.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+import { UserTabs, type UserTab } from "./UserTabs";
+
+const TABS: UserTab[] = [
+  { label: "Overview", segment: "" },
+  { label: "Agents", segment: "agents" },
+  { label: "Billing", segment: "billing" },
+  { label: "Container", segment: "container" },
+  { label: "Activity", segment: "activity" },
+  { label: "Actions", segment: "actions" },
+];
+
+interface UserLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+}
+
+export default async function UserLayout({ children, params }: UserLayoutProps) {
+  const { id } = await params;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <div className="text-xs text-zinc-500">
+          <Link href="/admin/users" className="hover:text-zinc-300">
+            Users
+          </Link>
+          <span className="mx-2 text-zinc-600">/</span>
+          <span className="font-mono text-zinc-300">{id}</span>
+        </div>
+        <h1 className="font-mono text-lg text-zinc-100" title={id}>
+          {id}
+        </h1>
+      </div>
+
+      <UserTabs userId={id} tabs={TABS} />
+
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/logs/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/logs/page.tsx
@@ -1,0 +1,218 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+
+import { getCloudwatchUrl, getLogs } from "@/app/admin/_lib/api";
+import { EmptyState } from "@/components/admin/EmptyState";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { LogRow, type LogEntry } from "@/components/admin/LogRow";
+
+export const metadata = { title: "Logs \u00b7 Admin" };
+
+// ---------------------------------------------------------------------------
+// Filter dimensions
+// ---------------------------------------------------------------------------
+
+const ALLOWED_LEVELS = ["ERROR", "WARN", "INFO"] as const;
+type LogLevel = (typeof ALLOWED_LEVELS)[number];
+
+const HOURS_OPTIONS = [
+  { value: 1, label: "1h" },
+  { value: 24, label: "24h" },
+  { value: 168, label: "7d" },
+] as const;
+
+function parseLevel(input: string | string[] | undefined): LogLevel {
+  const v = Array.isArray(input) ? input[0] : input;
+  if (v && (ALLOWED_LEVELS as readonly string[]).includes(v.toUpperCase())) {
+    return v.toUpperCase() as LogLevel;
+  }
+  return "ERROR";
+}
+
+function parseHours(input: string | string[] | undefined): number {
+  const v = Array.isArray(input) ? input[0] : input;
+  const n = Number(v);
+  if (Number.isFinite(n) && HOURS_OPTIONS.some((o) => o.value === n)) return n;
+  return 24;
+}
+
+function parseCursor(input: string | string[] | undefined): string | undefined {
+  const v = Array.isArray(input) ? input[0] : input;
+  return v && v.length > 0 ? v : undefined;
+}
+
+function asLogEntry(raw: unknown): LogEntry {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  return {
+    timestamp: typeof r.timestamp === "string" ? r.timestamp : "",
+    level:
+      typeof r.level === "string" || r.level === null
+        ? (r.level as LogEntry["level"])
+        : null,
+    message: typeof r.message === "string" ? r.message : "",
+    correlation_id:
+      typeof r.correlation_id === "string" ? r.correlation_id : null,
+    raw_json:
+      r.raw_json && typeof r.raw_json === "object"
+        ? (r.raw_json as Record<string, unknown>)
+        : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Filter form (server-rendered)
+//
+// `<form method="GET" action="/admin/users/{id}/logs">` keeps the page a
+// pure Server Component — no "use client" needed for the filter UI. URL is
+// the source of truth, so deep-linked filters / browser back work for free.
+// ---------------------------------------------------------------------------
+
+interface LogsFiltersProps {
+  userId: string;
+  level: LogLevel;
+  hours: number;
+}
+
+function LogsFilters({ userId, level, hours }: LogsFiltersProps) {
+  return (
+    <form
+      method="GET"
+      action={`/admin/users/${encodeURIComponent(userId)}/logs`}
+      className="flex flex-wrap items-end gap-3 rounded-md border border-white/5 bg-white/[0.02] p-3"
+    >
+      <label className="flex flex-col gap-1 text-xs text-zinc-400">
+        Level
+        <select
+          name="level"
+          defaultValue={level}
+          className="rounded-md border border-white/10 bg-zinc-900 px-2 py-1.5 text-sm text-zinc-100"
+        >
+          {ALLOWED_LEVELS.map((lvl) => (
+            <option key={lvl} value={lvl}>
+              {lvl}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs text-zinc-400">
+        Time window
+        <select
+          name="hours"
+          defaultValue={String(hours)}
+          className="rounded-md border border-white/10 bg-zinc-900 px-2 py-1.5 text-sm text-zinc-100"
+        >
+          {HOURS_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <button
+        type="submit"
+        className="h-9 rounded-md border border-white/10 bg-white/[0.04] px-4 text-sm text-zinc-100 hover:bg-white/[0.08]"
+      >
+        Apply
+      </button>
+    </form>
+  );
+}
+
+interface LogsPageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function LogsPage({ params, searchParams }: LogsPageProps) {
+  const { id } = await params;
+  const sp = await searchParams;
+  const level = parseLevel(sp.level);
+  const hours = parseHours(sp.hours);
+  const cursor = parseCursor(sp.cursor);
+
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (!token) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-xl font-semibold text-zinc-100">Logs</h1>
+        <ErrorBanner error="Missing Clerk session token." />
+      </div>
+    );
+  }
+
+  const end = new Date();
+  const start = new Date(end.getTime() - hours * 3_600_000);
+
+  const [logs, cwUrl] = await Promise.all([
+    getLogs(token, id, { level, hours, limit: 50, cursor }),
+    getCloudwatchUrl(token, id, start.toISOString(), end.toISOString(), level),
+  ]);
+
+  const entries = (logs.events ?? []).map(asLogEntry);
+
+  // Build the next-page link, preserving level + hours.
+  const nextCursorHref = logs.cursor
+    ? `/admin/users/${encodeURIComponent(id)}/logs?level=${encodeURIComponent(level)}&hours=${hours}&cursor=${encodeURIComponent(logs.cursor)}`
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-baseline justify-between">
+        <h1 className="text-xl font-semibold text-zinc-100">Logs</h1>
+        {cwUrl?.url ? (
+          <a
+            href={cwUrl.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-sky-300 hover:underline"
+          >
+            {"Open full search in CloudWatch \u2192"}
+          </a>
+        ) : null}
+      </div>
+
+      <LogsFilters userId={id} level={level} hours={hours} />
+
+      {logs.error ? (
+        <ErrorBanner error={logs.error} source="CloudWatch" />
+      ) : null}
+
+      {logs.missing ? (
+        <EmptyState
+          title="No log group"
+          body="The backend log group does not exist yet — typically because no
+            requests have run in this environment. The group is auto-created on
+            the first request."
+        />
+      ) : entries.length === 0 ? (
+        <EmptyState
+          title="No matching log entries"
+          body="No log lines match the current level + window. Widen the window or change the level to see more."
+        />
+      ) : (
+        <div className="space-y-1.5">
+          {entries.map((entry, i) => (
+            <LogRow
+              key={`${entry.timestamp}-${entry.correlation_id ?? i}`}
+              entry={entry}
+            />
+          ))}
+        </div>
+      )}
+
+      {nextCursorHref ? (
+        <div className="flex justify-center">
+          <Link
+            href={nextCursorHref}
+            className="rounded-md border border-white/10 bg-white/[0.04] px-4 py-2 text-sm text-zinc-100 hover:bg-white/[0.08]"
+          >
+            Load more
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/users/[id]/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/page.tsx
@@ -1,0 +1,390 @@
+import { auth } from "@clerk/nextjs/server";
+
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import { getOverview } from "@/app/admin/_lib/api";
+
+export const metadata = { title: "Overview \u00b7 Admin" };
+
+// ---------------------------------------------------------------------------
+// Section payload shapes (narrowed locally — `UserOverview.identity` etc.
+// are typed as `unknown` in the shared API client so the SC stays robust if
+// the backend evolves).
+// ---------------------------------------------------------------------------
+
+interface ErrorPayload {
+  error?: string;
+  source?: string;
+}
+
+interface ClerkIdentity extends ErrorPayload {
+  id?: string;
+  email_addresses?: Array<{ email_address?: string }>;
+  first_name?: string | null;
+  last_name?: string | null;
+  created_at?: number | string | null;
+  last_sign_in_at?: number | string | null;
+  banned?: boolean;
+}
+
+interface BillingRow extends ErrorPayload {
+  plan_tier?: string;
+  stripe_customer_id?: string;
+  stripe_subscription_id?: string | null;
+  overage_enabled?: boolean;
+}
+
+interface ContainerRow extends ErrorPayload {
+  status?: string;
+  task_arn?: string | null;
+  service_name?: string | null;
+  plan_tier?: string;
+  created_at?: number | string | null;
+}
+
+interface UsageRow extends ErrorPayload {
+  total_spend_microdollars?: number;
+  total_input_tokens?: number;
+  total_output_tokens?: number;
+  total_cache_read_tokens?: number;
+  total_cache_write_tokens?: number;
+  period?: string;
+}
+
+const CONTAINER_STATUS_CLASSES: Record<string, string> = {
+  running: "bg-emerald-500/15 text-emerald-300",
+  provisioning: "bg-sky-500/15 text-sky-300",
+  stopped: "bg-zinc-500/15 text-zinc-300",
+  error: "bg-red-500/15 text-red-300",
+};
+
+function statusClass(status?: string): string {
+  if (!status) return "bg-zinc-500/15 text-zinc-400";
+  return CONTAINER_STATUS_CLASSES[status] ?? "bg-zinc-500/15 text-zinc-400";
+}
+
+function hasError(
+  value: unknown,
+): value is { error: string; source?: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "error" in value &&
+    typeof (value as { error?: unknown }).error === "string"
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function formatDateValue(value: number | string | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "\u2014";
+  if (typeof value === "number") {
+    try {
+      return new Date(value).toISOString().replace("T", " ").slice(0, 19) + "Z";
+    } catch {
+      return String(value);
+    }
+  }
+  return value;
+}
+
+/**
+ * Format microdollars as USD. 1_000_000 microdollars = $1.00.
+ * `microdollars` here is the unit used by usage_repo (CEO billing convention).
+ */
+function formatUsd(microdollars?: number): string {
+  if (microdollars === undefined || microdollars === null) return "$0.00";
+  const dollars = microdollars / 1_000_000;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(dollars);
+}
+
+interface UserOverviewPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function UserOverviewPage({ params }: UserOverviewPageProps) {
+  const { id } = await params;
+  const { getToken } = await auth();
+  const token = await getToken();
+  const overview = token ? await getOverview(token, id) : null;
+
+  if (!overview) {
+    return (
+      <ErrorBanner error="Overview endpoint unreachable" variant="error" />
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <IdentityCard identity={overview.identity} />
+      <BillingCard billing={overview.billing} />
+      <ContainerCard container={overview.container} />
+      <UsageCard usage={overview.usage} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cards
+// ---------------------------------------------------------------------------
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-md border border-white/10 bg-white/[0.02] p-4">
+      <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-zinc-400">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-3 border-t border-white/5 py-1.5 first:border-t-0">
+      <span className="text-xs text-zinc-400">{label}</span>
+      <span className="max-w-[60%] truncate text-right text-sm text-zinc-100">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function IdentityCard({ identity }: { identity: unknown }) {
+  if (!isPlainObject(identity)) {
+    return (
+      <Card title="Identity">
+        <ErrorBanner error="No identity data available." source="Clerk" />
+      </Card>
+    );
+  }
+  if (hasError(identity)) {
+    return (
+      <Card title="Identity">
+        <ErrorBanner error={identity.error ?? "Unknown error"} source="Clerk" />
+      </Card>
+    );
+  }
+
+  const data = identity as ClerkIdentity;
+  const email = data.email_addresses?.[0]?.email_address ?? null;
+  const fullName = [data.first_name, data.last_name].filter(Boolean).join(" ");
+
+  return (
+    <Card title="Identity">
+      <div className="space-y-0">
+        <Field
+          label="Email"
+          value={email ?? <span className="text-zinc-500">(none)</span>}
+        />
+        <Field
+          label="Name"
+          value={fullName || <span className="text-zinc-500">(none)</span>}
+        />
+        <Field label="Created" value={<span className="font-mono text-xs">{formatDateValue(data.created_at)}</span>} />
+        <Field
+          label="Last sign-in"
+          value={<span className="font-mono text-xs">{formatDateValue(data.last_sign_in_at)}</span>}
+        />
+        <Field
+          label="Banned"
+          value={
+            data.banned ? (
+              <span className="rounded bg-red-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-red-300">
+                Yes
+              </span>
+            ) : (
+              <span className="text-xs text-zinc-500">No</span>
+            )
+          }
+        />
+      </div>
+    </Card>
+  );
+}
+
+function BillingCard({ billing }: { billing: unknown }) {
+  if (!isPlainObject(billing)) {
+    return (
+      <Card title="Billing">
+        <p className="text-sm text-zinc-500">No billing record.</p>
+      </Card>
+    );
+  }
+  if (hasError(billing)) {
+    return (
+      <Card title="Billing">
+        <ErrorBanner
+          error={billing.error ?? "Unknown error"}
+          source={billing.source ?? "DynamoDB"}
+        />
+      </Card>
+    );
+  }
+
+  const data = billing as BillingRow;
+  return (
+    <Card title="Billing">
+      <div className="space-y-0">
+        <Field label="Plan" value={data.plan_tier ?? <span className="text-zinc-500">(unknown)</span>} />
+        <Field
+          label="Stripe customer"
+          value={
+            data.stripe_customer_id ? (
+              <a
+                href={`https://dashboard.stripe.com/customers/${encodeURIComponent(data.stripe_customer_id)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-xs text-sky-300 hover:underline"
+                title={data.stripe_customer_id}
+              >
+                {data.stripe_customer_id}
+              </a>
+            ) : (
+              <span className="text-zinc-500">(none)</span>
+            )
+          }
+        />
+        <Field
+          label="Subscription"
+          value={
+            data.stripe_subscription_id ? (
+              <span className="font-mono text-xs" title={data.stripe_subscription_id}>
+                {data.stripe_subscription_id}
+              </span>
+            ) : (
+              <span className="text-zinc-500">(none)</span>
+            )
+          }
+        />
+      </div>
+    </Card>
+  );
+}
+
+function ContainerCard({ container }: { container: unknown }) {
+  if (!isPlainObject(container)) {
+    return (
+      <Card title="Container">
+        <p className="text-sm text-zinc-500">No container provisioned yet.</p>
+      </Card>
+    );
+  }
+  if (hasError(container)) {
+    return (
+      <Card title="Container">
+        <ErrorBanner
+          error={container.error ?? "Unknown error"}
+          source={container.source ?? "DynamoDB"}
+        />
+      </Card>
+    );
+  }
+
+  const data = container as ContainerRow;
+  return (
+    <Card title="Container">
+      <div className="space-y-0">
+        <Field
+          label="Status"
+          value={
+            <span
+              className={`rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusClass(data.status)}`}
+            >
+              {data.status ?? "unknown"}
+            </span>
+          }
+        />
+        <Field label="Plan" value={data.plan_tier ?? <span className="text-zinc-500">(unknown)</span>} />
+        <Field
+          label="Service"
+          value={
+            data.service_name ? (
+              <span className="font-mono text-xs" title={data.service_name}>
+                {data.service_name}
+              </span>
+            ) : (
+              <span className="text-zinc-500">(none)</span>
+            )
+          }
+        />
+        <Field
+          label="Task ARN"
+          value={
+            data.task_arn ? (
+              <span className="font-mono text-xs" title={data.task_arn}>
+                {data.task_arn}
+              </span>
+            ) : (
+              <span className="text-zinc-500">(none)</span>
+            )
+          }
+        />
+        <Field
+          label="Created"
+          value={<span className="font-mono text-xs">{formatDateValue(data.created_at)}</span>}
+        />
+      </div>
+    </Card>
+  );
+}
+
+function UsageCard({ usage }: { usage: unknown }) {
+  if (!isPlainObject(usage)) {
+    return (
+      <Card title="Usage">
+        <p className="text-sm text-zinc-500">No usage data.</p>
+      </Card>
+    );
+  }
+  if (hasError(usage)) {
+    return (
+      <Card title="Usage">
+        <ErrorBanner
+          error={usage.error ?? "Unknown error"}
+          source={usage.source ?? "DynamoDB"}
+        />
+      </Card>
+    );
+  }
+
+  const data = usage as UsageRow;
+  const totalTokens =
+    (data.total_input_tokens ?? 0) +
+    (data.total_output_tokens ?? 0) +
+    (data.total_cache_read_tokens ?? 0) +
+    (data.total_cache_write_tokens ?? 0);
+
+  return (
+    <Card title="Usage">
+      <div className="space-y-0">
+        <Field
+          label="Period"
+          value={data.period ?? <span className="text-zinc-500">current</span>}
+        />
+        <Field
+          label="Spend"
+          value={<span className="font-mono">{formatUsd(data.total_spend_microdollars)}</span>}
+        />
+        <Field
+          label="Tokens (total)"
+          value={<span className="font-mono">{totalTokens.toLocaleString()}</span>}
+        />
+        <Field
+          label="Input tokens"
+          value={<span className="font-mono">{(data.total_input_tokens ?? 0).toLocaleString()}</span>}
+        />
+        <Field
+          label="Output tokens"
+          value={<span className="font-mono">{(data.total_output_tokens ?? 0).toLocaleString()}</span>}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/apps/frontend/src/app/admin/users/page.tsx
+++ b/apps/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,170 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+
+import { EmptyState } from "@/components/admin/EmptyState";
+import { ErrorBanner } from "@/components/admin/ErrorBanner";
+import {
+  listUsers,
+  type UserDirectoryRow,
+  type UsersPage as UsersPageData,
+} from "@/app/admin/_lib/api";
+
+import { UsersClientHeader } from "./UsersClientHeader";
+
+export const metadata = { title: "Users \u00b7 Admin" };
+
+const CONTAINER_STATUS_CLASSES: Record<string, string> = {
+  running: "bg-emerald-500/15 text-emerald-300",
+  provisioning: "bg-sky-500/15 text-sky-300",
+  stopped: "bg-zinc-500/15 text-zinc-300",
+  error: "bg-red-500/15 text-red-300",
+  unknown: "bg-zinc-500/15 text-zinc-400",
+};
+
+function statusClass(status: string): string {
+  return CONTAINER_STATUS_CLASSES[status] ?? CONTAINER_STATUS_CLASSES.unknown;
+}
+
+function truncateId(id: string, head = 12): string {
+  if (id.length <= head) return id;
+  return `${id.slice(0, head)}\u2026`;
+}
+
+function formatTimestamp(value: number | string | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "\u2014";
+  // Clerk timestamps come as numeric ms-since-epoch. DDB rows may store
+  // ISO strings. Render either gracefully.
+  if (typeof value === "number") {
+    try {
+      return new Date(value).toISOString().slice(0, 10);
+    } catch {
+      return String(value);
+    }
+  }
+  return value;
+}
+
+interface UsersPageProps {
+  searchParams: Promise<{ q?: string; cursor?: string }>;
+}
+
+export default async function UsersPage({ searchParams }: UsersPageProps) {
+  const params = await searchParams;
+  const { getToken } = await auth();
+  const token = await getToken();
+  const result: UsersPageData = token
+    ? await listUsers(token, params.q, params.cursor)
+    : { users: [], cursor: null, stubbed: false };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-zinc-100">Users</h1>
+      </div>
+
+      <UsersClientHeader defaultValue={params.q} />
+
+      {result.stubbed ? (
+        <ErrorBanner
+          error="Clerk Backend API key not configured \u2014 list is stubbed."
+          variant="warning"
+        />
+      ) : null}
+
+      {result.users.length === 0 ? (
+        params.q ? (
+          <EmptyState
+            title="No users match your search"
+            body="Try a different email or Clerk ID."
+          />
+        ) : (
+          <EmptyState
+            title="No users yet"
+            body="Once a user signs up, they'll appear here."
+          />
+        )
+      ) : (
+        <UsersTable users={result.users} />
+      )}
+
+      {result.cursor ? (
+        <div className="flex justify-center">
+          <Link
+            href={{
+              pathname: "/admin/users",
+              query: params.q
+                ? { cursor: result.cursor, q: params.q }
+                : { cursor: result.cursor },
+            }}
+            className="rounded-md border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-zinc-200 hover:bg-zinc-800"
+          >
+            Load more
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function UsersTable({ users }: { users: UserDirectoryRow[] }) {
+  return (
+    <div className="overflow-hidden rounded-md border border-white/10">
+      <table className="w-full text-sm">
+        <thead className="bg-zinc-900 text-left text-xs uppercase tracking-wide text-zinc-400">
+          <tr>
+            <th className="px-3 py-2 font-medium">Email</th>
+            <th className="px-3 py-2 font-medium">Clerk ID</th>
+            <th className="px-3 py-2 font-medium">Plan</th>
+            <th className="px-3 py-2 font-medium">Container</th>
+            <th className="px-3 py-2 font-medium">Signup</th>
+            <th className="px-3 py-2 font-medium">Last sign-in</th>
+            <th className="px-3 py-2 font-medium">Banned</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr
+              key={u.clerk_id}
+              className="border-t border-white/5 transition-colors hover:bg-white/[0.03]"
+            >
+              <td className="px-3 py-2">
+                <Link
+                  href={`/admin/users/${encodeURIComponent(u.clerk_id)}`}
+                  className="text-sky-300 hover:underline"
+                >
+                  {u.email ?? <span className="text-zinc-500">(no email)</span>}
+                </Link>
+              </td>
+              <td className="px-3 py-2 font-mono text-xs text-zinc-300" title={u.clerk_id}>
+                {truncateId(u.clerk_id)}
+              </td>
+              <td className="px-3 py-2 text-zinc-300">{u.plan_tier}</td>
+              <td className="px-3 py-2">
+                <span
+                  className={`rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusClass(u.container_status)}`}
+                >
+                  {u.container_status}
+                </span>
+              </td>
+              <td className="px-3 py-2 font-mono text-xs text-zinc-300">
+                {formatTimestamp(u.created_at)}
+              </td>
+              <td className="px-3 py-2 font-mono text-xs text-zinc-300">
+                {formatTimestamp(u.last_sign_in_at)}
+              </td>
+              <td className="px-3 py-2">
+                {u.banned ? (
+                  <span className="rounded bg-red-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-red-300">
+                    Yes
+                  </span>
+                ) : (
+                  <span className="text-xs text-zinc-500">No</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/admin/AuditRow.tsx
+++ b/apps/frontend/src/components/admin/AuditRow.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface AuditEntry {
+  admin_user_id: string;
+  /** Composite sort key: `{ISO8601}#{ulid}`. */
+  timestamp_action_id: string;
+  target_user_id: string;
+  /** Dotted action name, e.g. `container.reprovision`. */
+  action: string;
+  result: "success" | "error";
+  audit_status?: "written" | "panic";
+  http_status: number;
+  elapsed_ms: number;
+  error_message?: string;
+}
+
+export interface AuditRowProps {
+  entry: AuditEntry;
+  /** Optional row click handler; renders the row as a button when present. */
+  onClick?: () => void;
+}
+
+function splitTimestamp(compositeKey: string): string {
+  const hashIdx = compositeKey.indexOf("#");
+  return hashIdx === -1 ? compositeKey : compositeKey.slice(0, hashIdx);
+}
+
+/**
+ * One row of the admin audit log table. Server-Component-friendly.
+ */
+export function AuditRow({ entry, onClick }: AuditRowProps) {
+  const timestamp = splitTimestamp(entry.timestamp_action_id);
+  const isPanic = entry.audit_status === "panic";
+  const isError = entry.result === "error";
+
+  const Wrapper: React.ElementType = onClick ? "button" : "div";
+
+  return (
+    <Wrapper
+      type={onClick ? "button" : undefined}
+      onClick={onClick}
+      title={`HTTP ${entry.http_status} \u00b7 ${entry.elapsed_ms}ms${entry.error_message ? ` \u00b7 ${entry.error_message}` : ""}`}
+      className={cn(
+        "grid w-full grid-cols-[180px_minmax(180px,1fr)_minmax(160px,1fr)_auto_auto] items-center gap-3 rounded-md border border-white/5 bg-white/[0.02] px-3 py-2 text-left text-xs",
+        onClick && "cursor-pointer transition-colors hover:bg-white/[0.04]",
+      )}
+      data-result={entry.result}
+      data-audit-status={entry.audit_status ?? "written"}
+    >
+      <time className="font-mono text-zinc-400" dateTime={timestamp}>
+        {timestamp}
+      </time>
+      <span className="truncate font-mono text-zinc-100">{entry.action}</span>
+      <span className="truncate text-zinc-300">{entry.target_user_id}</span>
+      <span
+        className={cn(
+          "rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+          isError
+            ? "bg-red-500/15 text-red-300"
+            : "bg-emerald-500/15 text-emerald-300",
+        )}
+      >
+        {entry.result}
+      </span>
+      {isPanic ? (
+        <span
+          className="rounded bg-yellow-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-300"
+          title="Audit row failed to write to DynamoDB; see CloudWatch"
+        >
+          {"audit panic \u2014 see CloudWatch"}
+        </span>
+      ) : (
+        <span aria-hidden="true" />
+      )}
+    </Wrapper>
+  );
+}

--- a/apps/frontend/src/components/admin/CodeBlock.tsx
+++ b/apps/frontend/src/components/admin/CodeBlock.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface CodeBlockProps {
+  /** JSON object (pretty-printed) or a raw string. */
+  value: object | string;
+  /** Hint for highlighting. JSON gets bold-key treatment; others render plain. */
+  language?: "json" | "yaml" | "text";
+  /** Max visible height in pixels before scrolling. Defaults to 400. */
+  maxHeight?: number;
+  className?: string;
+}
+
+// Match JSON object keys at the start of a line: indent, "key", optional space, ":".
+// Operates on the post-escape string so the quote chars are &quot;. Keys with
+// embedded quote characters are uncommon; keep this regex simple and targeted.
+const KEY_PATTERN = /^(\s*)(&quot;[^&\n]*?&quot;)(\s*:)/gm;
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderJsonHighlighted(jsonText: string): string {
+  // Bold object keys only. Pure HTML-string approach keeps this server-safe
+  // and avoids pulling in a syntax highlighter just for "make keys bold".
+  const escaped = escapeHtml(jsonText);
+  return escaped.replace(
+    KEY_PATTERN,
+    (_match, indent: string, key: string, colon: string) =>
+      `${indent}<span class="font-semibold text-sky-300">${key}</span>${colon}`,
+  );
+}
+
+/**
+ * Read-only code/JSON viewer with bold-key highlighting for JSON. Used to
+ * render redacted `openclaw.json` and similar config blobs on admin pages.
+ */
+export function CodeBlock({
+  value,
+  language = "json",
+  maxHeight = 400,
+  className,
+}: CodeBlockProps) {
+  const text =
+    typeof value === "string" ? value : JSON.stringify(value, null, 2);
+
+  const isJson = language === "json" && typeof value !== "string";
+
+  return (
+    <div
+      className={cn(
+        "overflow-auto rounded-md border border-white/10 bg-zinc-950 p-4",
+        className,
+      )}
+      style={{ maxHeight }}
+      data-language={language}
+    >
+      <pre className="m-0 whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-zinc-100">
+        {isJson ? (
+          <code
+            // We escape input above and only inject our own <span> tags.
+            dangerouslySetInnerHTML={{ __html: renderJsonHighlighted(text) }}
+          />
+        ) : (
+          <code>{text}</code>
+        )}
+      </pre>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/admin/ConfirmActionDialog.tsx
+++ b/apps/frontend/src/components/admin/ConfirmActionDialog.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export interface ConfirmActionDialogProps {
+  /** The exact string the user must type to enable confirmation. */
+  confirmText: string;
+  /** Human-readable label for the destructive/sensitive action, used in the heading and ARIA label. */
+  actionLabel: string;
+  /** When true, the confirm button uses destructive (red) styling. */
+  destructive?: boolean;
+  /** Async callback fired after the user types the correct confirmation string and clicks confirm. */
+  onConfirm: () => Promise<void> | void;
+  /** Trigger element (typically a button) that opens the dialog. */
+  children: React.ReactNode;
+}
+
+const MAX_WRONG_ATTEMPTS = 3;
+
+/**
+ * Confirmation dialog requiring the operator to type a literal phrase before
+ * a destructive action can fire. Implements the CEO S5 lockout policy:
+ * after 3 wrong attempts, the dialog locks until the page is reloaded.
+ */
+export function ConfirmActionDialog({
+  confirmText,
+  actionLabel,
+  destructive = false,
+  onConfirm,
+  children,
+}: ConfirmActionDialogProps) {
+  const [open, setOpen] = React.useState(false);
+  const [typed, setTyped] = React.useState("");
+  const [wrongAttempts, setWrongAttempts] = React.useState(0);
+  const [busy, setBusy] = React.useState(false);
+
+  const locked = wrongAttempts >= MAX_WRONG_ATTEMPTS;
+  const matches = typed === confirmText;
+  // Confirm is enabled once any text is typed so a wrong submission counts
+  // toward the 3-attempt lockout; matches-only enabling would make the
+  // lockout unreachable. The click handler validates the value.
+  const confirmDisabled = locked || busy || typed.length === 0;
+
+  // Reset typed/error state on close (lockout persists for component lifetime).
+  function handleOpenChange(next: boolean) {
+    if (busy) return;
+    setOpen(next);
+    if (!next) {
+      setTyped("");
+    }
+  }
+
+  async function handleConfirm(event: React.MouseEvent<HTMLButtonElement>) {
+    // Always prevent the default Radix close-on-action; we manage open state
+    // manually so async work can finish before the dialog disappears.
+    event.preventDefault();
+
+    if (locked || busy) return;
+
+    if (!matches) {
+      setWrongAttempts((n) => n + 1);
+      return;
+    }
+
+    setBusy(true);
+    try {
+      await onConfirm();
+      setOpen(false);
+      setTyped("");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{actionLabel}</AlertDialogTitle>
+          <AlertDialogDescription>
+            Type{" "}
+            <span className="font-mono font-semibold text-white">
+              {confirmText}
+            </span>{" "}
+            below to confirm.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {locked ? (
+          <p
+            role="alert"
+            className="rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-200"
+          >
+            Locked. Reload the page to try again.
+          </p>
+        ) : (
+          <Input
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            placeholder={confirmText}
+            autoComplete="off"
+            spellCheck={false}
+            disabled={busy}
+            aria-label={`Type ${confirmText} to confirm`}
+          />
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={confirmDisabled}
+            aria-busy={busy}
+            aria-label={`Confirm ${actionLabel}`}
+            className={cn(
+              destructive &&
+                "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20",
+            )}
+          >
+            {busy ? "Working\u2026" : actionLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/frontend/src/components/admin/EmptyState.tsx
+++ b/apps/frontend/src/components/admin/EmptyState.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface EmptyStateAction {
+  label: string;
+  /** If provided, the action renders as a Next.js `<Link>`. */
+  href?: string;
+  /** Otherwise, the action renders as a `<button>` with this click handler. */
+  onClick?: () => void;
+}
+
+export interface EmptyStateProps {
+  /** Optional decorative icon (e.g. a lucide icon component). */
+  icon?: React.ReactNode;
+  title: string;
+  body: string;
+  action?: EmptyStateAction;
+  className?: string;
+}
+
+/**
+ * Centered empty-state placeholder for "no results" or "day 1, no records yet"
+ * surfaces. Implements the CEO U1 rule: never show a blank table — always
+ * explain the state and (optionally) offer a next step.
+ */
+export function EmptyState({
+  icon,
+  title,
+  body,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex w-full flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-white/10 bg-white/[0.02] px-6 py-16 text-center",
+        className,
+      )}
+    >
+      {icon ? (
+        <div className="text-zinc-500" aria-hidden="true">
+          {icon}
+        </div>
+      ) : null}
+      <h2 className="text-lg font-semibold text-white">{title}</h2>
+      <p className="max-w-md text-sm text-zinc-400">{body}</p>
+      {action ? (
+        action.href ? (
+          <Button asChild variant="outline" size="sm">
+            <Link href={action.href}>{action.label}</Link>
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={action.onClick}
+          >
+            {action.label}
+          </Button>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/admin/ErrorBanner.tsx
+++ b/apps/frontend/src/components/admin/ErrorBanner.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import { AlertTriangle, Info, XCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type ErrorBannerVariant = "warning" | "error" | "info";
+
+export interface ErrorBannerProps {
+  /** Human-readable error message. */
+  error: string;
+  /** Optional source label, e.g. `"Stripe"`, `"Clerk"`, `"PostHog"`. */
+  source?: string;
+  /** Color treatment. Defaults to `"error"`. */
+  variant?: ErrorBannerVariant;
+  className?: string;
+}
+
+const VARIANT_CLASSES: Record<ErrorBannerVariant, string> = {
+  error: "border-red-500/40 bg-red-500/10 text-red-200",
+  warning: "border-yellow-500/40 bg-yellow-500/10 text-yellow-200",
+  info: "border-sky-500/40 bg-sky-500/10 text-sky-200",
+};
+
+const VARIANT_ICONS: Record<
+  ErrorBannerVariant,
+  React.ComponentType<{ className?: string }>
+> = {
+  error: XCircle,
+  warning: AlertTriangle,
+  info: Info,
+};
+
+const VARIANT_ROLE: Record<ErrorBannerVariant, "alert" | "status"> = {
+  error: "alert",
+  warning: "alert",
+  info: "status",
+};
+
+/**
+ * Inline banner for surfacing partial-failure messages on admin pages — e.g.
+ * "Stripe lookup timed out, showing cached data" while Clerk and PostHog
+ * sections still render normally.
+ */
+export function ErrorBanner({
+  error,
+  source,
+  variant = "error",
+  className,
+}: ErrorBannerProps) {
+  const Icon = VARIANT_ICONS[variant];
+  return (
+    <div
+      role={VARIANT_ROLE[variant]}
+      className={cn(
+        "flex items-start gap-3 rounded-md border px-3 py-2 text-sm",
+        VARIANT_CLASSES[variant],
+        className,
+      )}
+      data-variant={variant}
+    >
+      <Icon className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+      <div className="flex-1">
+        {source ? (
+          <span className="mr-2 font-semibold">{source}:</span>
+        ) : null}
+        <span>{error}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/admin/LogRow.tsx
+++ b/apps/frontend/src/components/admin/LogRow.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { CodeBlock } from "@/components/admin/CodeBlock";
+
+export interface LogEntry {
+  timestamp: string;
+  level: "ERROR" | "WARN" | "INFO" | "DEBUG" | string | null;
+  message: string;
+  correlation_id?: string | null;
+  raw_json: Record<string, unknown> | null;
+}
+
+export interface LogRowProps {
+  entry: LogEntry;
+}
+
+const MESSAGE_TRUNCATE = 200;
+
+const LEVEL_BADGE_CLASS: Record<string, string> = {
+  ERROR: "bg-red-500/15 text-red-300",
+  WARN: "bg-amber-500/15 text-amber-300",
+  INFO: "bg-sky-500/15 text-sky-300",
+  DEBUG: "bg-zinc-500/15 text-zinc-300",
+};
+
+function levelBadgeClass(level: string | null | undefined): string {
+  if (!level) return LEVEL_BADGE_CLASS.DEBUG;
+  return LEVEL_BADGE_CLASS[level.toUpperCase()] ?? LEVEL_BADGE_CLASS.DEBUG;
+}
+
+function truncate(input: string, max: number): string {
+  if (input.length <= max) return input;
+  return `${input.slice(0, max)}\u2026`;
+}
+
+/**
+ * Expandable log line for the inline CloudWatch viewer on admin pages.
+ * Collapsed by default; clicking reveals the correlation id and full raw JSON.
+ */
+export function LogRow({ entry }: LogRowProps) {
+  const [expanded, setExpanded] = React.useState(false);
+  const truncated = truncate(entry.message, MESSAGE_TRUNCATE);
+  const levelLabel = entry.level ?? "DEBUG";
+
+  return (
+    <div
+      className="rounded-md border border-white/5 bg-white/[0.02]"
+      data-expanded={expanded ? "true" : "false"}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-label={expanded ? "Collapse log entry" : "Expand log entry"}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-white/[0.03]"
+      >
+        {expanded ? (
+          <ChevronDown className="size-3 shrink-0 text-zinc-500" aria-hidden />
+        ) : (
+          <ChevronRight className="size-3 shrink-0 text-zinc-500" aria-hidden />
+        )}
+        <time
+          className="font-mono text-zinc-400"
+          dateTime={entry.timestamp}
+        >
+          {entry.timestamp}
+        </time>
+        <span
+          className={cn(
+            "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+            levelBadgeClass(entry.level),
+          )}
+          data-level={levelLabel}
+        >
+          {levelLabel}
+        </span>
+        <span className="flex-1 truncate font-mono text-zinc-100">
+          {truncated}
+        </span>
+      </button>
+
+      {expanded ? (
+        <div className="space-y-2 border-t border-white/5 px-3 py-3">
+          {entry.correlation_id ? (
+            <div className="text-xs text-zinc-400">
+              <span className="font-semibold text-zinc-300">
+                correlation_id:
+              </span>{" "}
+              <span className="font-mono text-zinc-100">
+                {entry.correlation_id}
+              </span>
+            </div>
+          ) : null}
+          {entry.raw_json ? (
+            <CodeBlock value={entry.raw_json} language="json" maxHeight={320} />
+          ) : (
+            <p className="text-xs italic text-zinc-500">
+              No raw JSON payload.
+            </p>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/admin/UserSearchInput.tsx
+++ b/apps/frontend/src/components/admin/UserSearchInput.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import * as React from "react";
+import { Loader2, Search } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export interface UserSearchInputProps {
+  /** Initial input value (uncontrolled). */
+  defaultValue?: string;
+  /** Fired 300ms after the user stops typing. */
+  onSearch: (query: string) => void;
+  /** Optional spinner toggle controlled by the caller (e.g. while a fetch is in flight). */
+  isLoading?: boolean;
+  placeholder?: string;
+  className?: string;
+}
+
+const DEBOUNCE_MS = 300;
+
+/**
+ * Debounced search input for the admin user directory. The component owns
+ * the input value; the caller owns the loading state for any in-flight fetch
+ * triggered by `onSearch`.
+ */
+export function UserSearchInput({
+  defaultValue = "",
+  onSearch,
+  isLoading = false,
+  placeholder = "Search by email, user ID, or org\u2026",
+  className,
+}: UserSearchInputProps) {
+  const [value, setValue] = React.useState(defaultValue);
+  const onSearchRef = React.useRef(onSearch);
+
+  // Keep the latest callback without retriggering the debounce effect.
+  React.useEffect(() => {
+    onSearchRef.current = onSearch;
+  }, [onSearch]);
+
+  React.useEffect(() => {
+    const handle = setTimeout(() => {
+      onSearchRef.current(value);
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [value]);
+
+  return (
+    <div className={cn("relative w-full", className)}>
+      <Search
+        className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-zinc-500"
+        aria-hidden="true"
+      />
+      <Input
+        type="search"
+        role="searchbox"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={placeholder}
+        className="pl-9 pr-10"
+        aria-label="Search users"
+      />
+      {isLoading ? (
+        <span
+          className="absolute right-3 top-1/2 flex -translate-y-1/2 items-center gap-1 text-xs text-zinc-400"
+          role="status"
+          aria-live="polite"
+        >
+          <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+          {"Searching\u2026"}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -1,8 +1,67 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isProtectedRoute = createRouteMatcher(["/chat(.*)", "/onboarding", "/settings(.*)"]);
 
+const DEFAULT_ADMIN_HOSTS = "admin.isol8.co,admin-dev.isol8.co,admin.localhost:3000";
+
+function parseAdminHosts(raw: string | undefined): Set<string> {
+  const source = raw && raw.length > 0 ? raw : DEFAULT_ADMIN_HOSTS;
+  return new Set(
+    source
+      .split(",")
+      .map((h) => h.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+const ADMIN_HOSTS = parseAdminHosts(process.env.NEXT_PUBLIC_ADMIN_HOSTS);
+
+export type AdminHostDecision =
+  | { kind: "passthrough" }
+  | { kind: "not_found" }
+  | { kind: "redirect"; to: string };
+
+/**
+ * Pure host/path -> decision function for the admin gate. Exported so the
+ * branching logic can be unit-tested without a Next.js request object.
+ *
+ * Defense in depth (CEO A1): unknown hosts hitting `/admin*` get a 404, not a
+ * 403 — we don't want host-header probes to confirm the path even exists.
+ * Conversely, an admin host that strays off `/admin` is funneled back to
+ * `/admin` so admins can't accidentally land on the public app.
+ */
+export function decideAdminHostRouting(
+  host: string | null | undefined,
+  pathname: string,
+  adminHosts: Set<string> = ADMIN_HOSTS,
+): AdminHostDecision {
+  const normalizedHost = (host ?? "").toLowerCase();
+  const isAdminHost = adminHosts.has(normalizedHost);
+  const isAdminPath = pathname === "/admin" || pathname.startsWith("/admin/");
+
+  if (isAdminPath && !isAdminHost) {
+    return { kind: "not_found" };
+  }
+  if (isAdminHost && !isAdminPath) {
+    return { kind: "redirect", to: "/admin" };
+  }
+  return { kind: "passthrough" };
+}
+
 export default clerkMiddleware(async (auth, req) => {
+  const host = req.headers.get("host");
+  const decision = decideAdminHostRouting(host, req.nextUrl.pathname);
+
+  if (decision.kind === "not_found") {
+    return new NextResponse(null, { status: 404 });
+  }
+  if (decision.kind === "redirect") {
+    const url = req.nextUrl.clone();
+    url.pathname = decision.to;
+    return NextResponse.redirect(url);
+  }
+
   const authObj = await auth();
 
   if (isProtectedRoute(req)) {

--- a/apps/frontend/tests/e2e/admin.spec.ts
+++ b/apps/frontend/tests/e2e/admin.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright';
+
+/**
+ * Admin dashboard golden path (#351).
+ *
+ * Skipped by default. The admin host is gated by the host-based middleware in
+ * `src/middleware.ts`, so this spec only makes sense when `BASE_URL` points at
+ * `admin{-dev}.isol8.co`. We also need a real Clerk admin session — until the
+ * admin Vercel domain alias + Cloudflare bypass are in place we cannot drive
+ * this from CI.
+ *
+ * TODO Phase F follow-ups (tracked in docs/runbooks/admin-rollout.md):
+ *   1. DNS + Vercel domain alias for `admin-dev.isol8.co` -> `isol8-frontend-dev`.
+ *   2. Cloudflare bypass + `VERCEL_AUTOMATION_BYPASS_SECRET` for the admin host.
+ *   3. Seed a Clerk test user in `PLATFORM_ADMIN_USER_IDS` and surface its
+ *      credentials via fixtures (similar to `personal.spec.ts`).
+ *   4. Drop the `test.skip(...)` guard once those land. The walk-through below
+ *      should pass against a live admin dev environment.
+ */
+
+test.describe('admin dashboard golden path', () => {
+  test.skip(
+    ({ baseURL }) => !baseURL?.includes('admin'),
+    'Only runs against the admin host (BASE_URL=https://admin-dev.isol8.co).',
+  );
+
+  test('admin can sign in, view a user, fire a read-only action', async ({
+    page,
+  }) => {
+    await clerkSetup();
+    await setupClerkTestingToken({ page });
+
+    // 1. Sign in via Clerk admin token.
+    //    The fixture for an admin Clerk user lives in apps/frontend/tests/e2e/fixtures/.
+    //    For now we just navigate to /sign-in and let the Clerk testing token
+    //    drive the sign-in. Once an admin fixture exists, swap to it here.
+    await page.goto('/sign-in');
+    // TODO: drive sign-in via Clerk admin testing token when fixture lands.
+
+    // 2. Navigate to /admin/users.
+    await page.goto('/admin/users');
+
+    // 3. Expect the user table to render OR the empty state.
+    const heading = page.getByRole('heading', { name: /users/i });
+    await expect(heading).toBeVisible();
+
+    // 4. Click the first user row (or skip if the table is empty).
+    const firstRow = page.getByRole('link').filter({ hasText: /user_/ }).first();
+    if ((await firstRow.count()) === 0) {
+      test.skip(true, 'No users in the directory yet — nothing to drill into.');
+    }
+    await firstRow.click();
+
+    // 5. Expect the Overview tab to render.
+    await expect(page.getByRole('heading', { name: /overview/i })).toBeVisible();
+
+    // 6. Click the Activity tab and assert both sections render.
+    await page.getByRole('link', { name: /activity/i }).click();
+    await expect(page.getByText(/recent error logs/i)).toBeVisible();
+    await expect(page.getByText(/posthog timeline/i)).toBeVisible();
+
+    // 7. Click the Actions tab and assert the page renders.
+    await page.getByRole('link', { name: /actions/i }).click();
+    await expect(page.getByRole('heading', { name: /admin actions/i })).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/unit/admin/middleware.test.ts
+++ b/apps/frontend/tests/unit/admin/middleware.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { decideAdminHostRouting } from '@/middleware';
+
+const ADMIN_HOSTS = new Set([
+  'admin.isol8.co',
+  'admin-dev.isol8.co',
+  'admin.localhost:3000',
+]);
+
+describe('decideAdminHostRouting (admin host gate)', () => {
+  it('passes through when an admin host hits an /admin path', () => {
+    expect(
+      decideAdminHostRouting('admin.isol8.co', '/admin/users', ADMIN_HOSTS),
+    ).toEqual({ kind: 'passthrough' });
+  });
+
+  it('returns 404 for an /admin path on a non-admin host', () => {
+    expect(
+      decideAdminHostRouting('app.isol8.co', '/admin/users', ADMIN_HOSTS),
+    ).toEqual({ kind: 'not_found' });
+  });
+
+  it('redirects to /admin when an admin host requests a non-admin path', () => {
+    expect(
+      decideAdminHostRouting('admin.isol8.co', '/chat', ADMIN_HOSTS),
+    ).toEqual({ kind: 'redirect', to: '/admin' });
+  });
+
+  it('returns 404 for /admin on an unknown random host (defense in depth)', () => {
+    expect(
+      decideAdminHostRouting('attacker.example.com', '/admin', ADMIN_HOSTS),
+    ).toEqual({ kind: 'not_found' });
+  });
+
+  it('allows admin.localhost:3000 (default admin host) for local dev', () => {
+    expect(
+      decideAdminHostRouting('admin.localhost:3000', '/admin/users', ADMIN_HOSTS),
+    ).toEqual({ kind: 'passthrough' });
+  });
+
+  it('treats null/missing host as non-admin (404 on /admin)', () => {
+    expect(
+      decideAdminHostRouting(null, '/admin/users', ADMIN_HOSTS),
+    ).toEqual({ kind: 'not_found' });
+  });
+
+  it('passes through public hosts on public paths', () => {
+    expect(
+      decideAdminHostRouting('app.isol8.co', '/chat', ADMIN_HOSTS),
+    ).toEqual({ kind: 'passthrough' });
+  });
+
+  it('matches /admin exactly (not just prefix-with-extra-letters)', () => {
+    // /administrator should NOT be treated as an admin path
+    expect(
+      decideAdminHostRouting('app.isol8.co', '/administrator', ADMIN_HOSTS),
+    ).toEqual({ kind: 'passthrough' });
+  });
+
+  it('is case-insensitive on host comparison', () => {
+    expect(
+      decideAdminHostRouting('ADMIN.ISOL8.CO', '/admin/users', ADMIN_HOSTS),
+    ).toEqual({ kind: 'passthrough' });
+  });
+});

--- a/apps/frontend/tests/unit/components/admin/ConfirmActionDialog.test.tsx
+++ b/apps/frontend/tests/unit/components/admin/ConfirmActionDialog.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ConfirmActionDialog } from "@/components/admin/ConfirmActionDialog";
+
+function renderDialog(props?: {
+  onConfirm?: () => Promise<void> | void;
+  confirmText?: string;
+  actionLabel?: string;
+}) {
+  const onConfirm = props?.onConfirm ?? vi.fn();
+  const utils = render(
+    <ConfirmActionDialog
+      confirmText={props?.confirmText ?? "DELETE"}
+      actionLabel={props?.actionLabel ?? "Cancel subscription"}
+      destructive
+      onConfirm={onConfirm}
+    >
+      <button type="button">Open</button>
+    </ConfirmActionDialog>,
+  );
+  return { ...utils, onConfirm };
+}
+
+async function openDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Open" }));
+  // Radix portals the dialog content; wait for it to appear.
+  await waitFor(() => {
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+  });
+}
+
+function getConfirmButton(actionLabel = "Cancel subscription"): HTMLButtonElement {
+  return screen.getByRole("button", {
+    name: `Confirm ${actionLabel}`,
+  }) as HTMLButtonElement;
+}
+
+describe("ConfirmActionDialog", () => {
+  it("renders with trigger and disabled confirm initially", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await openDialog(user);
+
+    const confirm = getConfirmButton();
+    expect(confirm).toBeDisabled();
+  });
+
+  it("enables confirm button when correct text typed", async () => {
+    const user = userEvent.setup();
+    renderDialog({ confirmText: "DELETE" });
+    await openDialog(user);
+
+    const input = screen.getByLabelText("Type DELETE to confirm");
+    await user.type(input, "DELETE");
+
+    expect(getConfirmButton()).toBeEnabled();
+  });
+
+  it("calls onConfirm when correct text typed and clicked", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    renderDialog({ onConfirm, confirmText: "DELETE" });
+    await openDialog(user);
+
+    await user.type(screen.getByLabelText("Type DELETE to confirm"), "DELETE");
+    await user.click(getConfirmButton());
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("locks dialog after 3 wrong attempts", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    renderDialog({ onConfirm, confirmText: "DELETE" });
+    await openDialog(user);
+
+    const input = screen.getByLabelText("Type DELETE to confirm");
+    await user.type(input, "WRONG");
+
+    // Three clicks with mismatched text trigger the lockout.
+    for (let i = 0; i < 3; i++) {
+      await user.click(getConfirmButton());
+    }
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Locked\. Reload the page to try again\./i),
+      ).toBeInTheDocument();
+    });
+    expect(getConfirmButton()).toBeDisabled();
+  });
+
+  it("aria-busy during async onConfirm", async () => {
+    const user = userEvent.setup();
+    let resolveConfirm: (() => void) | undefined;
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+    renderDialog({ onConfirm, confirmText: "DELETE" });
+    await openDialog(user);
+
+    await user.type(screen.getByLabelText("Type DELETE to confirm"), "DELETE");
+    const confirm = getConfirmButton();
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(getConfirmButton()).toHaveAttribute("aria-busy", "true");
+    });
+    expect(getConfirmButton()).toHaveTextContent(/Working/);
+
+    resolveConfirm?.();
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/tests/unit/components/admin/EmptyState.test.tsx
+++ b/apps/frontend/tests/unit/components/admin/EmptyState.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { EmptyState } from "@/components/admin/EmptyState";
+
+describe("EmptyState", () => {
+  it("renders title and body", () => {
+    render(<EmptyState title="No users yet" body="Day 1 is normal." />);
+    expect(screen.getByText("No users yet")).toBeInTheDocument();
+    expect(screen.getByText("Day 1 is normal.")).toBeInTheDocument();
+  });
+
+  it("renders link action when href is provided", () => {
+    render(
+      <EmptyState
+        title="No users yet"
+        body="Try inviting one."
+        action={{ label: "Invite user", href: "/admin/users/invite" }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Invite user" });
+    expect(link).toHaveAttribute("href", "/admin/users/invite");
+  });
+
+  it("renders button action when only onClick is provided", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <EmptyState
+        title="No users yet"
+        body="Reload to retry."
+        action={{ label: "Retry", onClick }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/tests/unit/components/admin/LogRow.test.tsx
+++ b/apps/frontend/tests/unit/components/admin/LogRow.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { LogRow, type LogEntry } from "@/components/admin/LogRow";
+
+const baseEntry: LogEntry = {
+  timestamp: "2026-04-18T12:00:00Z",
+  level: "ERROR",
+  message: "Container failed to provision: ECS task could not start",
+  correlation_id: "corr-abc-123",
+  raw_json: {
+    request_id: "req-123",
+    user_id: "user_test_123",
+    error: "ResourceInitializationError",
+  },
+};
+
+describe("LogRow", () => {
+  it("renders collapsed by default with timestamp + level + message", () => {
+    render(<LogRow entry={baseEntry} />);
+
+    expect(screen.getByText(baseEntry.timestamp)).toBeInTheDocument();
+    expect(screen.getByText("ERROR")).toBeInTheDocument();
+    expect(screen.getByText(baseEntry.message)).toBeInTheDocument();
+    // Collapsed: raw json and correlation id are not visible.
+    expect(screen.queryByText(/correlation_id:/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/ResourceInitializationError/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("expands to show full raw_json on click", async () => {
+    const user = userEvent.setup();
+    render(<LogRow entry={baseEntry} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Expand log entry/i }),
+    );
+
+    expect(screen.getByText(/correlation_id:/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/ResourceInitializationError/),
+    ).toBeInTheDocument();
+  });
+
+  it("displays correlation_id when present", async () => {
+    const user = userEvent.setup();
+    render(<LogRow entry={baseEntry} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Expand log entry/i }),
+    );
+
+    expect(screen.getByText("corr-abc-123")).toBeInTheDocument();
+  });
+
+  it("level badge has appropriate color class for ERROR", () => {
+    render(<LogRow entry={baseEntry} />);
+    const badge = screen.getByText("ERROR");
+    expect(badge.className).toMatch(/text-red-300/);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,8 @@ importers:
 
   apps/backend: {}
 
+  apps/desktop: {}
+
   apps/frontend:
     dependencies:
       '@clerk/nextjs':
@@ -152,6 +154,9 @@ importers:
       eslint-config-next:
         specifier: 16.1.1
         version: 16.1.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.1.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.1.3)
+      eslint-plugin-boundaries:
+        specifier: ^6.0.2
+        version: 6.0.2(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.1.3))(eslint@9.39.4(jiti@2.6.1))
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -421,6 +426,10 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@boundaries/elements@2.0.1':
+    resolution: {integrity: sha512-sAWO3D8PFP6pBXdxxW93SQi/KQqqhE2AAHo3AgWfdtJXwO6bfK6/wUN81XnOZk0qRC6vHzUEKhjwVD9dtDWvxg==}
+    engines: {node: '>=18.18'}
 
   '@clerk/backend@2.33.0':
     resolution: {integrity: sha512-sVR214TlJ5vsRprDE9EiZpqeNq/YVhCQLtAZ19ugjNf1C9xMX28JoMyodI/dU5FLBelmgSyjBAjodPULjIeF+w==}
@@ -2862,6 +2871,12 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
+  eslint-plugin-boundaries@6.0.2:
+    resolution: {integrity: sha512-wSHgiYeMEbziP91lH0UQ9oslgF2djG1x+LV9z/qO19ggMKZaCB8pKIGePHAY91eLF4EAgpsxQk8MRSFGRPfPzw==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      eslint: '>=6.0.0'
+
   eslint-plugin-import@2.32.0:
     resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
     engines: {node: '>=4'}
@@ -3166,6 +3181,11 @@ packages:
 
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -5473,6 +5493,20 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@boundaries/elements@2.0.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.1.3))(eslint@9.39.4(jiti@2.6.1))':
+    dependencies:
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      handlebars: 4.7.9
+      is-core-module: 2.16.1
+      micromatch: 4.0.8
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
 
   '@clerk/backend@2.33.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -7924,6 +7958,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-boundaries@6.0.2(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.1.3))(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@boundaries/elements': 2.0.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.1.3))(eslint@9.39.4(jiti@2.6.1))
+      chalk: 4.1.2
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.1.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      handlebars: 4.7.9
+      micromatch: 4.0.8
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.1.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -8303,6 +8352,15 @@ snapshots:
   graphql@16.13.1: {}
 
   handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2


### PR DESCRIPTION
## Summary

Phases D + E + F of the admin dashboard implementation per the merged plan. **The whole admin frontend lands in this PR** — foundations, all 11 routes, every Server Action, env wiring, and an E2E spec scaffold. Backend is fully wired by Phases A/B/C (#355, #359, #360 — all merged).

Closes Phases D + E + F of #351 (the full implementation phase).

Built by **5 parallel subagents** (2 for D, 3 for E+F) working on disjoint file sets — zero file-level conflicts. End-to-end agent execution: ~30 min wall-clock for ~30 frontend files.

## What lands

### Phase D — Foundations (commit 1: `feat(admin): Phase D — frontend foundations + shared components`)

| Layer | Files |
|---|---|
| Middleware | Extended `src/middleware.ts` with host-based gating per CEO A1 (default-to-404 on unknown hosts; `NEXT_PUBLIC_ADMIN_HOSTS` env-driven) |
| Layout | `src/app/admin/{layout,page,not-authorized/page}.tsx` — Clerk gate + `/admin/me` probe + dark-zinc nav |
| API client | `src/app/admin/_lib/{api,url}.ts` — server-only typed wrappers for all 10 Phase C read endpoints with `cache: "no-store"` |
| ESLint | `eslint-plugin-boundaries` rule per CEO A2: `src/components/admin/*` may only be imported by `src/app/admin/*` or `src/components/admin/*` |
| Components | 7 reusable components in `src/components/admin/`: `ConfirmActionDialog` (CEO S5 3-attempt lockout), `CodeBlock`, `AuditRow`, `UserSearchInput`, `EmptyState` (CEO U1), `ErrorBanner`, `LogRow` |
| Tests | 17 vitest cases (middleware host-gating, ConfirmActionDialog lockout, LogRow expand, EmptyState) |

### Phase E — Pages (commit 2: `feat(admin): Phase E + F — admin UI pages + Server Actions + E2E + env`)

11 routes:
- `/admin/health` — fleet tiles + upstream chips + recent errors
- `/admin/users` — directory with debounced search + EmptyState/ErrorBanner per state
- `/admin/users/[id]/{layout,page (Overview),agents,agents/[agent_id],billing,container,activity,logs,actions}`

### Phase F deliverables

- `apps/frontend/.env.example` — admin env vars documented (`NEXT_PUBLIC_ADMIN_HOSTS`, `NEXT_PUBLIC_POSTHOG_HOST`, optional `API_URL`)
- `apps/frontend/tests/e2e/admin.spec.ts` — Playwright happy-path scaffold (skipped by default; needs Clerk admin test user + DNS to actually run)
- 5 Server Action files in `src/app/admin/_actions/` (container/billing/account/config/agent) — each request sets `Idempotency-Key` per CEO D1

## CEO must-fix items addressed in Phases D-F

| Item | Where |
|---|---|
| **A1** Default-to-404 on unknown hosts | `src/middleware.ts` `decideAdminHostRouting()` |
| **A2** ESLint import-boundary rule | `eslint.config.mjs` (eslint-plugin-boundaries v6) |
| **S5** 3-attempt confirmation lockout | `ConfirmActionDialog.tsx` |
| **U1** Empty states | `EmptyState.tsx` used on every list page (zero users / zero agents / no logs / no PostHog) |
| **U2** Tab/sidebar layout | `users/[id]/layout.tsx` 6-tab nav (Logs folded into Activity per spec) |
| **D1** Idempotency-Key | All container + billing Server Actions set a fresh uuid per request |

## Architecture decisions baked in

- **Server Components by default.** Client islands kept tiny: `UsersClientHeader`, `UserTabs`, `AgentActionsFooter`, `BillingActionsPanel`, `ContainerActionsPanel`. Each only owns event handlers + state.
- **No client-side admin secrets.** API client is server-only via `import "server-only"`; admin token lives only in Clerk + Server Component env.
- **Server-side filter forms** on `/admin/users/[id]/logs` — `<form method="GET">` makes the URL the source of truth (no client JS, free deep-linking, back-button works).
- **Permissive API types** — backend fields like `events: unknown[]` get narrowed locally in each page so the API client survives backend evolution.
- **All write paths through ConfirmActionDialog** — typed-confirmation gates every destructive action. No naked confirm buttons anywhere.

## Verification

```bash
cd apps/frontend && pnpm lint                # exit 0 (0 errors, 17 baseline warnings)
cd apps/frontend && npx tsc --noEmit         # 0 errors in admin code
cd apps/frontend && pnpm test                # 317/325 pass (8 pre-existing unrelated failures)
```

## Test plan (CI / pre-merge)

- [x] `pnpm lint` exit 0
- [x] `npx tsc --noEmit` no admin-code errors
- [x] `pnpm test` no regressions
- [ ] Frontend CI (Vercel preview build)
- [ ] Manual smoke against admin.localhost:3000 once env vars set

## Phase F operational follow-ups (outside this PR — manual ops)

Tracked in `docs/runbooks/admin-rollout.md` from Phase A:

1. **DNS + Vercel domain alias** for `admin-dev.isol8.co` and `admin.isol8.co` — point CNAMEs at the frontend Vercel project
2. **Backend Secrets Manager** — populate `PLATFORM_ADMIN_USER_IDS`, `POSTHOG_PROJECT_*` in `isol8/{env}/backend-env`
3. **Clerk admin test user fixture** for the E2E spec (mirror `personal.spec.ts`'s `createE2EUser` pattern)
4. **Drop the `test.skip`** in admin.spec.ts once steps 1-3 land

## Refs

- Tracking issue: #351
- Plan: `docs/superpowers/plans/2026-04-21-admin-dashboard.md`
- Phase A (infra): #355 (merged)
- Phase B (backend foundations): #359 (merged)
- Phase C (router): #360 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
