### PR TITLE
feat(admin-catalog): move publish + unpublish into the admin dashboard

### DIFF
--- a/apps/backend/core/services/admin_audit.py
+++ b/apps/backend/core/services/admin_audit.py
@@ -91,6 +91,7 @@ def audit_admin_action(
     action: str,
     *,
     target_param: str = "user_id",
+    target_user_id_override: str | None = None,
     redact_paths: list[str] | None = None,
 ) -> Callable:
     """Decorate an admin router handler to write an audit row per call.
@@ -98,6 +99,12 @@ def audit_admin_action(
     See module docstring for the contract. `action` is a dotted name like
     'container.reprovision' that ends up in the audit_actions DDB row's
     `action` field (the same value the audit viewer uses for filtering).
+
+    `target_user_id_override`: when set (e.g. "__catalog__"), the audit
+    row's `target_user_id` is this static value rather than being pulled
+    from the handler's kwargs. Intended for actions that operate on a
+    shared resource (the catalog, platform config, etc.) rather than a
+    specific user.
     """
     redact_paths = redact_paths or []
 
@@ -110,7 +117,10 @@ def audit_admin_action(
                 raise RuntimeError(f"@audit_admin_action({action!r}) requires AuthContext in args or kwargs")
 
             request = kwargs.get("request")
-            target_user_id = kwargs.get(target_param) or "system"
+            if target_user_id_override is not None:
+                target_user_id = target_user_id_override
+            else:
+                target_user_id = kwargs.get(target_param) or "system"
             payload = _redact_payload(_payload_from_body(kwargs.get("body")), redact_paths)
 
             user_agent = _extract_user_agent(request)

--- a/apps/backend/core/services/admin_audit.py
+++ b/apps/backend/core/services/admin_audit.py
@@ -77,6 +77,25 @@ def _payload_from_body(body: Any) -> dict:
     return {}
 
 
+def _audit_value(v: Any) -> Any:
+    """Coerce a kwarg into a JSON-friendly shape for the audit payload."""
+    if hasattr(v, "model_dump"):
+        try:
+            return v.model_dump()
+        except Exception:
+            return str(v)
+    return v
+
+
+def _payload_from_capture_params(kwargs: dict, capture_params: list[str]) -> dict:
+    """Build the audit payload from named kwargs.
+
+    Each listed name becomes a top-level key. Pydantic models are serialized
+    via ``model_dump()``; path/query params pass through as-is.
+    """
+    return {k: _audit_value(kwargs.get(k)) for k in capture_params}
+
+
 def _find_auth(args: tuple, kwargs: dict) -> AuthContext | None:
     auth = kwargs.get("auth")
     if isinstance(auth, AuthContext):
@@ -93,6 +112,7 @@ def audit_admin_action(
     target_param: str = "user_id",
     target_user_id_override: str | None = None,
     redact_paths: list[str] | None = None,
+    capture_params: list[str] | None = None,
 ) -> Callable:
     """Decorate an admin router handler to write an audit row per call.
 
@@ -105,6 +125,14 @@ def audit_admin_action(
     from the handler's kwargs. Intended for actions that operate on a
     shared resource (the catalog, platform config, etc.) rather than a
     specific user.
+
+    `capture_params`: explicit list of handler kwarg names to include in
+    the audit `payload`. Pydantic models are serialized via
+    ``model_dump()``; other values pass through unchanged. Use this when
+    the request body arg is named something other than `body`, or when
+    the meaningful identifier is a path/query param (e.g. `slug`). When
+    omitted, the decorator falls back to its historical behavior of
+    serializing the `body` kwarg.
     """
     redact_paths = redact_paths or []
 
@@ -121,7 +149,11 @@ def audit_admin_action(
                 target_user_id = target_user_id_override
             else:
                 target_user_id = kwargs.get(target_param) or "system"
-            payload = _redact_payload(_payload_from_body(kwargs.get("body")), redact_paths)
+            if capture_params:
+                raw_payload = _payload_from_capture_params(kwargs, capture_params)
+            else:
+                raw_payload = _payload_from_body(kwargs.get("body"))
+            payload = _redact_payload(raw_payload, redact_paths)
 
             user_agent = _extract_user_agent(request)
             ip = _extract_client_ip(request)

--- a/apps/backend/core/services/catalog_service.py
+++ b/apps/backend/core/services/catalog_service.py
@@ -61,6 +61,63 @@ class CatalogService:
             )
         return entries
 
+    # ---- list_all (admin) ----
+
+    def list_all(self) -> dict[str, list[dict[str, Any]]]:
+        """Admin view: return {"live": [...with manifest preview], "retired": [...]}.
+        Live entries include the full manifest (same shape as list()).
+        Retired entries include only the metadata stored at retire time.
+        """
+        catalog = self._s3.get_json("catalog.json", default={"agents": [], "retired": []})
+        live: list[dict[str, Any]] = []
+        for item in catalog.get("agents") or []:
+            manifest = self._s3.get_json(item["manifest_url"], default=None)
+            if not manifest:
+                continue
+            live.append(
+                {
+                    "slug": manifest["slug"],
+                    "name": manifest.get("name", manifest["slug"]),
+                    "emoji": manifest.get("emoji", ""),
+                    "vibe": manifest.get("vibe", ""),
+                    "description": manifest.get("description", ""),
+                    "current_version": manifest["version"],
+                    "published_at": manifest.get("published_at", ""),
+                    "published_by": manifest.get("published_by", ""),
+                    "suggested_model": manifest.get("suggested_model", ""),
+                    "suggested_channels": manifest.get("suggested_channels", []),
+                    "required_skills": manifest.get("required_skills", []),
+                    "required_plugins": manifest.get("required_plugins", []),
+                }
+            )
+
+        retired = list(catalog.get("retired") or [])
+        return {"live": live, "retired": retired}
+
+    # ---- list_versions (admin) ----
+
+    def list_versions(self, slug: str) -> list[dict[str, Any]]:
+        """List all published versions of a slug, ascending.
+        Each entry: {version, manifest_url, published_at, published_by, manifest}.
+        """
+        versions = self._s3.list_versions(slug)
+        out: list[dict[str, Any]] = []
+        for v in versions:
+            manifest_url = f"{slug}/v{v}/manifest.json"
+            manifest = self._s3.get_json(manifest_url, default=None)
+            if not manifest:
+                continue
+            out.append(
+                {
+                    "version": v,
+                    "manifest_url": manifest_url,
+                    "published_at": manifest.get("published_at", ""),
+                    "published_by": manifest.get("published_by", ""),
+                    "manifest": manifest,
+                }
+            )
+        return out
+
     # ---- deploy ----
 
     async def deploy(self, *, user_id: str, slug: str) -> dict[str, Any]:

--- a/apps/backend/core/services/catalog_service.py
+++ b/apps/backend/core/services/catalog_service.py
@@ -205,7 +205,7 @@ class CatalogService:
         self._s3.put_json(f"{prefix}/manifest.json", manifest)
         self._s3.put_json(f"{prefix}/openclaw-slice.json", slice_)
 
-        catalog = self._s3.get_json("catalog.json", default={"agents": []})
+        catalog = self._s3.get_json("catalog.json", default={"agents": [], "retired": []})
         entries = [e for e in (catalog.get("agents") or []) if e.get("slug") != slug]
         entries.append(
             {
@@ -214,15 +214,58 @@ class CatalogService:
                 "manifest_url": f"{prefix}/manifest.json",
             }
         )
+        # Republishing a slug removes it from retired (if present)
+        retired = [r for r in (catalog.get("retired") or []) if r.get("slug") != slug]
         self._s3.put_json(
             "catalog.json",
             {
                 "updated_at": datetime.now(timezone.utc).isoformat(),
                 "agents": entries,
+                "retired": retired,
             },
         )
 
         return {"slug": slug, "version": next_version, "s3_prefix": prefix}
+
+    # ---- unpublish ----
+
+    async def unpublish(self, *, admin_user_id: str, slug: str) -> dict[str, Any]:
+        """Soft-delete: move slug from agents list to retired list in catalog.json.
+        S3 artifacts (versioned manifests + tarballs) remain untouched for audit.
+        Raises KeyError if slug isn't currently live.
+        """
+        catalog = self._s3.get_json("catalog.json", default={"agents": [], "retired": []})
+        agents = list(catalog.get("agents") or [])
+        retired = list(catalog.get("retired") or [])
+
+        match = next((a for a in agents if a.get("slug") == slug), None)
+        if not match:
+            raise KeyError(f"slug {slug!r} is not currently live")
+
+        new_agents = [a for a in agents if a.get("slug") != slug]
+        retired_entry = {
+            "slug": slug,
+            "last_version": match["current_version"],
+            "last_manifest_url": match["manifest_url"],
+            "retired_at": datetime.now(timezone.utc).isoformat(),
+            "retired_by": admin_user_id,
+        }
+        new_retired = retired + [retired_entry]
+
+        self._s3.put_json(
+            "catalog.json",
+            {
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+                "agents": new_agents,
+                "retired": new_retired,
+            },
+        )
+
+        return {
+            "slug": slug,
+            "last_version": match["current_version"],
+            "last_manifest_url": match["manifest_url"],
+        }
 
 
 _catalog_service: CatalogService | None = None

--- a/apps/backend/routers/admin_catalog.py
+++ b/apps/backend/routers/admin_catalog.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from core.auth import AuthContext, require_platform_admin
 from core.services.admin_audit import audit_admin_action
 from core.services.catalog_service import CatalogService, get_catalog_service
+from core.services.idempotency import idempotency
 
 
 router = APIRouter(prefix="/admin/catalog", tags=["admin", "catalog"])
@@ -19,6 +20,7 @@ class PublishRequest(BaseModel):
     "/publish",
     description="Package an agent from the admin's EFS workspace and upload it to the shared catalog bucket.",
 )
+@idempotency()
 @audit_admin_action(
     "catalog.publish",
     target_user_id_override="__catalog__",
@@ -53,6 +55,7 @@ async def list_all(
     "/{slug}/unpublish",
     description="Soft-delete a catalog slug. Moves the slug to catalog.json's retired list; S3 artifacts preserved.",
 )
+@idempotency()
 @audit_admin_action(
     "catalog.unpublish",
     target_user_id_override="__catalog__",

--- a/apps/backend/routers/admin_catalog.py
+++ b/apps/backend/routers/admin_catalog.py
@@ -22,6 +22,7 @@ class PublishRequest(BaseModel):
 @audit_admin_action(
     "catalog.publish",
     target_user_id_override="__catalog__",
+    capture_params=["req"],
 )
 async def publish(
     req: PublishRequest,
@@ -55,6 +56,7 @@ async def list_all(
 @audit_admin_action(
     "catalog.unpublish",
     target_user_id_override="__catalog__",
+    capture_params=["slug"],
 )
 async def unpublish(
     slug: str,

--- a/apps/backend/routers/admin_catalog.py
+++ b/apps/backend/routers/admin_catalog.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 
 from core.auth import AuthContext, require_platform_admin
+from core.services.admin_audit import audit_admin_action
 from core.services.catalog_service import CatalogService, get_catalog_service
 
 
@@ -18,8 +19,13 @@ class PublishRequest(BaseModel):
     "/publish",
     description="Package an agent from the admin's EFS workspace and upload it to the shared catalog bucket.",
 )
+@audit_admin_action(
+    "catalog.publish",
+    target_user_id_override="__catalog__",
+)
 async def publish(
     req: PublishRequest,
+    request: Request,
     auth: AuthContext = Depends(require_platform_admin),
     service: CatalogService = Depends(get_catalog_service),
 ) -> dict:

--- a/apps/backend/routers/admin_catalog.py
+++ b/apps/backend/routers/admin_catalog.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from core.auth import AuthContext, require_platform_admin
@@ -35,3 +35,46 @@ async def publish(
         slug_override=req.slug,
         description_override=req.description,
     )
+
+
+@router.get(
+    "",
+    description="Admin view of the catalog: live entries with manifest preview + retired entries.",
+)
+async def list_all(
+    auth: AuthContext = Depends(require_platform_admin),
+    service: CatalogService = Depends(get_catalog_service),
+) -> dict:
+    return service.list_all()
+
+
+@router.post(
+    "/{slug}/unpublish",
+    description="Soft-delete a catalog slug. Moves the slug to catalog.json's retired list; S3 artifacts preserved.",
+)
+@audit_admin_action(
+    "catalog.unpublish",
+    target_user_id_override="__catalog__",
+)
+async def unpublish(
+    slug: str,
+    request: Request,
+    auth: AuthContext = Depends(require_platform_admin),
+    service: CatalogService = Depends(get_catalog_service),
+) -> dict:
+    try:
+        return await service.unpublish(admin_user_id=auth.user_id, slug=slug)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get(
+    "/{slug}/versions",
+    description="List every published version of a catalog slug.",
+)
+async def list_versions(
+    slug: str,
+    auth: AuthContext = Depends(require_platform_admin),
+    service: CatalogService = Depends(get_catalog_service),
+) -> dict:
+    return {"versions": service.list_versions(slug)}

--- a/apps/backend/tests/unit/test_admin_audit.py
+++ b/apps/backend/tests/unit/test_admin_audit.py
@@ -1,0 +1,68 @@
+"""Unit tests for @audit_admin_action decorator.
+
+Verifies:
+1. New `target_user_id_override` kwarg sets the audit row's target
+   to the override value verbatim (used for catalog actions that
+   target the shared catalog, not a specific user).
+2. Existing kwarg-based target resolution is preserved when no
+   override is given.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.auth import AuthContext
+from core.services.admin_audit import audit_admin_action
+
+
+class _Req:
+    """Minimal stand-in for a FastAPI Request — decorator reads headers + client."""
+
+    headers = {"user-agent": "pytest"}
+    client = type("c", (), {"host": "127.0.0.1"})()
+
+
+def _auth() -> AuthContext:
+    """Real AuthContext so the decorator's isinstance check passes."""
+    return AuthContext(user_id="user_admin_123")
+
+
+@pytest.mark.asyncio
+async def test_audit_uses_static_target_override():
+    """When target_user_id_override is passed, the audit row uses it verbatim
+    rather than pulling from kwargs."""
+    create_mock = AsyncMock(return_value={})
+
+    @audit_admin_action("catalog.test", target_user_id_override="__catalog__")
+    async def handler(request, auth):
+        return {"ok": True}
+
+    with patch(
+        "core.repositories.admin_actions_repo.create",
+        new=create_mock,
+    ):
+        await handler(request=_Req(), auth=_auth())
+
+    assert create_mock.await_count == 1
+    # repo.create is keyword-only; all fields land in kwargs.
+    assert create_mock.await_args.kwargs["target_user_id"] == "__catalog__"
+
+
+@pytest.mark.asyncio
+async def test_audit_falls_back_to_kwarg_without_override():
+    """Sanity: existing behavior is preserved when no override is given."""
+    create_mock = AsyncMock(return_value={})
+
+    @audit_admin_action("user.test")
+    async def handler(user_id, request, auth):
+        return {"ok": True}
+
+    with patch(
+        "core.repositories.admin_actions_repo.create",
+        new=create_mock,
+    ):
+        await handler(user_id="user_target_xyz", request=_Req(), auth=_auth())
+
+    assert create_mock.await_count == 1
+    assert create_mock.await_args.kwargs["target_user_id"] == "user_target_xyz"

--- a/apps/backend/tests/unit/test_admin_audit.py
+++ b/apps/backend/tests/unit/test_admin_audit.py
@@ -66,3 +66,89 @@ async def test_audit_falls_back_to_kwarg_without_override():
 
     assert create_mock.await_count == 1
     assert create_mock.await_args.kwargs["target_user_id"] == "user_target_xyz"
+
+
+@pytest.mark.asyncio
+async def test_audit_captures_specified_kwargs_as_payload():
+    """capture_params=['slug'] stores {slug: 'pitch'} in payload."""
+    create_mock = AsyncMock()
+
+    @audit_admin_action("catalog.test", target_user_id_override="__catalog__", capture_params=["slug"])
+    async def handler(slug, request, auth):
+        return {"ok": True}
+
+    class _Req:
+        headers = {"user-agent": "pytest"}
+        client = type("c", (), {"host": "127.0.0.1"})()
+
+    from core.auth import AuthContext
+
+    with patch("core.repositories.admin_actions_repo.create", new=create_mock):
+        await handler(slug="pitch", request=_Req(), auth=AuthContext(user_id="user_admin"))
+
+    row = create_mock.await_args.kwargs
+    assert row["payload"] == {"slug": "pitch"}
+
+
+@pytest.mark.asyncio
+async def test_audit_captures_pydantic_model_via_capture_params():
+    """capture_params on a Pydantic kwarg serializes via model_dump()."""
+    from pydantic import BaseModel
+
+    class DummyReq(BaseModel):
+        agent_id: str
+        slug: str | None = None
+
+    create_mock = AsyncMock()
+
+    @audit_admin_action("catalog.test", target_user_id_override="__catalog__", capture_params=["req"])
+    async def handler(req, request, auth):
+        return {"ok": True}
+
+    class _Req:
+        headers = {"user-agent": "pytest"}
+        client = type("c", (), {"host": "127.0.0.1"})()
+
+    from core.auth import AuthContext
+
+    with patch("core.repositories.admin_actions_repo.create", new=create_mock):
+        await handler(
+            req=DummyReq(agent_id="agent_abc", slug="pitch"),
+            request=_Req(),
+            auth=AuthContext(user_id="user_admin"),
+        )
+
+    row = create_mock.await_args.kwargs
+    assert row["payload"] == {"req": {"agent_id": "agent_abc", "slug": "pitch"}}
+
+
+@pytest.mark.asyncio
+async def test_audit_falls_back_to_body_when_capture_params_absent():
+    """Existing behavior: without capture_params, still extracts body kwarg."""
+    from pydantic import BaseModel
+
+    class DummyBody(BaseModel):
+        note: str
+
+    create_mock = AsyncMock()
+
+    @audit_admin_action("existing.test")
+    async def handler(user_id, body, request, auth):
+        return {"ok": True}
+
+    class _Req:
+        headers = {"user-agent": "pytest"}
+        client = type("c", (), {"host": "127.0.0.1"})()
+
+    from core.auth import AuthContext
+
+    with patch("core.repositories.admin_actions_repo.create", new=create_mock):
+        await handler(
+            user_id="user_xyz",
+            body=DummyBody(note="hello"),
+            request=_Req(),
+            auth=AuthContext(user_id="user_admin"),
+        )
+
+    row = create_mock.await_args.kwargs
+    assert row["payload"] == {"note": "hello"}

--- a/apps/backend/tests/unit/test_catalog_service.py
+++ b/apps/backend/tests/unit/test_catalog_service.py
@@ -404,3 +404,128 @@ async def test_publish_removes_retired_entry_when_republishing(service, mock_s3,
     new_catalog = catalog_put.args[1]
     assert [a["slug"] for a in new_catalog["agents"]] == ["pitch"]
     assert new_catalog["retired"] == []
+
+
+def test_list_all_returns_live_and_retired(service, mock_s3):
+    """Admin view: live entries include full manifest preview; retired
+    entries include the metadata we stored at retire time."""
+
+    def _get_json(key, default=None):
+        if key == "catalog.json":
+            return {
+                "agents": [
+                    {"slug": "pitch", "current_version": 3, "manifest_url": "pitch/v3/manifest.json"},
+                ],
+                "retired": [
+                    {
+                        "slug": "echo",
+                        "last_version": 1,
+                        "last_manifest_url": "echo/v1/manifest.json",
+                        "retired_at": "2026-04-22T00:00:00Z",
+                        "retired_by": "user_admin",
+                    },
+                ],
+            }
+        if key == "pitch/v3/manifest.json":
+            return {
+                "slug": "pitch",
+                "version": 3,
+                "name": "Pitch",
+                "emoji": "🎯",
+                "vibe": "Direct",
+                "description": "Sales",
+                "suggested_model": "qwen",
+                "suggested_channels": [],
+                "required_skills": [],
+                "required_plugins": [],
+                "required_tools": [],
+                "published_at": "2026-04-20T00:00:00Z",
+                "published_by": "user_admin",
+            }
+        return default
+
+    mock_s3.get_json.side_effect = _get_json
+
+    result = service.list_all()
+
+    assert len(result["live"]) == 1
+    assert result["live"][0]["slug"] == "pitch"
+    assert result["live"][0]["name"] == "Pitch"
+    assert result["live"][0]["current_version"] == 3
+    assert "published_at" in result["live"][0]
+
+    assert len(result["retired"]) == 1
+    assert result["retired"][0]["slug"] == "echo"
+    assert result["retired"][0]["retired_by"] == "user_admin"
+    assert result["retired"][0]["last_version"] == 1
+
+
+def test_list_all_empty_catalog(service, mock_s3):
+    mock_s3.get_json.return_value = {"agents": [], "retired": []}
+    result = service.list_all()
+    assert result == {"live": [], "retired": []}
+
+
+def test_list_all_handles_missing_retired_key(service, mock_s3):
+    mock_s3.get_json.side_effect = lambda key, default=None: {"agents": []} if key == "catalog.json" else default
+    result = service.list_all()
+    assert result == {"live": [], "retired": []}
+
+
+def test_list_versions_returns_sorted_with_manifests(service, mock_s3):
+    """Versions sorted ascending; each entry includes manifest JSON + timestamps."""
+    mock_s3.list_versions.return_value = [1, 2, 3]
+
+    def _get_json(key, default=None):
+        if key == "pitch/v1/manifest.json":
+            return {
+                "slug": "pitch",
+                "version": 1,
+                "name": "Pitch",
+                "published_at": "2026-04-19T00:00:00Z",
+                "published_by": "user_admin",
+            }
+        if key == "pitch/v2/manifest.json":
+            return {
+                "slug": "pitch",
+                "version": 2,
+                "name": "Pitch",
+                "published_at": "2026-04-20T00:00:00Z",
+                "published_by": "user_admin",
+            }
+        if key == "pitch/v3/manifest.json":
+            return {
+                "slug": "pitch",
+                "version": 3,
+                "name": "Pitch",
+                "published_at": "2026-04-21T00:00:00Z",
+                "published_by": "user_admin",
+            }
+        return default
+
+    mock_s3.get_json.side_effect = _get_json
+
+    result = service.list_versions("pitch")
+
+    assert [v["version"] for v in result] == [1, 2, 3]
+    assert result[2]["published_at"] == "2026-04-21T00:00:00Z"
+    assert result[0]["manifest"]["name"] == "Pitch"
+    assert result[0]["manifest_url"] == "pitch/v1/manifest.json"
+
+
+def test_list_versions_empty_for_unknown_slug(service, mock_s3):
+    mock_s3.list_versions.return_value = []
+    result = service.list_versions("ghost")
+    assert result == []
+
+
+def test_list_versions_skips_missing_manifest(service, mock_s3):
+    """If an S3 manifest is missing, the version is omitted rather than crashing."""
+    mock_s3.list_versions.return_value = [1, 2]
+    mock_s3.get_json.side_effect = lambda key, default=None: (
+        {"slug": "pitch", "version": 2, "name": "Pitch", "published_at": "2026-04-22T00:00:00Z", "published_by": "u"}
+        if key == "pitch/v2/manifest.json"
+        else default
+    )
+    result = service.list_versions("pitch")
+    assert [v["version"] for v in result] == [2]

--- a/apps/backend/tests/unit/test_catalog_service.py
+++ b/apps/backend/tests/unit/test_catalog_service.py
@@ -296,3 +296,111 @@ async def test_publish_bumps_version_when_prior_exists(service, mock_s3, mock_wo
 
     result = await service.publish(admin_user_id="admin", agent_id="a1")
     assert result["version"] == 6
+
+
+@pytest.mark.asyncio
+async def test_unpublish_moves_slug_from_live_to_retired(service, mock_s3):
+    """Soft delete: slug moves from agents -> retired. S3 artifacts untouched."""
+    mock_s3.get_json.return_value = {
+        "updated_at": "2026-04-22T00:00:00Z",
+        "agents": [
+            {"slug": "pitch", "current_version": 3, "manifest_url": "pitch/v3/manifest.json"},
+            {"slug": "echo", "current_version": 1, "manifest_url": "echo/v1/manifest.json"},
+        ],
+        "retired": [],
+    }
+
+    result = await service.unpublish(admin_user_id="user_admin", slug="pitch")
+
+    assert result["slug"] == "pitch"
+    assert result["last_version"] == 3
+
+    put_json_calls = [c for c in mock_s3.put_json.call_args_list if c.args[0] == "catalog.json"]
+    assert len(put_json_calls) == 1
+    new_catalog = put_json_calls[0].args[1]
+    assert [a["slug"] for a in new_catalog["agents"]] == ["echo"]
+    assert len(new_catalog["retired"]) == 1
+    assert new_catalog["retired"][0]["slug"] == "pitch"
+    assert new_catalog["retired"][0]["last_version"] == 3
+    assert new_catalog["retired"][0]["retired_by"] == "user_admin"
+    assert "retired_at" in new_catalog["retired"][0]
+
+
+@pytest.mark.asyncio
+async def test_unpublish_missing_slug_raises(service, mock_s3):
+    mock_s3.get_json.return_value = {"agents": [], "retired": []}
+    with pytest.raises(KeyError):
+        await service.unpublish(admin_user_id="user_admin", slug="ghost")
+
+
+@pytest.mark.asyncio
+async def test_unpublish_preserves_other_retired_entries(service, mock_s3):
+    mock_s3.get_json.return_value = {
+        "updated_at": "2026-04-22T00:00:00Z",
+        "agents": [
+            {"slug": "pitch", "current_version": 2, "manifest_url": "pitch/v2/manifest.json"},
+        ],
+        "retired": [
+            {
+                "slug": "oldie",
+                "last_version": 1,
+                "last_manifest_url": "oldie/v1/manifest.json",
+                "retired_at": "2026-04-01T00:00:00Z",
+                "retired_by": "user_admin",
+            },
+        ],
+    }
+    await service.unpublish(admin_user_id="user_admin", slug="pitch")
+
+    new_catalog = next(c for c in mock_s3.put_json.call_args_list if c.args[0] == "catalog.json").args[1]
+    retired_slugs = sorted(r["slug"] for r in new_catalog["retired"])
+    assert retired_slugs == ["oldie", "pitch"]
+
+
+@pytest.mark.asyncio
+async def test_unpublish_handles_missing_retired_key(service, mock_s3):
+    """Backward compat: catalog.json without a 'retired' key is treated as []."""
+    mock_s3.get_json.return_value = {
+        "updated_at": "2026-04-22T00:00:00Z",
+        "agents": [
+            {"slug": "pitch", "current_version": 1, "manifest_url": "pitch/v1/manifest.json"},
+        ],
+    }
+    await service.unpublish(admin_user_id="user_admin", slug="pitch")
+    new_catalog = next(c for c in mock_s3.put_json.call_args_list if c.args[0] == "catalog.json").args[1]
+    assert new_catalog["retired"][0]["slug"] == "pitch"
+
+
+@pytest.mark.asyncio
+async def test_publish_removes_retired_entry_when_republishing(service, mock_s3, mock_workspace, tmp_path):
+    """Republishing a retired slug removes it from retired and adds it to agents."""
+    mock_workspace.read_openclaw_config.return_value = {
+        "agents": [{"id": "a1", "name": "Pitch", "skills": []}],
+        "plugins": {},
+        "tools": {},
+    }
+    admin_workspace = tmp_path / "ws"
+    admin_workspace.mkdir()
+    (admin_workspace / "IDENTITY.md").write_text("x")
+    mock_workspace.agent_workspace_path.return_value = admin_workspace
+    mock_s3.list_versions.return_value = [1, 2]
+    mock_s3.get_json.return_value = {
+        "agents": [],
+        "retired": [
+            {
+                "slug": "pitch",
+                "last_version": 2,
+                "last_manifest_url": "pitch/v2/manifest.json",
+                "retired_at": "2026-04-01T00:00:00Z",
+                "retired_by": "user_admin",
+            },
+        ],
+    }
+
+    result = await service.publish(admin_user_id="user_admin", agent_id="a1", slug_override="pitch")
+    assert result["version"] == 3
+
+    catalog_put = next(c for c in mock_s3.put_json.call_args_list if c.args[0] == "catalog.json")
+    new_catalog = catalog_put.args[1]
+    assert [a["slug"] for a in new_catalog["agents"]] == ["pitch"]
+    assert new_catalog["retired"] == []

--- a/apps/backend/tests/unit/test_routers_catalog.py
+++ b/apps/backend/tests/unit/test_routers_catalog.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -27,6 +27,12 @@ def mock_service():
     app.dependency_overrides[get_catalog_service] = lambda: svc
     yield svc
     app.dependency_overrides.pop(get_catalog_service, None)
+
+
+@pytest.fixture
+def admin_env(monkeypatch):
+    monkeypatch.setattr("core.config.settings.PLATFORM_ADMIN_USER_IDS", "user_admin_42")
+    yield
 
 
 def test_list_returns_catalog_entries(client, mock_service):
@@ -110,4 +116,31 @@ def test_publish_happy_path(client, mock_service):
     assert r.status_code == 200
     assert r.json()["version"] == 4
     mock_service.publish.assert_awaited_once()
+    app.dependency_overrides.pop(require_platform_admin, None)
+
+
+def test_publish_writes_audit_row(client, mock_service, admin_env):
+    """POST /admin/catalog/publish creates an admin-actions row with
+    action=catalog.publish and target_user_id=__catalog__."""
+    from core.auth import AuthContext, require_platform_admin
+    from main import app
+
+    app.dependency_overrides[require_platform_admin] = lambda: AuthContext(user_id="user_admin_42")
+    mock_service.publish = AsyncMock(return_value={"slug": "pitch", "version": 1, "s3_prefix": "pitch/v1"})
+
+    audit_mock = AsyncMock()
+    with patch("core.repositories.admin_actions_repo.create", new=audit_mock):
+        r = client.post(
+            "/api/v1/admin/catalog/publish",
+            json={"agent_id": "agent_abc"},
+        )
+
+    assert r.status_code == 200
+    assert audit_mock.await_count == 1
+
+    row_kwargs = audit_mock.await_args.kwargs
+    assert row_kwargs["action"] == "catalog.publish"
+    assert row_kwargs["target_user_id"] == "__catalog__"
+    assert row_kwargs["admin_user_id"] == "user_admin_42"
+
     app.dependency_overrides.pop(require_platform_admin, None)

--- a/apps/backend/tests/unit/test_routers_catalog.py
+++ b/apps/backend/tests/unit/test_routers_catalog.py
@@ -282,6 +282,80 @@ def test_unpublish_audit_captures_slug_in_payload(client, mock_service):
     app.dependency_overrides.pop(require_platform_admin, None)
 
 
+def test_unpublish_idempotency_returns_cached_on_replay(client, mock_service):
+    """Replayed POST with the same Idempotency-Key short-circuits — service runs once.
+
+    Without @idempotency(), the second call would hit service.unpublish again
+    which, after the first call retired the slug, would raise KeyError and
+    surface as a 404 to the client (a completed action wrongly reported as
+    a failure). With @idempotency(), the cached 200 payload is returned.
+    """
+    from core.auth import AuthContext, require_platform_admin
+    from core.services.idempotency import reset_cache
+    from main import app
+
+    reset_cache()
+    app.dependency_overrides[require_platform_admin] = lambda: AuthContext(user_id="user_admin")
+    mock_service.unpublish = AsyncMock(
+        return_value={
+            "slug": "pitch",
+            "last_version": 3,
+            "last_manifest_url": "pitch/v3/manifest.json",
+        }
+    )
+    headers = {"Idempotency-Key": "test-unpublish-key-12345"}
+
+    with patch("core.repositories.admin_actions_repo.create", new=AsyncMock()):
+        r1 = client.post("/api/v1/admin/catalog/pitch/unpublish", headers=headers)
+        r2 = client.post("/api/v1/admin/catalog/pitch/unpublish", headers=headers)
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json() == r2.json()
+    # Service was called exactly once; second POST returned the cached result.
+    assert mock_service.unpublish.await_count == 1
+
+    app.dependency_overrides.pop(require_platform_admin, None)
+    reset_cache()
+
+
+def test_publish_idempotency_returns_cached_on_replay(client, mock_service):
+    """Replayed publish POST with the same Idempotency-Key short-circuits.
+
+    Without @idempotency(), a retried publish would bump the version on
+    every network retry. With @idempotency(), the cached 200 payload is
+    returned and service.publish runs exactly once.
+    """
+    from core.auth import AuthContext, require_platform_admin
+    from core.services.idempotency import reset_cache
+    from main import app
+
+    reset_cache()
+    app.dependency_overrides[require_platform_admin] = lambda: AuthContext(user_id="user_admin")
+    mock_service.publish = AsyncMock(return_value={"slug": "pitch", "version": 4, "s3_prefix": "pitch/v4"})
+    headers = {"Idempotency-Key": "test-publish-key-67890"}
+
+    with patch("core.repositories.admin_actions_repo.create", new=AsyncMock()):
+        r1 = client.post(
+            "/api/v1/admin/catalog/publish",
+            json={"agent_id": "agent_abc"},
+            headers=headers,
+        )
+        r2 = client.post(
+            "/api/v1/admin/catalog/publish",
+            json={"agent_id": "agent_abc"},
+            headers=headers,
+        )
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json() == r2.json()
+    assert mock_service.publish.await_count == 1
+
+    app.dependency_overrides.pop(require_platform_admin, None)
+    reset_cache()
+
+
 def test_admin_catalog_endpoints_require_platform_admin(client):
     """Any non-admin user hitting /admin/catalog/* returns 403."""
     from core.auth import require_platform_admin

--- a/apps/backend/tests/unit/test_routers_catalog.py
+++ b/apps/backend/tests/unit/test_routers_catalog.py
@@ -144,3 +144,113 @@ def test_publish_writes_audit_row(client, mock_service, admin_env):
     assert row_kwargs["admin_user_id"] == "user_admin_42"
 
     app.dependency_overrides.pop(require_platform_admin, None)
+
+
+def test_admin_list_catalog_returns_live_and_retired(client, mock_service):
+    from core.auth import AuthContext, require_platform_admin
+    from main import app
+
+    app.dependency_overrides[require_platform_admin] = lambda: AuthContext(user_id="user_admin")
+    mock_service.list_all = MagicMock(
+        return_value={
+            "live": [
+                {
+                    "slug": "pitch",
+                    "name": "Pitch",
+                    "current_version": 3,
+                    "emoji": "🎯",
+                    "vibe": "",
+                    "description": "",
+                    "suggested_model": "",
+                    "suggested_channels": [],
+                    "required_skills": [],
+                    "required_plugins": [],
+                    "published_at": "2026-04-22T00:00:00Z",
+                    "published_by": "user_admin",
+                }
+            ],
+            "retired": [],
+        }
+    )
+    r = client.get("/api/v1/admin/catalog")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["live"][0]["slug"] == "pitch"
+    assert body["retired"] == []
+    app.dependency_overrides.pop(require_platform_admin, None)
+
+
+def test_admin_unpublish_soft_deletes_slug(client, mock_service):
+    from core.auth import AuthContext, require_platform_admin
+    from main import app
+
+    app.dependency_overrides[require_platform_admin] = lambda: AuthContext(user_id="user_admin")
+    mock_service.unpublish = AsyncMock(
+        return_value={"slug": "pitch", "last_version": 3, "last_manifest_url": "pitch/v3/manifest.json"}
+    )
+
+    audit_mock = AsyncMock()
+    with patch("core.repositories.admin_actions_repo.create", new=audit_mock):
+        r = client.post("/api/v1/admin/catalog/pitch/unpublish")
+
+    assert r.status_code == 200
+    assert r.json()["slug"] == "pitch"
+    mock_service.unpublish.assert_awaited_once_with(admin_user_id="user_admin", slug="pitch")
+    assert audit_mock.await_count == 1
+    row_kwargs = audit_mock.await_args.kwargs
+    assert row_kwargs["action"] == "catalog.unpublish"
+    assert row_kwargs["target_user_id"] == "__catalog__"
+    app.dependency_overrides.pop(require_platform_admin, None)
+
+
+def test_admin_unpublish_missing_slug_404(client, mock_service):
+    from core.auth import AuthContext, require_platform_admin
+    from main import app
+
+    app.dependency_overrides[require_platform_admin] = lambda: AuthContext(user_id="user_admin")
+    mock_service.unpublish = AsyncMock(side_effect=KeyError("not live"))
+
+    r = client.post("/api/v1/admin/catalog/ghost/unpublish")
+    assert r.status_code == 404
+
+    app.dependency_overrides.pop(require_platform_admin, None)
+
+
+def test_admin_list_versions(client, mock_service):
+    from core.auth import AuthContext, require_platform_admin
+    from main import app
+
+    app.dependency_overrides[require_platform_admin] = lambda: AuthContext(user_id="user_admin")
+    mock_service.list_versions = MagicMock(
+        return_value=[
+            {
+                "version": 1,
+                "manifest_url": "pitch/v1/manifest.json",
+                "published_at": "2026-04-19T00:00:00Z",
+                "published_by": "user_admin",
+                "manifest": {"slug": "pitch", "version": 1},
+            },
+        ]
+    )
+    r = client.get("/api/v1/admin/catalog/pitch/versions")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["versions"][0]["version"] == 1
+    app.dependency_overrides.pop(require_platform_admin, None)
+
+
+def test_admin_catalog_endpoints_require_platform_admin(client):
+    """Any non-admin user hitting /admin/catalog/* returns 403."""
+    from core.auth import require_platform_admin
+    from main import app
+    from fastapi import HTTPException
+
+    def _deny():
+        raise HTTPException(status_code=403, detail="Platform admin access required")
+
+    app.dependency_overrides[require_platform_admin] = _deny
+
+    assert client.get("/api/v1/admin/catalog").status_code == 403
+    assert client.post("/api/v1/admin/catalog/pitch/unpublish").status_code == 403
+    assert client.get("/api/v1/admin/catalog/pitch/versions").status_code == 403
+    app.dependency_overrides.pop(require_platform_admin, None)

--- a/apps/backend/tests/unit/test_routers_catalog.py
+++ b/apps/backend/tests/unit/test_routers_catalog.py
@@ -239,6 +239,49 @@ def test_admin_list_versions(client, mock_service):
     app.dependency_overrides.pop(require_platform_admin, None)
 
 
+def test_publish_audit_captures_agent_id_in_payload(client, mock_service):
+    """Publish audit row includes the agent_id (and optional slug/description) from req."""
+    from core.auth import AuthContext, require_platform_admin
+    from main import app
+
+    app.dependency_overrides[require_platform_admin] = lambda: AuthContext(user_id="user_admin_42")
+    mock_service.publish = AsyncMock(return_value={"slug": "pitch", "version": 1, "s3_prefix": "pitch/v1"})
+
+    audit_mock = AsyncMock()
+    with patch("core.repositories.admin_actions_repo.create", new=audit_mock):
+        r = client.post(
+            "/api/v1/admin/catalog/publish",
+            json={"agent_id": "agent_abc", "slug": "custom-pitch"},
+        )
+
+    assert r.status_code == 200
+    payload = audit_mock.await_args.kwargs["payload"]
+    assert payload["req"]["agent_id"] == "agent_abc"
+    assert payload["req"]["slug"] == "custom-pitch"
+
+    app.dependency_overrides.pop(require_platform_admin, None)
+
+
+def test_unpublish_audit_captures_slug_in_payload(client, mock_service):
+    """Unpublish audit row includes the slug path param."""
+    from core.auth import AuthContext, require_platform_admin
+    from main import app
+
+    app.dependency_overrides[require_platform_admin] = lambda: AuthContext(user_id="user_admin")
+    mock_service.unpublish = AsyncMock(
+        return_value={"slug": "pitch", "last_version": 3, "last_manifest_url": "pitch/v3/manifest.json"}
+    )
+
+    audit_mock = AsyncMock()
+    with patch("core.repositories.admin_actions_repo.create", new=audit_mock):
+        r = client.post("/api/v1/admin/catalog/pitch/unpublish")
+
+    assert r.status_code == 200
+    assert audit_mock.await_args.kwargs["payload"] == {"slug": "pitch"}
+
+    app.dependency_overrides.pop(require_platform_admin, None)
+
+
 def test_admin_catalog_endpoints_require_platform_admin(client):
     """Any non-admin user hitting /admin/catalog/* returns 403."""
     from core.auth import require_platform_admin

--- a/apps/frontend/src/app/admin/_actions/catalog.ts
+++ b/apps/frontend/src/app/admin/_actions/catalog.ts
@@ -1,0 +1,103 @@
+"use server";
+
+import { randomUUID } from "crypto";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { apiUrl } from "@/app/admin/_lib/url";
+
+/**
+ * Server Actions for the shared agent catalog (admin dashboard).
+ *
+ * `publishAgent` adds a new version under a slug (or creates the slug on
+ * first publish); `unpublishSlug` retires a slug so newcomers don't see the
+ * template but the manifest history stays queryable for rollback + audit.
+ *
+ * Each action POSTs with a fresh `Idempotency-Key` so double-clicks
+ * short-circuit on the backend. The Clerk JWT is fetched server-side via
+ * `auth()`; never exposed to the client. Shape + error semantics mirror the
+ * sibling `container.ts` / `agent.ts` actions so CatalogRowActions can treat
+ * all admin server actions uniformly.
+ */
+
+interface ActionResult {
+  ok: boolean;
+  status: number;
+  data?: unknown;
+  error?: string;
+}
+
+async function adminPost(path: string, body?: object): Promise<ActionResult> {
+  const { getToken } = await auth();
+  const token = await getToken();
+  if (!token) {
+    return { ok: false, status: 401, error: "missing_token" };
+  }
+
+  const base = apiUrl().replace(/\/+$/, "");
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": randomUUID(),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      cache: "no-store",
+    });
+    const text = await res.text();
+    let data: unknown = undefined;
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        data,
+        error:
+          (data && typeof data === "object" && "detail" in data
+            ? String((data as { detail?: unknown }).detail)
+            : undefined) ?? `http_${res.status}`,
+      };
+    }
+    return { ok: true, status: res.status, data };
+  } catch (e) {
+    return {
+      ok: false,
+      status: 0,
+      error: e instanceof Error ? e.message : "network_error",
+    };
+  }
+}
+
+/**
+ * Publish an agent to the shared catalog. Optional `slug` / `description`
+ * overrides let the caller rename the template or edit its blurb at publish
+ * time; omitted fields default to the agent's current metadata on the
+ * backend.
+ */
+export async function publishAgent(
+  agentId: string,
+  slug?: string,
+  description?: string,
+): Promise<ActionResult> {
+  const body: Record<string, string> = { agent_id: agentId };
+  if (slug) body.slug = slug;
+  if (description) body.description = description;
+  return adminPost("/admin/catalog/publish", body);
+}
+
+/** Retire a catalog slug. History remains queryable; newcomers no longer see it. */
+export async function unpublishSlug(slug: string): Promise<ActionResult> {
+  return adminPost(`/admin/catalog/${encodeURIComponent(slug)}/unpublish`);
+}
+
+export type { ActionResult };

--- a/apps/frontend/src/app/admin/_lib/api.ts
+++ b/apps/frontend/src/app/admin/_lib/api.ts
@@ -314,3 +314,65 @@ export async function getCloudwatchUrl(
     { query: { start, end, level } },
   );
 }
+
+// ---------------------------------------------------------------------------
+// Catalog (shared agent templates)
+//
+// The admin catalog view lists both currently-live entries (one per slug,
+// newest version) and retired slugs (tombstoned so names don't get reused).
+// Per-slug history exposes every published manifest version for rollback /
+// audit. Field shapes mirror `CatalogListItem` / `CatalogRetiredItem` /
+// `CatalogVersion` in apps/backend/core/services/catalog_service.py.
+// ---------------------------------------------------------------------------
+
+export interface CatalogLiveEntry {
+  slug: string;
+  name: string;
+  emoji: string;
+  vibe: string;
+  description: string;
+  current_version: number;
+  published_at: string;
+  published_by: string;
+  suggested_model: string;
+  suggested_channels: string[];
+  required_skills: string[];
+  required_plugins: string[];
+}
+
+export interface CatalogRetiredEntry {
+  slug: string;
+  last_version: number;
+  last_manifest_url: string;
+  retired_at: string;
+  retired_by: string;
+}
+
+export interface AdminCatalog {
+  live: CatalogLiveEntry[];
+  retired: CatalogRetiredEntry[];
+}
+
+export interface CatalogVersion {
+  version: number;
+  manifest_url: string;
+  published_at: string;
+  published_by: string;
+  manifest: Record<string, unknown>;
+}
+
+export async function listCatalog(token: string): Promise<AdminCatalog> {
+  const data = await adminFetch<AdminCatalog>(token, "/admin/catalog");
+  return data ?? { live: [], retired: [] };
+}
+
+export async function listSlugVersions(
+  token: string,
+  slug: string,
+): Promise<CatalogVersion[]> {
+  const data = await adminFetch<{ versions: CatalogVersion[] }>(
+    token,
+    `/admin/catalog/${encodeURIComponent(slug)}/versions`,
+  );
+  return data?.versions ?? [];
+}

--- a/apps/frontend/src/app/admin/catalog/CatalogPageClient.tsx
+++ b/apps/frontend/src/app/admin/catalog/CatalogPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import type { AdminCatalog, CatalogVersion } from "@/app/admin/_lib/api";
 
@@ -23,11 +23,22 @@ export function CatalogPageClient({ catalog }: CatalogPageClientProps) {
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [versions, setVersions] = useState<CatalogVersion[] | null>(null);
   const [retiredOpen, setRetiredOpen] = useState(false);
+  // Increments on every openVersionsFor invocation and on panel close; the
+  // in-flight request captures the current value at send time and discards
+  // its own result if it no longer matches. Prevents a stale response from
+  // overwriting the panel when the operator clicks a second row (or closes
+  // the panel) before the first fetch resolves.
+  const versionsRequestIdRef = useRef(0);
 
   async function openVersionsFor(slug: string) {
+    const requestId = ++versionsRequestIdRef.current;
     setSelectedSlug(slug);
     setVersions(null);
     const result = await fetchVersions(slug);
+    if (requestId !== versionsRequestIdRef.current) {
+      // A newer request (or panel close) superseded this one — drop the stale result.
+      return;
+    }
     setVersions(result);
   }
 
@@ -128,6 +139,7 @@ export function CatalogPageClient({ catalog }: CatalogPageClientProps) {
         slug={selectedSlug}
         versions={versions}
         onClose={() => {
+          versionsRequestIdRef.current += 1;
           setSelectedSlug(null);
           setVersions(null);
         }}

--- a/apps/frontend/src/app/admin/catalog/CatalogPageClient.tsx
+++ b/apps/frontend/src/app/admin/catalog/CatalogPageClient.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+
+import type { AdminCatalog, CatalogVersion } from "@/app/admin/_lib/api";
+
+import { CatalogRowActions } from "./CatalogRowActions";
+import { fetchVersions } from "./fetchVersions";
+import { VersionsPanel } from "./VersionsPanel";
+
+interface CatalogPageClientProps {
+  catalog: AdminCatalog;
+}
+
+/**
+ * Client shell for /admin/catalog. Owns the selected-slug + loaded-versions
+ * state for the right-side VersionsPanel. The parent Server Component passes
+ * the initial catalog listing (server-rendered with the bearer token) and we
+ * lazy-load per-slug version history through a Server Action so the token
+ * never leaves the server.
+ */
+export function CatalogPageClient({ catalog }: CatalogPageClientProps) {
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [versions, setVersions] = useState<CatalogVersion[] | null>(null);
+  const [retiredOpen, setRetiredOpen] = useState(false);
+
+  async function openVersionsFor(slug: string) {
+    setSelectedSlug(slug);
+    setVersions(null);
+    const result = await fetchVersions(slug);
+    setVersions(result);
+  }
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold text-neutral-100 mb-4">Catalog</h1>
+
+      <section className="mb-8">
+        <h2 className="text-xs uppercase tracking-wide text-neutral-500 mb-2">
+          Live ({catalog.live.length})
+        </h2>
+        {catalog.live.length === 0 ? (
+          <p className="text-sm text-neutral-400">
+            No agents published yet. Publish one from its admin detail page.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-left text-neutral-500">
+              <tr>
+                <th className="py-2 px-3">Slug</th>
+                <th className="py-2 px-3">Name</th>
+                <th className="py-2 px-3">Version</th>
+                <th className="py-2 px-3">Published</th>
+                <th className="py-2 px-3">By</th>
+                <th className="py-2 px-3"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {catalog.live.map((e) => (
+                <tr
+                  key={e.slug}
+                  className="border-t border-neutral-800 text-neutral-200"
+                >
+                  <td className="py-2 px-3">
+                    <span aria-hidden className="mr-1">
+                      {e.emoji || "🤖"}
+                    </span>
+                    {e.slug}
+                  </td>
+                  <td className="py-2 px-3">{e.name}</td>
+                  <td className="py-2 px-3">v{e.current_version}</td>
+                  <td className="py-2 px-3 text-neutral-400">
+                    {e.published_at}
+                  </td>
+                  <td className="py-2 px-3 text-neutral-400">
+                    {e.published_by}
+                  </td>
+                  <td className="py-2 px-3">
+                    <CatalogRowActions
+                      slug={e.slug}
+                      name={e.name}
+                      onOpenVersions={openVersionsFor}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section>
+        <button
+          type="button"
+          onClick={() => setRetiredOpen((o) => !o)}
+          className="text-xs uppercase tracking-wide text-neutral-500 mb-2 hover:text-neutral-300"
+        >
+          {retiredOpen ? "▾" : "▸"} Retired ({catalog.retired.length})
+        </button>
+        {retiredOpen && catalog.retired.length > 0 && (
+          <table className="w-full text-sm">
+            <thead className="text-left text-neutral-500">
+              <tr>
+                <th className="py-2 px-3">Slug</th>
+                <th className="py-2 px-3">Last version</th>
+                <th className="py-2 px-3">Retired at</th>
+                <th className="py-2 px-3">Retired by</th>
+              </tr>
+            </thead>
+            <tbody>
+              {catalog.retired.map((r) => (
+                <tr
+                  key={r.slug}
+                  className="border-t border-neutral-800 text-neutral-400"
+                >
+                  <td className="py-2 px-3">{r.slug}</td>
+                  <td className="py-2 px-3">v{r.last_version}</td>
+                  <td className="py-2 px-3">{r.retired_at}</td>
+                  <td className="py-2 px-3">{r.retired_by}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <VersionsPanel
+        slug={selectedSlug}
+        versions={versions}
+        onClose={() => {
+          setSelectedSlug(null);
+          setVersions(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/catalog/CatalogRowActions.tsx
+++ b/apps/frontend/src/app/admin/catalog/CatalogRowActions.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
 import { ConfirmActionDialog } from "@/components/admin/ConfirmActionDialog";
 import { Button } from "@/components/ui/button";
 import { unpublishSlug } from "@/app/admin/_actions/catalog";
@@ -18,20 +21,30 @@ export interface CatalogRowActionsProps {
  *
  * The Unpublish flow wraps `unpublishSlug` in `ConfirmActionDialog` with the
  * CEO S5 convention: the operator must type the literal phrase
- * `unpublish <slug>` before the action fires. We rethrow backend errors so the
- * dialog's own busy / error state handles the failure — keeping this island
- * state-free and cheap to re-render per row.
+ * `unpublish <slug>` before the action fires. On success we call
+ * `router.refresh()` so the parent Server Component re-runs and the retired
+ * slug moves out of the Live table immediately — without this, the row
+ * lingers until a manual reload and a second click hits a 404. Failures are
+ * captured into local state and surfaced inline; the dialog component itself
+ * has no error slot, so throwing would end up as an unhandled rejection with
+ * no operator-visible feedback.
  */
 export function CatalogRowActions({
   slug,
   name,
   onOpenVersions,
 }: CatalogRowActionsProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
   async function handleUnpublish() {
+    setError(null);
     const result = await unpublishSlug(slug);
     if (!result.ok) {
-      throw new Error(result.error ?? `unpublish_failed_${result.status}`);
+      setError(result.error ?? `unpublish_failed_${result.status}`);
+      return;
     }
+    router.refresh();
   }
 
   return (
@@ -54,6 +67,11 @@ export function CatalogRowActions({
       >
         View versions
       </Button>
+      {error && (
+        <span className="text-xs text-red-400 ml-2" role="alert">
+          {error}
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/app/admin/catalog/CatalogRowActions.tsx
+++ b/apps/frontend/src/app/admin/catalog/CatalogRowActions.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ConfirmActionDialog } from "@/components/admin/ConfirmActionDialog";
+import { Button } from "@/components/ui/button";
+import { unpublishSlug } from "@/app/admin/_actions/catalog";
+
+export interface CatalogRowActionsProps {
+  slug: string;
+  name: string;
+  onOpenVersions: (slug: string) => void;
+}
+
+/**
+ * Per-row action cluster for the admin catalog table. Pairs a
+ * typed-confirmation Unpublish dialog with a sibling "View versions" button
+ * that hoists selection state up to the parent page (the versions panel lives
+ * alongside the table so a single instance re-renders as the slug changes).
+ *
+ * The Unpublish flow wraps `unpublishSlug` in `ConfirmActionDialog` with the
+ * CEO S5 convention: the operator must type the literal phrase
+ * `unpublish <slug>` before the action fires. We rethrow backend errors so the
+ * dialog's own busy / error state handles the failure — keeping this island
+ * state-free and cheap to re-render per row.
+ */
+export function CatalogRowActions({
+  slug,
+  name,
+  onOpenVersions,
+}: CatalogRowActionsProps) {
+  async function handleUnpublish() {
+    const result = await unpublishSlug(slug);
+    if (!result.ok) {
+      throw new Error(result.error ?? `unpublish_failed_${result.status}`);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <ConfirmActionDialog
+        confirmText={`unpublish ${slug}`}
+        actionLabel={`Unpublish ${name}`}
+        destructive
+        onConfirm={handleUnpublish}
+      >
+        <Button type="button" variant="outline" size="sm">
+          Unpublish
+        </Button>
+      </ConfirmActionDialog>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onOpenVersions(slug)}
+      >
+        View versions
+      </Button>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/admin/catalog/VersionsPanel.tsx
+++ b/apps/frontend/src/app/admin/catalog/VersionsPanel.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+
+import type { CatalogVersion } from "@/app/admin/_lib/api";
+
+export interface VersionsPanelProps {
+  slug: string | null;
+  versions: CatalogVersion[] | null;
+  onClose: () => void;
+}
+
+/**
+ * Right-side drawer that renders a slug's publish history. The bearer token
+ * lives server-side, so this component never fetches — the parent page loads
+ * versions via a Server Action and threads them down as a prop. The three
+ * states are encoded in the `versions` prop:
+ *
+ * - `null`: request in flight — render "Loading…"
+ * - `[]`  : no versions (edge case for a brand-new slug) — render empty state
+ * - array : render rows with a per-version expand-to-show-manifest toggle
+ *
+ * `slug === null` hides the panel entirely so the caller can use a single
+ * always-mounted instance and toggle visibility by setting/clearing the slug.
+ */
+export function VersionsPanel({ slug, versions, onClose }: VersionsPanelProps) {
+  const [openVersion, setOpenVersion] = useState<number | null>(null);
+
+  if (!slug) return null;
+
+  return (
+    <aside className="fixed right-0 top-0 h-full w-96 bg-neutral-900 border-l border-neutral-800 p-6 overflow-y-auto z-50">
+      <div className="flex items-start justify-between mb-4">
+        <h3 className="text-lg font-semibold text-neutral-100">
+          {slug} versions
+        </h3>
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="p-1 rounded hover:bg-neutral-800"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      {versions === null && (
+        <p className="text-sm text-neutral-400">Loading…</p>
+      )}
+      {versions?.length === 0 && (
+        <p className="text-sm text-neutral-400">No versions found.</p>
+      )}
+      {versions?.map((v) => (
+        <div
+          key={v.version}
+          className="mb-4 border border-neutral-800 rounded p-3"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-neutral-200">
+              v{v.version}
+            </span>
+            <span className="text-xs text-neutral-500">{v.published_at}</span>
+          </div>
+          <div className="text-xs text-neutral-500 mt-1">
+            Published by {v.published_by}
+          </div>
+          <button
+            type="button"
+            onClick={() =>
+              setOpenVersion(openVersion === v.version ? null : v.version)
+            }
+            className="mt-2 text-xs text-indigo-400 hover:underline"
+          >
+            {openVersion === v.version ? "Hide" : "Show"} manifest
+          </button>
+          {openVersion === v.version && (
+            <pre className="mt-2 text-xs bg-neutral-950 text-neutral-300 p-2 rounded overflow-x-auto">
+              {JSON.stringify(v.manifest, null, 2)}
+            </pre>
+          )}
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/apps/frontend/src/app/admin/catalog/fetchVersions.ts
+++ b/apps/frontend/src/app/admin/catalog/fetchVersions.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { listSlugVersions, type CatalogVersion } from "@/app/admin/_lib/api";
+
+/**
+ * Server Action invoked from CatalogPageClient when the operator opens the
+ * VersionsPanel for a slug. Keeps the Clerk bearer token server-side — the
+ * client never sees it — and returns the version history array directly so
+ * the parent can thread it into the panel as a prop.
+ */
+export async function fetchVersions(slug: string): Promise<CatalogVersion[]> {
+  const { getToken } = await auth();
+  const token = (await getToken()) ?? "";
+  return listSlugVersions(token, slug);
+}

--- a/apps/frontend/src/app/admin/catalog/page.tsx
+++ b/apps/frontend/src/app/admin/catalog/page.tsx
@@ -1,0 +1,15 @@
+import { auth } from "@clerk/nextjs/server";
+
+import { listCatalog } from "@/app/admin/_lib/api";
+
+import { CatalogPageClient } from "./CatalogPageClient";
+
+export const metadata = { title: "Catalog · Admin" };
+
+export default async function CatalogPage() {
+  const { getToken } = await auth();
+  const token = (await getToken()) ?? "";
+  const catalog = await listCatalog(token);
+
+  return <CatalogPageClient catalog={catalog} />;
+}

--- a/apps/frontend/src/app/admin/layout.tsx
+++ b/apps/frontend/src/app/admin/layout.tsx
@@ -52,6 +52,12 @@ export default async function AdminLayout({
                 Users
               </Link>
               <Link
+                href="/admin/catalog"
+                className="rounded-md px-3 py-1.5 text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
+              >
+                Catalog
+              </Link>
+              <Link
                 href="/admin/health"
                 className="rounded-md px-3 py-1.5 text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100"
               >

--- a/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/AgentActionsFooter.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/AgentActionsFooter.tsx
@@ -7,10 +7,18 @@ import { ConfirmActionDialog } from "@/components/admin/ConfirmActionDialog";
 import { ErrorBanner } from "@/components/admin/ErrorBanner";
 import { Button } from "@/components/ui/button";
 import { clearAgentSessions, deleteAgent } from "@/app/admin/_actions/agent";
+import { publishAgent } from "@/app/admin/_actions/catalog";
 
 export interface AgentActionsFooterProps {
   userId: string;
   agentId: string;
+  agentName?: string;
+  /**
+   * When true, the admin is viewing their own agent and the "Publish to
+   * catalog" action is enabled. Publishing someone else's agent is blocked
+   * on the backend; the UI surfaces that up-front as a disabled button.
+   */
+  isOwnAgent: boolean;
 }
 
 /**
@@ -20,7 +28,12 @@ export interface AgentActionsFooterProps {
  * phrase and the 3-attempt lockout. We surface backend errors inline rather
  * than throwing so the SC stays mounted.
  */
-export function AgentActionsFooter({ userId, agentId }: AgentActionsFooterProps) {
+export function AgentActionsFooter({
+  userId,
+  agentId,
+  agentName,
+  isOwnAgent,
+}: AgentActionsFooterProps) {
   const router = useRouter();
   const [error, setError] = React.useState<string | null>(null);
   const [notice, setNotice] = React.useState<string | null>(null);
@@ -52,6 +65,18 @@ export function AgentActionsFooter({ userId, agentId }: AgentActionsFooterProps)
     router.refresh();
   }
 
+  async function handlePublish() {
+    setError(null);
+    setNotice(null);
+    const result = await publishAgent(agentId);
+    if (!result.ok) {
+      setError(result.error ?? "publish_failed");
+      return;
+    }
+    setNotice("Agent published to catalog.");
+    router.refresh();
+  }
+
   return (
     <div className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
       <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
@@ -80,6 +105,28 @@ export function AgentActionsFooter({ userId, agentId }: AgentActionsFooterProps)
             Clear sessions
           </Button>
         </ConfirmActionDialog>
+
+        {isOwnAgent ? (
+          <ConfirmActionDialog
+            confirmText={`publish ${agentName ?? agentId}`}
+            actionLabel="Publish to catalog"
+            onConfirm={handlePublish}
+          >
+            <Button type="button" variant="outline" size="sm">
+              Publish to catalog
+            </Button>
+          </ConfirmActionDialog>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled
+            title="Only your own agents can be published"
+          >
+            Publish to catalog
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/page.tsx
@@ -96,9 +96,10 @@ function toSessionRow(raw: unknown): SessionRow {
 export default async function AdminAgentDetailPage({ params }: PageProps) {
   const { id, agent_id: agentId } = await params;
 
-  const { getToken } = await auth();
+  const { userId: adminUserId, getToken } = await auth();
   const token = await getToken();
   const detail = token ? await getAgentDetail(token, id, agentId) : null;
+  const isOwnAgent = adminUserId === id;
 
   if (!detail) {
     return (
@@ -253,7 +254,12 @@ export default async function AdminAgentDetailPage({ params }: PageProps) {
       </section>
 
       {/* Destructive actions footer */}
-      <AgentActionsFooter userId={id} agentId={agentId} />
+      <AgentActionsFooter
+        userId={id}
+        agentId={agentId}
+        agentName={meta.name}
+        isOwnAgent={isOwnAgent}
+      />
     </div>
   );
 }

--- a/apps/frontend/tests/stubs/server-only.ts
+++ b/apps/frontend/tests/stubs/server-only.ts
@@ -1,0 +1,5 @@
+// No-op stub for Next.js `server-only` package under vitest (node env).
+// In production, `server-only` throws when imported into a client bundle;
+// in unit tests we're running in node with no such constraint, so it's safe
+// to expose the module as empty.
+export {};

--- a/apps/frontend/tests/unit/admin/catalog-row-actions.test.tsx
+++ b/apps/frontend/tests/unit/admin/catalog-row-actions.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const { unpublishMock } = vi.hoisted(() => ({
+  unpublishMock: vi.fn(async () => ({ ok: true, status: 200 })),
+}));
+vi.mock("@/app/admin/_actions/catalog", () => ({
+  unpublishSlug: unpublishMock,
+}));
+
+vi.mock("@/components/admin/ConfirmActionDialog", () => ({
+  ConfirmActionDialog: ({
+    children,
+    onConfirm,
+    confirmText,
+  }: {
+    children: React.ReactNode;
+    onConfirm: () => Promise<void>;
+    confirmText: string;
+  }) => (
+    <div data-testid="confirm-dialog" data-confirm-text={confirmText}>
+      {children}
+      <button onClick={onConfirm}>__confirm__</button>
+    </div>
+  ),
+}));
+
+import { CatalogRowActions } from "@/app/admin/catalog/CatalogRowActions";
+
+describe("CatalogRowActions", () => {
+  beforeEach(() => {
+    unpublishMock.mockReset();
+    unpublishMock.mockResolvedValue({ ok: true, status: 200 });
+  });
+
+  it("renders Unpublish + View versions buttons", () => {
+    render(
+      <CatalogRowActions slug="pitch" name="Pitch" onOpenVersions={vi.fn()} />,
+    );
+    expect(screen.getByRole("button", { name: /unpublish/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /view versions/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls unpublishSlug with the slug when the confirm dialog fires", async () => {
+    render(
+      <CatalogRowActions slug="pitch" name="Pitch" onOpenVersions={vi.fn()} />,
+    );
+    const confirm = within(screen.getByTestId("confirm-dialog")).getByText(
+      "__confirm__",
+    );
+    await userEvent.click(confirm);
+    expect(unpublishMock).toHaveBeenCalledWith("pitch");
+  });
+
+  it("sets confirm text to 'unpublish <slug>'", () => {
+    render(
+      <CatalogRowActions slug="pitch" name="Pitch" onOpenVersions={vi.fn()} />,
+    );
+    const dialog = screen.getByTestId("confirm-dialog");
+    expect(dialog.getAttribute("data-confirm-text")).toBe("unpublish pitch");
+  });
+
+  it("calls onOpenVersions when View versions clicked", async () => {
+    const onOpenVersions = vi.fn();
+    render(
+      <CatalogRowActions
+        slug="pitch"
+        name="Pitch"
+        onOpenVersions={onOpenVersions}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /view versions/i }),
+    );
+    expect(onOpenVersions).toHaveBeenCalledWith("pitch");
+  });
+});

--- a/apps/frontend/tests/unit/admin/catalog-row-actions.test.tsx
+++ b/apps/frontend/tests/unit/admin/catalog-row-actions.test.tsx
@@ -2,11 +2,26 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const { unpublishMock } = vi.hoisted(() => ({
+const { unpublishMock, refreshMock } = vi.hoisted(() => ({
   unpublishMock: vi.fn(async () => ({ ok: true, status: 200 })),
+  refreshMock: vi.fn(),
 }));
 vi.mock("@/app/admin/_actions/catalog", () => ({
   unpublishSlug: unpublishMock,
+}));
+
+// Per-file override of the global setup.ts next/navigation mock so we can
+// assert on router.refresh() — the global mock doesn't expose refresh.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: refreshMock,
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("@/components/admin/ConfirmActionDialog", () => ({
@@ -32,6 +47,7 @@ describe("CatalogRowActions", () => {
   beforeEach(() => {
     unpublishMock.mockReset();
     unpublishMock.mockResolvedValue({ ok: true, status: 200 });
+    refreshMock.mockReset();
   });
 
   it("renders Unpublish + View versions buttons", () => {
@@ -76,5 +92,35 @@ describe("CatalogRowActions", () => {
       screen.getByRole("button", { name: /view versions/i }),
     );
     expect(onOpenVersions).toHaveBeenCalledWith("pitch");
+  });
+
+  it("calls router.refresh after successful unpublish", async () => {
+    render(
+      <CatalogRowActions slug="pitch" name="Pitch" onOpenVersions={vi.fn()} />,
+    );
+    const confirm = within(screen.getByTestId("confirm-dialog")).getByText(
+      "__confirm__",
+    );
+    await userEvent.click(confirm);
+    await vi.waitFor(() => expect(refreshMock).toHaveBeenCalled());
+  });
+
+  it("shows inline error when unpublish fails", async () => {
+    unpublishMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      error: "Internal Server Error",
+    });
+    render(
+      <CatalogRowActions slug="pitch" name="Pitch" onOpenVersions={vi.fn()} />,
+    );
+    const confirm = within(screen.getByTestId("confirm-dialog")).getByText(
+      "__confirm__",
+    );
+    await userEvent.click(confirm);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Internal Server Error/,
+    );
+    expect(refreshMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/tests/unit/admin/catalog-server-actions.test.ts
+++ b/apps/frontend/tests/unit/admin/catalog-server-actions.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { authMock, getTokenMock, fetchMock } = vi.hoisted(() => {
+  const getTokenMock = vi.fn();
+  return {
+    getTokenMock,
+    authMock: vi.fn(async () => ({ getToken: getTokenMock })),
+    fetchMock: vi.fn(),
+  };
+});
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: authMock }));
+vi.stubGlobal("fetch", fetchMock);
+
+import { publishAgent, unpublishSlug } from "@/app/admin/_actions/catalog";
+
+describe("catalog server actions", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    getTokenMock.mockReset();
+    getTokenMock.mockResolvedValue("test-token");
+  });
+
+  it("publishAgent posts to /admin/catalog/publish", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ slug: "pitch", version: 1, s3_prefix: "pitch/v1" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await publishAgent("agent_abc");
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toMatch(/\/admin\/catalog\/publish$/);
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(init?.body as string)).toEqual({
+      agent_id: "agent_abc",
+    });
+  });
+
+  it("unpublishSlug posts to /admin/catalog/{slug}/unpublish", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ slug: "pitch", last_version: 3 }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await unpublishSlug("pitch");
+
+    expect(result.ok).toBe(true);
+    const [url] = fetchMock.mock.calls[0];
+    expect(String(url)).toMatch(/\/admin\/catalog\/pitch\/unpublish$/);
+  });
+
+  it("returns ok=false when token is missing", async () => {
+    getTokenMock.mockResolvedValueOnce(null);
+    const result = await publishAgent("agent_abc");
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates backend error status", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("{}", { status: 404 }),
+    );
+    const result = await unpublishSlug("ghost");
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+  });
+});

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // `server-only` is a Next.js runtime guard that errors on client import.
+      // In vitest (node), it's a no-op — alias to an empty stub so server-side
+      // modules (e.g. src/app/admin/_lib/url.ts) can be imported for unit tests.
+      'server-only': path.resolve(__dirname, './tests/stubs/server-only.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary

Builds on #316 (the one-click deploy catalog) by moving the operator flows — publish, unpublish, view versions — out of `scripts/publish-agent.sh` CLI and into the admin dashboard shipped by #351. Every catalog write now lands in the shared `admin-actions` audit table with the same fail-closed semantics as container/billing/account actions.

- **Publish** — `[Publish to catalog]` button on `/admin/users/[id]/agents/[agent_id]`, rendered only when the admin is viewing their own agent. Typed confirmation; backend endpoint unchanged except for the new `@audit_admin_action` wrapper.
- **Manage** — new `/admin/catalog` page lists every published slug with `[Unpublish]` and `[View versions]` per row, plus a collapsible "Retired" section.
- **Audit** — both `catalog.publish` and `catalog.unpublish` write audit rows with `target_user_id = "__catalog__"` sentinel (catalog is the target, not a user).
- **Shell script stays functional** — `publish-agent.sh` still works; it lands audit rows identical to the dashboard path via the same decorated endpoint.

## Design

| Concern | Decision |
|---|---|
| Unpublish semantics | Soft delete. Slug moves from `catalog.json#agents` to `catalog.json#retired`. S3 artifacts untouched for audit. |
| Retired slug reuse | Republishing a retired slug removes it from `retired` and re-adds to `agents` with next sequential version. |
| Whose agents can admin publish | Admin's own only (v1). Frontend gates the button by `params.id === auth.user_id`; backend reads from `auth.user_id`'s EFS. |
| Audit target for catalog actions | Sentinel `"__catalog__"` — not a user ID. Prevents per-user audit queries from colliding with catalog writes. |
| User-facing `/catalog` | Unchanged. Reads only the `agents` list; retired is invisible to end users. |

## Docs

- Spec: [`docs/superpowers/specs/2026-04-22-admin-catalog-integration-design.md`](docs/superpowers/specs/2026-04-22-admin-catalog-integration-design.md) (commit `ed9da0cc` on main)
- Plan: [`docs/superpowers/plans/2026-04-22-admin-catalog-integration.md`](docs/superpowers/plans/2026-04-22-admin-catalog-integration.md) (commit `73f05d4c` on main)

## Test plan

- [x] Backend unit suite: **1093 passing** on feature branch
- [x] New catalog service tests: 19 pass (6 new for `list_all` + `list_versions`, 5 new for `unpublish` + `retired` schema, existing 8)
- [x] New router tests: 12 pass (5 new for list/unpublish/versions + 1 for audit-on-publish, existing 6)
- [x] New audit-decorator tests: 2 pass (static override + kwarg fallback)
- [x] Frontend catalog tests: 8 pass (4 row actions + 4 Server Actions)
- [x] Frontend TypeScript: clean
- [x] Frontend lint: 0 errors
- [ ] **After merge:** admin signs in at `admin-dev.isol8.co/admin/catalog` — empty page renders. Publishes first agent via `[Publish to catalog]` on their agent detail page. Audit row in DDB. Unpublishes. Slug moves to retired. CLI `publish-agent.sh` still works and produces identical audit rows.

## Known pre-existing frontend test failures (not from this branch)

8 failures in unrelated test files that are red on main already:
- `PostHogProvider.test.tsx`
- `BotSetupWizard.test.tsx` (4 cases)
- `MyChannelsSection.test.tsx` (2 cases)
- `AgentChannelsSection.test.tsx`

These predate this PR and this PR does not touch any of the relevant source files. Documented for review — not blockers.

## Non-goals / Phase 2

- Publish-from-any-user (needs a consent flow for non-admin-owned agents)
- Deployed-count column on the catalog page
- Edit manifest fields post-publish
- "Recall" / force-update already-deployed users (fork model preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)