### PR TITLE
fix(infra): AuthStack posthog secret — use createSecret helper

### DIFF
--- a/apps/infra/lib/stacks/auth-stack.ts
+++ b/apps/infra/lib/stacks/auth-stack.ts
@@ -49,32 +49,19 @@ export class AuthStack extends cdk.Stack {
       });
     };
 
-    // PostHog personal API key for the admin Activity tab. Distinct from
-    // NEXT_PUBLIC_POSTHOG_KEY (which is the frontend ingest key). Defaults
-    // to empty string rather than a random value — an empty key makes
-    // posthog_admin.py short-circuit to {stubbed: true} so the backend
-    // starts cleanly before the operator populates the real key via
-    // `aws secretsmanager update-secret`.
-    const posthogProjectApiKey = new secretsmanager.Secret(
-      this,
-      "PosthogProjectApiKey",
-      {
-        secretName: `isol8/${env}/posthog_project_api_key`,
-        description: `Isol8 ${env} posthog_project_api_key`,
-        encryptionKey: this.kmsKey,
-        secretStringValue: cdk.SecretValue.unsafePlainText(
-          secretVals["posthog_project_api_key"] ?? "",
-        ),
-      },
-    );
-
     this.secrets = {
       clerkIssuer: createSecret("ClerkIssuer", "clerk_issuer"),
       clerkSecretKey: createSecret("ClerkSecretKey", "clerk_secret_key"),
       stripeSecretKey: createSecret("StripeSecretKey", "stripe_secret_key"),
       stripeWebhookSecret: createSecret("StripeWebhookSecret", "stripe_webhook_secret"),
       encryptionKey: createSecret("EncryptionKey", "encryption_key"),
-      posthogProjectApiKey,
+      // Same createSecret pattern as Clerk/Stripe — CDK generates a random
+      // placeholder on first create (CFN emits only GenerateSecretString).
+      // Operator immediately overrides via `aws secretsmanager update-secret`
+      // with the real phx_ key from PostHog. Harmless until then because
+      // posthog_admin.py also gates on POSTHOG_PROJECT_ID being set, and
+      // that defaults to empty in service-stack's environment block.
+      posthogProjectApiKey: createSecret("PosthogProjectApiKey", "posthog_project_api_key"),
     };
   }
 }


### PR DESCRIPTION
## Summary

Fixes the CFN error from PR #371's deploy:
> Resource handler returned message: \"Can only specify either SecretString or GenerateSecretString.\"

The auth stack's `PosthogProjectApiKey` resource failed in CloudFormation because the template had both `SecretString=\"\"` and `GenerateSecretString` — mutually exclusive CFN properties. Caused by `secretStringValue: cdk.SecretValue.unsafePlainText(\"\")` in the original wiring.

## Fix

Use the same `createSecret` helper as Clerk / Stripe / encryption secrets. With no initial value provided, CDK emits only `GenerateSecretString` (a random placeholder). The operator populates the real `phx_` PostHog key immediately after deploy via:

```bash
aws secretsmanager update-secret \
  --secret-id isol8/dev/posthog_project_api_key \
  --secret-string "phx_REAL_KEY" \
  --profile isol8-admin
```

The random placeholder is harmless because `posthog_admin.py` gates the Persons API call on **both** `POSTHOG_PROJECT_API_KEY` and `POSTHOG_PROJECT_ID` being set, and `POSTHOG_PROJECT_ID` defaults to empty in `service-stack.ts`.

## Test plan

- [x] `cdk synth` clean across all stages
- [ ] After merge: AuthStack deploys cleanly, creates `isol8/{env}/posthog_project_api_key` secret with random placeholder
- [ ] Operator runs `update-secret` with the real key
- [ ] Future PR sets `POSTHOG_PROJECT_ID` + fixes `POSTHOG_HOST` to `us.posthog.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)