### PR TITLE
fix(ci): skip codesigning for desktop-dev-v* builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -64,14 +64,27 @@ jobs:
       - name: Patch tauri.conf.json for ${{ steps.env.outputs.target_env }}
         run: |
           TAURI_CFG="apps/desktop/src-tauri/tauri.conf.json"
+          # Patch URLs for the target environment.
           jq --arg url "${{ steps.env.outputs.frontend_url }}" '
             .build.devUrl = $url |
             .build.frontendDist = $url |
             .app.windows[0].url = $url
           ' "$TAURI_CFG" > "$TAURI_CFG.new"
           mv "$TAURI_CFG.new" "$TAURI_CFG"
+          # Dev builds skip codesigning. The macos-latest runner has no
+          # Developer ID cert in its keychain (we only provide APPLE_ID
+          # for notarization). Strip signingIdentity so Tauri produces
+          # an unsigned DMG — testers bypass Gatekeeper via right-click
+          # > Open on first launch. Prod builds require a .p12 imported
+          # via APPLE_CERTIFICATE / APPLE_CERTIFICATE_PASSWORD secrets
+          # (separate follow-up).
+          if [[ "${{ steps.env.outputs.target_env }}" == "dev" ]]; then
+            jq 'del(.bundle.macOS.signingIdentity)' "$TAURI_CFG" > "$TAURI_CFG.new"
+            mv "$TAURI_CFG.new" "$TAURI_CFG"
+            echo "Stripped bundle.macOS.signingIdentity for dev build (unsigned DMG)"
+          fi
           echo "Patched URLs in tauri.conf.json:"
-          jq '{devUrl: .build.devUrl, frontendDist: .build.frontendDist, windowUrl: .app.windows[0].url}' "$TAURI_CFG"
+          jq '{devUrl: .build.devUrl, frontendDist: .build.frontendDist, windowUrl: .app.windows[0].url, signingIdentity: .bundle.macOS.signingIdentity}' "$TAURI_CFG"
 
       # Vendor Node.js + pinned `openclaw` npm package for both macOS
       # archs. Tauri's externalBin + resources point at these paths;


### PR DESCRIPTION
## Summary
- desktop-dev-v0.2.3 failed at the codesign step: \`The specified item could not be found in the keychain\`
- macos-latest runner only has APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID (for notarization), no \`.p12\` cert in keychain. \`bundle.macOS.signingIdentity\` in tauri.conf.json forced codesign to look up a missing cert
- For \`desktop-dev-v*\` tags: strip \`signingIdentity\` via jq in the existing env-patch step → unsigned DMG (testers use right-click > Open to bypass Gatekeeper on first launch)
- \`desktop-v*\` (prod) tags left intact — expect APPLE_CERTIFICATE + APPLE_CERTIFICATE_PASSWORD secrets (follow-up)

## Test plan
- [ ] Retag \`desktop-dev-v0.2.4\` after merge; confirm the DMG now produces (unsigned, install via right-click > Open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)