### PR TITLE
infra(posthog): POSTHOG_PROJECT_ID=380894 + us.posthog.com host

### DIFF
--- a/apps/infra/lib/stacks/service-stack.ts
+++ b/apps/infra/lib/stacks/service-stack.ts
@@ -623,13 +623,13 @@ export class ServiceStack extends cdk.Stack {
         CLOUD_MAP_SERVICE_ARN: props.container.cloudMapService.serviceArn,
         DYNAMODB_TABLE_PREFIX: `isol8-${env}-`,
         AGENT_CATALOG_BUCKET: agentCatalogBucket.bucketName,
-        // PostHog server-side reads for the admin Activity tab. Host is the
-        // same for every env; project ID is public (visible in every
-        // PostHog URL). The personal API key is sensitive — comes in via
-        // the secrets: block below. posthog_admin.py stubs when the key is
-        // empty, so leaving POSTHOG_PROJECT_ID unset here is also safe.
-        POSTHOG_HOST: "https://app.posthog.com",
-        POSTHOG_PROJECT_ID: "",
+        // PostHog server-side reads for the admin Activity tab.
+        // us.posthog.com is the API host for US Cloud (our project lives
+        // there). Project ID is public — visible in the PostHog dashboard
+        // URL for the Default project. Personal API key comes in via the
+        // secrets: block below.
+        POSTHOG_HOST: "https://us.posthog.com",
+        POSTHOG_PROJECT_ID: "380894",
         // Observability: page topic ARN for backend-initiated SNS alerts.
         // Populated after first deploy via Fn.importValue from ObservabilityStack.
         ...(props.alertPageTopicArn


### PR DESCRIPTION
## Summary

Final piece of the admin Activity tab wiring. Combined with:
- PR #371 — wired `POSTHOG_HOST` / `POSTHOG_PROJECT_ID` / `POSTHOG_PROJECT_API_KEY` into the backend task
- PR #372 — fixed the AuthStack CFN error so the `isol8/{env}/posthog_project_api_key` secret auto-creates
- Secrets Manager — operator populated both `isol8/dev/posthog_project_api_key` and `isol8/prod/posthog_project_api_key` with the real `phx_` key

…this completes the setup. After this lands + deploy runs, the admin Activity tab at `/admin/users/[id]/activity` will show real PostHog events instead of stubbing.

## Changes

- `POSTHOG_HOST`: `app.posthog.com` → `us.posthog.com`. The PostHog project is in US Cloud; `app.posthog.com` is the EU-defaulted UI alias.
- `POSTHOG_PROJECT_ID`: `""` → `"380894"`. Project ID is public (in the dashboard URL), not a secret.

Same values for both dev and prod envs — the org shares one PostHog project, same as how `NEXT_PUBLIC_POSTHOG_KEY` is shared by the frontend.

## Test plan

- [x] `cdk synth` clean
- [ ] After merge: backend task gets `POSTHOG_PROJECT_ID=380894` + `POSTHOG_HOST=https://us.posthog.com`. `posthog_admin.py` stops stubbing; admin Activity tab fetches from the Persons API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)