### PR TITLE
fix(ci): grant contents:write for desktop-build release creation

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -15,6 +15,12 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    # tauri-action creates a draft release + uploads the DMG via the
+    # GitHub REST API using GITHUB_TOKEN. The default token is
+    # read-only for contents; grant write so the create-release step
+    # doesn't 403 with "Resource not accessible by integration".
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- desktop-dev-v0.2.4 built + codesign-skip passed, but release creation failed: \`Resource not accessible by integration\`
- Default GITHUB_TOKEN has read-only \`contents\` permission; tauri-action needs write to create the draft release + upload the DMG
- One-line job-level \`permissions: contents: write\`

## Test plan
- [ ] Retag \`desktop-dev-v0.2.5\` after merge; confirm the draft release is created with the DMG attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)