### PR TITLE
fix(admin): rename admin-dev.isol8.co → admin.dev.isol8.co

### DIFF
--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 
 const isProtectedRoute = createRouteMatcher(["/chat(.*)", "/onboarding", "/settings(.*)"]);
 
-const DEFAULT_ADMIN_HOSTS = "admin.isol8.co,admin-dev.isol8.co,admin.localhost:3000";
+const DEFAULT_ADMIN_HOSTS = "admin.isol8.co,admin.dev.isol8.co,admin.localhost:3000";
 
 function parseAdminHosts(raw: string | undefined): Set<string> {
   const source = raw && raw.length > 0 ? raw : DEFAULT_ADMIN_HOSTS;

--- a/apps/frontend/tests/e2e/admin.spec.ts
+++ b/apps/frontend/tests/e2e/admin.spec.ts
@@ -11,7 +11,7 @@ import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright';
  * this from CI.
  *
  * TODO Phase F follow-ups (tracked in docs/runbooks/admin-rollout.md):
- *   1. DNS + Vercel domain alias for `admin-dev.isol8.co` -> `isol8-frontend-dev`.
+ *   1. DNS + Vercel domain alias for `admin.dev.isol8.co` -> `isol8-frontend-dev`.
  *   2. Cloudflare bypass + `VERCEL_AUTOMATION_BYPASS_SECRET` for the admin host.
  *   3. Seed a Clerk test user in `PLATFORM_ADMIN_USER_IDS` and surface its
  *      credentials via fixtures (similar to `personal.spec.ts`).
@@ -22,7 +22,7 @@ import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright';
 test.describe('admin dashboard golden path', () => {
   test.skip(
     ({ baseURL }) => !baseURL?.includes('admin'),
-    'Only runs against the admin host (BASE_URL=https://admin-dev.isol8.co).',
+    'Only runs against the admin host (BASE_URL=https://admin.dev.isol8.co).',
   );
 
   test('admin can sign in, view a user, fire a read-only action', async ({

--- a/apps/frontend/tests/unit/admin/middleware.test.ts
+++ b/apps/frontend/tests/unit/admin/middleware.test.ts
@@ -3,7 +3,7 @@ import { decideAdminHostRouting } from '@/middleware';
 
 const ADMIN_HOSTS = new Set([
   'admin.isol8.co',
-  'admin-dev.isol8.co',
+  'admin.dev.isol8.co',
   'admin.localhost:3000',
 ]);
 

--- a/docs/runbooks/admin-rollout.md
+++ b/docs/runbooks/admin-rollout.md
@@ -1,6 +1,6 @@
 # Admin dashboard rollout
 
-Operational runbook for `admin.isol8.co` (and `admin-dev.isol8.co`).
+Operational runbook for `admin.isol8.co` (and `admin.dev.isol8.co`).
 
 **Tracking issue:** [Isol8AI/isol8#351](https://github.com/Isol8AI/isol8/issues/351)
 **Spec:** [`docs/superpowers/specs/2026-04-21-admin-dashboard-design.md`](../superpowers/specs/2026-04-21-admin-dashboard-design.md)
@@ -16,7 +16,7 @@ Operational runbook for `admin.isol8.co` (and `admin-dev.isol8.co`).
 
 ## Prerequisites — one-time per environment
 
-1. **DNS + Vercel domain alias:** `admin-dev.isol8.co` → `isol8-frontend-dev` Vercel project; `admin.isol8.co` → `isol8-frontend-prod`. Verify with `dig admin-dev.isol8.co CNAME`.
+1. **DNS + Vercel domain alias:** `admin.dev.isol8.co` → `isol8-frontend-dev` Vercel project; `admin.isol8.co` → `isol8-frontend-prod`. Verify with `dig admin.dev.isol8.co CNAME`.
 2. **Backend secrets** (one Secrets Manager entry per value, consistent with existing `isol8/{env}/clerk_issuer`, `isol8/{env}/stripe_secret_key`, etc.):
    - `isol8/{env}/platform_admin_user_ids` — comma-separated Clerk user IDs of the Isol8 team. Wired into the backend task as `PLATFORM_ADMIN_USER_IDS`.
    - `isol8/{env}/posthog_project_api_key` — PostHog personal API key with scopes `person:read`, `events:read`, `session_recording:read`. Wired as `POSTHOG_PROJECT_API_KEY`. Optional; the Activity tab stubs gracefully when absent.
@@ -93,7 +93,7 @@ PLATFORM_ADMIN_USER_IDS=user_<your dev Clerk id>
 Frontend env (`apps/frontend/.env.local`):
 
 ```
-NEXT_PUBLIC_ADMIN_HOSTS=admin.isol8.co,admin-dev.isol8.co,admin.localhost:3000
+NEXT_PUBLIC_ADMIN_HOSTS=admin.isol8.co,admin.dev.isol8.co,admin.localhost:3000
 ```
 
 Then `pnpm dev` and visit `http://admin.localhost:3000/admin` (Chrome/Safari resolve `*.localhost` → 127.0.0.1 automatically — no `/etc/hosts` edit).


### PR DESCRIPTION
Operator chose the sub-subdomain pattern. DNS is now live (A record to 76.76.21.21). Middleware default + the 3 references in tests/docs swap over. Once this merges + Vercel redeploys, the admin dashboard is reachable at `admin.dev.isol8.co/admin`.