### PR TITLE
fix(admin): resolve org owner_id when viewing org-member users

### DIFF
--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -20,6 +20,7 @@ timeout via _with_timeout. Slow Stripe doesn't starve other panels.
 
 import asyncio
 import logging
+import uuid
 from typing import Any
 
 from core.containers import get_ecs_manager, get_gateway_pool
@@ -55,8 +56,22 @@ async def _resolve_owner_for_admin(user_id: str) -> tuple[str, dict | None]:
         Clerk lookup errors (fail-open: better to show personal-mode data
         than to break the dashboard).
     """
+    # Bound Clerk call with the same per-panel timeout budget used by
+    # _with_timeout — a slow Clerk upstream must not block overview / agents /
+    # detail before their own _with_timeout-wrapped reads even start. Read the
+    # constant at call time so tests can monkeypatch _PARALLEL_TIMEOUT_S.
     try:
-        orgs = await clerk_admin.list_user_organizations(user_id)
+        orgs = await asyncio.wait_for(
+            clerk_admin.list_user_organizations(user_id),
+            timeout=_PARALLEL_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "admin_service._resolve_owner_for_admin Clerk timeout for %s after %ss; falling back to personal-mode",
+            user_id,
+            _PARALLEL_TIMEOUT_S,
+        )
+        return user_id, None
     except Exception as e:  # noqa: BLE001 — defensive, Clerk must never take the dashboard down
         logger.warning("admin_service._resolve_owner_for_admin Clerk error for %s: %s", user_id, e)
         return user_id, None
@@ -194,11 +209,16 @@ async def list_user_agents(user_id: str, *, cursor: str | None = None, limit: in
         return {"agents": [], "cursor": None, "container_status": "unreachable", "org": org_context}
 
     pool = get_gateway_pool()
+    # uuid4 entropy in req_id: after switching to owner_id, all members of an
+    # org share a single gateway connection whose pending-RPC dict is keyed by
+    # req_id. A deterministic id would let concurrent admin requests overwrite
+    # each other's futures (intermittent timeouts / mismatched responses).
+    nonce = uuid.uuid4().hex[:8]
     try:
         result = await asyncio.wait_for(
             pool.send_rpc(
                 user_id=owner_id,
-                req_id=f"admin-agents-list-{owner_id}",
+                req_id=f"admin-agents-list-{owner_id}-{nonce}",
                 method="agents.list",
                 params={"cursor": cursor, "limit": limit},
                 ip=ip,
@@ -261,9 +281,13 @@ async def get_agent_detail(user_id: str, agent_id: str) -> dict:
     token = container["gateway_token"]
 
     async def _rpc(method: str, params: dict, suffix: str) -> Any:
+        # uuid4 entropy in req_id: same org → shared gateway connection whose
+        # pending-RPC dict is keyed by req_id. Deterministic ids collide on
+        # concurrent detail loads for the same agent (see list_user_agents).
+        nonce = uuid.uuid4().hex[:8]
         return await pool.send_rpc(
             user_id=owner_id,
-            req_id=f"admin-{suffix}-{agent_id}",
+            req_id=f"admin-{suffix}-{agent_id}-{nonce}",
             method=method,
             params=params,
             ip=ip,

--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -35,7 +35,7 @@ _PARALLEL_TIMEOUT_S = 2.0
 _GATEWAY_RPC_TIMEOUT_S = 3.0
 
 
-async def _resolve_owner_for_admin(user_id: str) -> tuple[str, dict | None]:
+async def resolve_admin_owner_id(user_id: str) -> tuple[str, dict | None]:
     """Return (owner_id, org_context) for a target user viewed by an admin.
 
     The DDB partition key ``owner_id`` is the Clerk org_id for org-member
@@ -44,6 +44,13 @@ async def _resolve_owner_for_admin(user_id: str) -> tuple[str, dict | None]:
     which org (if any) the user belongs to before querying repos — otherwise
     every org-member user renders as "no container provisioned" (CEO
     admin-org-owner-id bug).
+
+    This is the public helper used by both admin_service read composition and
+    the admin router's mutation handlers (container / billing / config /
+    agents) — org-member mutation targets ``openclaw-{org_id}-{hash}``, not
+    ``openclaw-{user_id}-{hash}``. Account mutations (suspend / reactivate /
+    force-signout / resend-verification) target the Clerk user directly and
+    MUST NOT call this resolver.
 
     Per ``project_single_org_per_user`` memory, users are assumed to be in at
     most one org. If Clerk returns multiple (shouldn't happen), pick the
@@ -67,13 +74,13 @@ async def _resolve_owner_for_admin(user_id: str) -> tuple[str, dict | None]:
         )
     except asyncio.TimeoutError:
         logger.warning(
-            "admin_service._resolve_owner_for_admin Clerk timeout for %s after %ss; falling back to personal-mode",
+            "admin_service.resolve_admin_owner_id Clerk timeout for %s after %ss; falling back to personal-mode",
             user_id,
             _PARALLEL_TIMEOUT_S,
         )
         return user_id, None
     except Exception as e:  # noqa: BLE001 — defensive, Clerk must never take the dashboard down
-        logger.warning("admin_service._resolve_owner_for_admin Clerk error for %s: %s", user_id, e)
+        logger.warning("admin_service.resolve_admin_owner_id Clerk error for %s: %s", user_id, e)
         return user_id, None
 
     if not orgs:
@@ -88,6 +95,15 @@ async def _resolve_owner_for_admin(user_id: str) -> tuple[str, dict | None]:
 
     org = orgs[0]
     return org["id"], org
+
+
+# Back-compat alias: the helper was previously private (``_resolve_owner_for_admin``)
+# and is still referenced by at least one regression test. Keep the alias so the
+# existing unit test in test_admin_org_resolution.py (``test_resolve_owner_falls_back_
+# to_personal_mode_on_clerk_timeout``) keeps working without churning the test
+# name alongside the rename. Safe to delete in a follow-up once the test is
+# migrated.
+_resolve_owner_for_admin = resolve_admin_owner_id
 
 
 async def _with_timeout(coro, label: str, timeout_s: float | None = None):
@@ -167,7 +183,7 @@ async def get_overview(user_id: str) -> dict:
     """
     period = "current"  # usage_repo uses "YYYY-MM" or "current"; current covers month-to-date
 
-    owner_id, org_context = await _resolve_owner_for_admin(user_id)
+    owner_id, org_context = await resolve_admin_owner_id(user_id)
 
     clerk, container, billing, usage = await asyncio.gather(
         _with_timeout(clerk_admin.get_user(user_id), "clerk"),
@@ -192,7 +208,7 @@ async def list_user_agents(user_id: str, *, cursor: str | None = None, limit: in
     org_id, not user_id. ``org`` in the response is null for personal-mode
     users and {id, slug, name, role} otherwise.
     """
-    owner_id, org_context = await _resolve_owner_for_admin(user_id)
+    owner_id, org_context = await resolve_admin_owner_id(user_id)
 
     container_row = await container_repo.get_by_owner_id(owner_id)
     if not container_row or container_row.get("status") != "running":
@@ -262,7 +278,7 @@ async def get_agent_detail(user_id: str, agent_id: str) -> dict:
     the response is null for personal-mode users and {id, slug, name, role}
     otherwise.
     """
-    owner_id, org_context = await _resolve_owner_for_admin(user_id)
+    owner_id, org_context = await resolve_admin_owner_id(user_id)
 
     container_row = await container_repo.get_by_owner_id(owner_id)
     if not container_row or container_row.get("status") != "running":

--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -34,6 +34,47 @@ _PARALLEL_TIMEOUT_S = 2.0
 _GATEWAY_RPC_TIMEOUT_S = 3.0
 
 
+async def _resolve_owner_for_admin(user_id: str) -> tuple[str, dict | None]:
+    """Return (owner_id, org_context) for a target user viewed by an admin.
+
+    The DDB partition key ``owner_id`` is the Clerk org_id for org-member
+    resources and the Clerk user_id for personal-mode resources. The admin
+    dashboard receives the target user_id from the URL, so we must ask Clerk
+    which org (if any) the user belongs to before querying repos — otherwise
+    every org-member user renders as "no container provisioned" (CEO
+    admin-org-owner-id bug).
+
+    Per ``project_single_org_per_user`` memory, users are assumed to be in at
+    most one org. If Clerk returns multiple (shouldn't happen), pick the
+    first and log a warning.
+
+    Returns:
+      (org_id, org_context_dict) when the user is in an org; org_context is
+        {"id", "slug", "name", "role"}.
+      (user_id, None) when the user is personal-mode (no orgs) or when the
+        Clerk lookup errors (fail-open: better to show personal-mode data
+        than to break the dashboard).
+    """
+    try:
+        orgs = await clerk_admin.list_user_organizations(user_id)
+    except Exception as e:  # noqa: BLE001 — defensive, Clerk must never take the dashboard down
+        logger.warning("admin_service._resolve_owner_for_admin Clerk error for %s: %s", user_id, e)
+        return user_id, None
+
+    if not orgs:
+        return user_id, None
+
+    if len(orgs) > 1:
+        logger.warning(
+            "admin_service: Clerk returned %d orgs for user %s — single-org-per-user expected; using first",
+            len(orgs),
+            user_id,
+        )
+
+    org = orgs[0]
+    return org["id"], org
+
+
 async def _with_timeout(coro, label: str, timeout_s: float | None = None):
     """Wrap a coroutine with a timeout; return {error, source} on timeout/error.
 
@@ -100,16 +141,24 @@ async def list_users(*, q: str = "", limit: int = 50, cursor: str | None = None)
 async def get_overview(user_id: str) -> dict:
     """Identity + billing + container + usage in one payload.
 
-    Five parallel fetches with per-call timeout — slow Stripe doesn't
-    starve the others; each panel can render even if its source errors.
+    Parallel fetches with per-call timeout — slow Stripe doesn't starve the
+    others; each panel can render even if its source errors.
+
+    For org-member users the container / billing / usage records are keyed
+    by owner_id == org_id. We resolve the effective owner via Clerk before
+    issuing the DDB reads so admins see the org's resources, not empty
+    personal-mode rows (admin-org-owner-id fix). The returned ``org`` field
+    is null for personal-mode users and {id, slug, name, role} otherwise.
     """
     period = "current"  # usage_repo uses "YYYY-MM" or "current"; current covers month-to-date
 
+    owner_id, org_context = await _resolve_owner_for_admin(user_id)
+
     clerk, container, billing, usage = await asyncio.gather(
         _with_timeout(clerk_admin.get_user(user_id), "clerk"),
-        _with_timeout(container_repo.get_by_owner_id(user_id), "ddb_containers"),
-        _with_timeout(billing_repo.get_by_owner_id(user_id), "ddb_billing"),
-        _with_timeout(usage_repo.get_period_usage(user_id, period), "ddb_usage"),
+        _with_timeout(container_repo.get_by_owner_id(owner_id), "ddb_containers"),
+        _with_timeout(billing_repo.get_by_owner_id(owner_id), "ddb_billing"),
+        _with_timeout(usage_repo.get_period_usage(owner_id, period), "ddb_usage"),
     )
 
     return {
@@ -117,30 +166,39 @@ async def get_overview(user_id: str) -> dict:
         "container": container,
         "billing": billing,
         "usage": usage,
+        "org": org_context,
     }
 
 
 async def list_user_agents(user_id: str, *, cursor: str | None = None, limit: int = 50) -> dict:
-    """Agents list via gateway RPC with E2 timeout + E3 stopped detection."""
-    container_row = await container_repo.get_by_owner_id(user_id)
+    """Agents list via gateway RPC with E2 timeout + E3 stopped detection.
+
+    Resolves org context first — org-member users' container is keyed by
+    org_id, not user_id. ``org`` in the response is null for personal-mode
+    users and {id, slug, name, role} otherwise.
+    """
+    owner_id, org_context = await _resolve_owner_for_admin(user_id)
+
+    container_row = await container_repo.get_by_owner_id(owner_id)
     if not container_row or container_row.get("status") != "running":
         return {
             "agents": [],
             "cursor": None,
             "container_status": (container_row or {}).get("status", "none"),
+            "org": org_context,
         }
 
     ecs = get_ecs_manager()
-    container, ip = await ecs.resolve_running_container(user_id)
+    container, ip = await ecs.resolve_running_container(owner_id)
     if not container or not ip:
-        return {"agents": [], "cursor": None, "container_status": "unreachable"}
+        return {"agents": [], "cursor": None, "container_status": "unreachable", "org": org_context}
 
     pool = get_gateway_pool()
     try:
         result = await asyncio.wait_for(
             pool.send_rpc(
-                user_id=user_id,
-                req_id=f"admin-agents-list-{user_id}",
+                user_id=owner_id,
+                req_id=f"admin-agents-list-{owner_id}",
                 method="agents.list",
                 params={"cursor": cursor, "limit": limit},
                 ip=ip,
@@ -154,15 +212,23 @@ async def list_user_agents(user_id: str, *, cursor: str | None = None, limit: in
             "cursor": None,
             "container_status": "timeout",
             "error": "gateway_rpc_timeout",
+            "org": org_context,
         }
     except Exception as e:  # noqa: BLE001
         logger.warning("admin_service.list_user_agents gateway error: %s", e)
-        return {"agents": [], "cursor": None, "container_status": "error", "error": str(e)}
+        return {
+            "agents": [],
+            "cursor": None,
+            "container_status": "error",
+            "error": str(e),
+            "org": org_context,
+        }
 
     return {
         "agents": result.get("agents", []) if isinstance(result, dict) else [],
         "cursor": result.get("cursor") if isinstance(result, dict) else None,
         "container_status": "running",
+        "org": org_context,
     }
 
 
@@ -171,22 +237,32 @@ async def get_agent_detail(user_id: str, agent_id: str) -> dict:
 
     Four parallel gateway RPCs with a single shared timeout. CEO S3
     redaction applied to the openclaw.json config slice before return.
+
+    Resolves org context first so org-keyed containers are found. ``org`` in
+    the response is null for personal-mode users and {id, slug, name, role}
+    otherwise.
     """
-    container_row = await container_repo.get_by_owner_id(user_id)
+    owner_id, org_context = await _resolve_owner_for_admin(user_id)
+
+    container_row = await container_repo.get_by_owner_id(owner_id)
     if not container_row or container_row.get("status") != "running":
-        return {"error": "container_not_running", "container_status": (container_row or {}).get("status", "none")}
+        return {
+            "error": "container_not_running",
+            "container_status": (container_row or {}).get("status", "none"),
+            "org": org_context,
+        }
 
     ecs = get_ecs_manager()
-    container, ip = await ecs.resolve_running_container(user_id)
+    container, ip = await ecs.resolve_running_container(owner_id)
     if not container or not ip:
-        return {"error": "container_unreachable"}
+        return {"error": "container_unreachable", "org": org_context}
 
     pool = get_gateway_pool()
     token = container["gateway_token"]
 
     async def _rpc(method: str, params: dict, suffix: str) -> Any:
         return await pool.send_rpc(
-            user_id=user_id,
+            user_id=owner_id,
             req_id=f"admin-{suffix}-{agent_id}",
             method=method,
             params=params,
@@ -205,16 +281,17 @@ async def get_agent_detail(user_id: str, agent_id: str) -> dict:
             timeout=_GATEWAY_RPC_TIMEOUT_S,  # read at call time so tests can monkeypatch
         )
     except asyncio.TimeoutError:
-        return {"error": "gateway_rpc_timeout"}
+        return {"error": "gateway_rpc_timeout", "org": org_context}
     except Exception as e:  # noqa: BLE001
         logger.warning("admin_service.get_agent_detail gateway error: %s", e)
-        return {"error": str(e)}
+        return {"error": str(e), "org": org_context}
 
     return {
         "agent": agent,
         "sessions": sessions.get("sessions", []) if isinstance(sessions, dict) else [],
         "skills": skills.get("skills", []) if isinstance(skills, dict) else [],
         "config_redacted": redact_openclaw_config(config),
+        "org": org_context,
     }
 
 

--- a/apps/backend/core/services/clerk_admin.py
+++ b/apps/backend/core/services/clerk_admin.py
@@ -141,3 +141,67 @@ async def get_user(user_id: str) -> dict | None:
         logger.warning("clerk_admin.get_user HTTP %s", response.status_code)
         return None
     return response.json()
+
+
+async def list_user_organizations(user_id: str, *, limit: int = 25) -> list[dict]:
+    """Return the orgs a Clerk user belongs to.
+
+    Each element: {"id": "org_...", "slug": "...", "name": "...", "role": "org:admin" | "org:member" | ...}
+    The role field comes from the membership, not the org itself.
+    Returns [] if the user is in no orgs, if the Clerk key is unset, or on
+    network / HTTP error (logged as warning).
+
+    Uses Clerk Backend API GET /v1/users/{user_id}/organization_memberships,
+    which returns an envelope {data: [...memberships], total_count: N}. Each
+    membership has shape {id, role, organization: {id, slug, name, ...}, ...}.
+    """
+    if not settings.CLERK_SECRET_KEY:
+        return []
+
+    headers = {"Authorization": f"Bearer {settings.CLERK_SECRET_KEY}"}
+    params = {"limit": min(limit, 100)}
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+            response = await client.get(
+                f"{_CLERK_API_BASE}/users/{user_id}/organization_memberships",
+                headers=headers,
+                params=params,
+            )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("clerk_admin.list_user_organizations network error: %s", e)
+        return []
+
+    if response.status_code == 404:
+        return []
+    if response.status_code >= 400:
+        logger.warning("clerk_admin.list_user_organizations HTTP %s", response.status_code)
+        return []
+
+    try:
+        payload = response.json()
+    except ValueError:
+        return []
+
+    # Clerk v1 wraps collection responses in {data, total_count}. Older/alt
+    # shapes may return a bare list — accept both defensively.
+    memberships = payload.get("data") if isinstance(payload, dict) else payload
+    if not isinstance(memberships, list):
+        return []
+
+    result: list[dict] = []
+    for m in memberships:
+        if not isinstance(m, dict):
+            continue
+        org = m.get("organization") or {}
+        org_id = org.get("id")
+        if not org_id:
+            continue
+        result.append(
+            {
+                "id": org_id,
+                "slug": org.get("slug") or "",
+                "name": org.get("name") or "",
+                "role": m.get("role") or "",
+            }
+        )
+    return result

--- a/apps/backend/routers/admin.py
+++ b/apps/backend/routers/admin.py
@@ -14,6 +14,7 @@ distinct side-effect.
 """
 
 import logging
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
@@ -28,6 +29,7 @@ from core.services import (
     system_health,
 )
 from core.services.admin_audit import audit_admin_action
+from core.services.admin_service import resolve_admin_owner_id
 from core.services.config_patcher import patch_openclaw_config
 from core.services.idempotency import idempotency
 
@@ -214,8 +216,12 @@ async def admin_container_reprovision(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
+    # Resolve owner_id so org-member targets hit ``openclaw-{org_id}-{hash}``,
+    # not the non-existent ``openclaw-{user_id}-{hash}`` (admin-org-owner-id
+    # P1). Audit decorator still captures the URL path param (user_id).
+    owner_id, _ = await resolve_admin_owner_id(user_id)
     ecs = get_ecs_manager()
-    return await ecs.reprovision_for_user(user_id)
+    return await ecs.reprovision_for_user(owner_id)
 
 
 @router.post(
@@ -229,8 +235,9 @@ async def admin_container_stop(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
+    owner_id, _ = await resolve_admin_owner_id(user_id)
     ecs = get_ecs_manager()
-    return await ecs.stop_user_service(user_id)
+    return await ecs.stop_user_service(owner_id)
 
 
 @router.post(
@@ -244,8 +251,9 @@ async def admin_container_start(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
+    owner_id, _ = await resolve_admin_owner_id(user_id)
     ecs = get_ecs_manager()
-    return await ecs.start_user_service(user_id)
+    return await ecs.start_user_service(owner_id)
 
 
 @router.post(
@@ -260,8 +268,9 @@ async def admin_container_resize(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
+    owner_id, _ = await resolve_admin_owner_id(user_id)
     ecs = get_ecs_manager()
-    return await ecs.resize_for_user(user_id, body.tier)
+    return await ecs.resize_for_user(owner_id, body.tier)
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +289,11 @@ async def admin_billing_cancel_subscription(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
-    return await billing_service.cancel_subscription_for_owner(user_id)
+    # Billing accounts are partitioned on owner_id (= org_id for org members).
+    # Without the resolver the mutation targets a personal-key account that
+    # doesn't exist for org members (admin-org-owner-id P1).
+    owner_id, _ = await resolve_admin_owner_id(user_id)
+    return await billing_service.cancel_subscription_for_owner(owner_id)
 
 
 @router.post(
@@ -294,7 +307,8 @@ async def admin_billing_pause_subscription(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
-    return await billing_service.pause_subscription_for_owner(user_id)
+    owner_id, _ = await resolve_admin_owner_id(user_id)
+    return await billing_service.pause_subscription_for_owner(owner_id)
 
 
 @router.post(
@@ -309,7 +323,8 @@ async def admin_billing_issue_credit(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
-    return await billing_service.issue_credit_for_owner(user_id, amount_cents=body.amount_cents, reason=body.reason)
+    owner_id, _ = await resolve_admin_owner_id(user_id)
+    return await billing_service.issue_credit_for_owner(owner_id, amount_cents=body.amount_cents, reason=body.reason)
 
 
 @router.post(
@@ -324,7 +339,8 @@ async def admin_billing_mark_invoice_resolved(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
-    return await billing_service.mark_invoice_resolved(user_id, body.invoice_id)
+    owner_id, _ = await resolve_admin_owner_id(user_id)
+    return await billing_service.mark_invoice_resolved(owner_id, body.invoice_id)
 
 
 # ---------------------------------------------------------------------------
@@ -400,7 +416,11 @@ async def admin_config_patch(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
-    await patch_openclaw_config(owner_id=user_id, patch=body.patch)
+    # EFS workspace lives at /mnt/efs/users/{owner_id}/openclaw.json. For org
+    # members owner_id is the org_id — patching {user_id} writes to a non-
+    # existent personal dir (admin-org-owner-id P1).
+    owner_id, _ = await resolve_admin_owner_id(user_id)
+    await patch_openclaw_config(owner_id=owner_id, patch=body.patch)
     return {"status": "patched"}
 
 
@@ -415,14 +435,24 @@ async def admin_agent_delete(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
+    # Container / gateway pool keyed on owner_id. For org members that's the
+    # org_id — resolve before the ECS / gateway dispatch so we don't send the
+    # RPC to a non-existent personal-mode container (admin-org-owner-id P1).
+    owner_id, _ = await resolve_admin_owner_id(user_id)
     pool = get_gateway_pool()
     ecs = get_ecs_manager()
-    container, ip = await ecs.resolve_running_container(user_id)
+    container, ip = await ecs.resolve_running_container(owner_id)
     if not container or not ip:
         raise HTTPException(status_code=409, detail="container_not_running")
+    # uuid4 entropy: org members share a single gateway connection whose
+    # pending-RPC dict is keyed by req_id. Deterministic ids (previously
+    # ``admin-agent-delete-{agent_id}``) collide when two admins click delete
+    # on the same shared agent concurrently — same pattern Codex already
+    # flagged on the read path.
+    nonce = uuid.uuid4().hex[:8]
     return await pool.send_rpc(
-        user_id=user_id,
-        req_id=f"admin-agent-delete-{agent_id}",
+        user_id=owner_id,
+        req_id=f"admin-agent-delete-{agent_id}-{nonce}",
         method="agents.delete",
         params={"agent_id": agent_id},
         ip=ip,
@@ -441,14 +471,16 @@ async def admin_agent_clear_sessions(
     request: Request,
     auth: AuthContext = Depends(require_platform_admin),
 ):
+    owner_id, _ = await resolve_admin_owner_id(user_id)
     pool = get_gateway_pool()
     ecs = get_ecs_manager()
-    container, ip = await ecs.resolve_running_container(user_id)
+    container, ip = await ecs.resolve_running_container(owner_id)
     if not container or not ip:
         raise HTTPException(status_code=409, detail="container_not_running")
+    nonce = uuid.uuid4().hex[:8]
     return await pool.send_rpc(
-        user_id=user_id,
-        req_id=f"admin-agent-clear-{agent_id}",
+        user_id=owner_id,
+        req_id=f"admin-agent-clear-{agent_id}-{nonce}",
         method="sessions.clear",
         params={"agent_id": agent_id},
         ip=ip,

--- a/apps/backend/tests/unit/test_admin_org_resolution.py
+++ b/apps/backend/tests/unit/test_admin_org_resolution.py
@@ -13,12 +13,22 @@ These tests pin:
   ``org: None``.
 - get_overview is defensive: when Clerk itself errors, we still render the
   personal-mode payload (fail-open) rather than 500 the whole dashboard.
+
+The second half of this file (``TestAdminMutationOwnerResolution``) covers
+Codex's follow-up P1: admin MUTATION endpoints must also resolve owner_id
+before dispatching to downstream services. Previously only reads did; writes
+(container stop/start/reprovision/resize, billing cancel/pause/credit/invoice,
+PATCH /config, agent delete/clear-sessions) still targeted the raw
+``{user_id}`` from the URL — so for org members the mutations hit a
+non-existent ``openclaw-{user_id}-{hash}`` ECS service instead of the real
+``openclaw-{org_id}-{hash}``. Account ops (suspend/reactivate/force-signout/
+resend-verification) target the Clerk user directly and MUST NOT resolve.
 """
 
 import asyncio
 import logging
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -368,3 +378,285 @@ async def test_resolve_owner_falls_back_to_personal_mode_on_clerk_timeout(caplog
     assert org_context is None
     # Warning must mention timeout so operators know Clerk is slow.
     assert any("timeout" in rec.message.lower() for rec in caplog.records)
+
+
+# =============================================================================
+# Codex P1 (PR #376 follow-up): admin MUTATION endpoints must resolve owner_id
+# =============================================================================
+#
+# These tests drive the admin router (routers/admin.py) through FastAPI's
+# TestClient and verify each mutation endpoint's internal dispatch switches
+# from the raw URL path param to the Clerk-resolved owner_id when the target
+# user is in an org. They use the same dependency_overrides pattern as
+# tests/unit/routers/test_admin_actions_writes.py — the ``app`` and
+# ``async_client`` fixtures from conftest.py provide a full FastAPI app with
+# auth shimmed to an @isol8.co admin.
+#
+# Org-mode fixtures mock ``clerk_admin.list_user_organizations`` to return a
+# single org so ``resolve_admin_owner_id`` yields the org_id. Personal-mode
+# tests return []. Account-ops tests assert the raw user_id still flows
+# through (regression guard — suspending an org-member's account must ban
+# the specific user, not the org).
+
+
+ORG_FIXTURE = {
+    "id": "org_abc",
+    "slug": "acme",
+    "name": "Acme Co.",
+    "role": "org:admin",
+}
+
+
+@pytest.fixture
+def admin_env(app):
+    """Caller has an @isol8.co email — require_platform_admin admits them."""
+    from core.auth import AuthContext, get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: AuthContext(user_id="user_test_123", email="admin@isol8.co")
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+def org_mode():
+    """Patch resolve_admin_owner_id to return ('org_abc', ORG_FIXTURE).
+
+    Patching at the router's import path (``routers.admin.resolve_admin_owner_id``)
+    is enough — that's the symbol the mutation handlers call. We avoid
+    patching ``clerk_admin.list_user_organizations`` directly so the test
+    stays tight: a future refactor that moves resolution elsewhere still fails
+    loudly if it stops calling the resolver.
+    """
+    with patch(
+        "routers.admin.resolve_admin_owner_id",
+        new=AsyncMock(return_value=("org_abc", ORG_FIXTURE)),
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def personal_mode():
+    """Patch resolve_admin_owner_id to return ('user_123', None) — personal mode."""
+    with patch(
+        "routers.admin.resolve_admin_owner_id",
+        new=AsyncMock(return_value=("user_123", None)),
+    ) as mock:
+        yield mock
+
+
+class TestAdminMutationOwnerResolution:
+    """Each admin mutation endpoint dispatches to the resolved owner_id, not
+    the raw URL path param."""
+
+    # -- Container mutations -------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_container_stop_uses_org_owner_id(self, async_client, admin_env, org_mode):
+        ecs = MagicMock()
+        ecs.stop_user_service = AsyncMock(return_value={"status": "stopped"})
+        with patch("routers.admin.get_ecs_manager", return_value=ecs):
+            res = await async_client.post("/api/v1/admin/users/user_123/container/stop")
+        assert res.status_code == 200
+        ecs.stop_user_service.assert_awaited_once_with("org_abc")
+        org_mode.assert_awaited_once_with("user_123")
+
+    @pytest.mark.asyncio
+    async def test_container_stop_personal_mode_uses_user_id(self, async_client, admin_env, personal_mode):
+        """Negative test: personal-mode user (no orgs) → dispatch targets the
+        Clerk user_id unchanged."""
+        ecs = MagicMock()
+        ecs.stop_user_service = AsyncMock(return_value={"status": "stopped"})
+        with patch("routers.admin.get_ecs_manager", return_value=ecs):
+            res = await async_client.post("/api/v1/admin/users/user_123/container/stop")
+        assert res.status_code == 200
+        ecs.stop_user_service.assert_awaited_once_with("user_123")
+
+    @pytest.mark.asyncio
+    async def test_container_start_uses_org_owner_id(self, async_client, admin_env, org_mode):
+        ecs = MagicMock()
+        ecs.start_user_service = AsyncMock(return_value={"status": "started"})
+        with patch("routers.admin.get_ecs_manager", return_value=ecs):
+            res = await async_client.post("/api/v1/admin/users/user_123/container/start")
+        assert res.status_code == 200
+        ecs.start_user_service.assert_awaited_once_with("org_abc")
+
+    @pytest.mark.asyncio
+    async def test_container_reprovision_uses_org_owner_id(self, async_client, admin_env, org_mode):
+        ecs = MagicMock()
+        ecs.reprovision_for_user = AsyncMock(return_value={"status": "reprovisioned"})
+        with patch("routers.admin.get_ecs_manager", return_value=ecs):
+            res = await async_client.post("/api/v1/admin/users/user_123/container/reprovision")
+        assert res.status_code == 200
+        ecs.reprovision_for_user.assert_awaited_once_with("org_abc")
+
+    @pytest.mark.asyncio
+    async def test_container_resize_uses_org_owner_id(self, async_client, admin_env, org_mode):
+        ecs = MagicMock()
+        ecs.resize_for_user = AsyncMock(return_value={"task_def_arn": "arn:..."})
+        with patch("routers.admin.get_ecs_manager", return_value=ecs):
+            res = await async_client.post(
+                "/api/v1/admin/users/user_123/container/resize",
+                json={"tier": "pro"},
+            )
+        assert res.status_code == 200
+        ecs.resize_for_user.assert_awaited_once_with("org_abc", "pro")
+
+    # -- Billing mutations ---------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_billing_cancel_subscription_uses_org_owner_id(self, async_client, admin_env, org_mode):
+        billing = MagicMock()
+        billing.cancel_subscription_for_owner = AsyncMock(return_value={"status": "canceled"})
+        with patch("routers.admin.billing_service", new=billing):
+            res = await async_client.post("/api/v1/admin/users/user_123/billing/cancel-subscription")
+        assert res.status_code == 200
+        billing.cancel_subscription_for_owner.assert_awaited_once_with("org_abc")
+
+    @pytest.mark.asyncio
+    async def test_billing_pause_subscription_uses_org_owner_id(self, async_client, admin_env, org_mode):
+        billing = MagicMock()
+        billing.pause_subscription_for_owner = AsyncMock(return_value={"status": "paused"})
+        with patch("routers.admin.billing_service", new=billing):
+            res = await async_client.post("/api/v1/admin/users/user_123/billing/pause-subscription")
+        assert res.status_code == 200
+        billing.pause_subscription_for_owner.assert_awaited_once_with("org_abc")
+
+    @pytest.mark.asyncio
+    async def test_billing_issue_credit_uses_org_owner_id(self, async_client, admin_env, org_mode):
+        billing = MagicMock()
+        billing.issue_credit_for_owner = AsyncMock(return_value={"credit_id": "cn_1"})
+        with patch("routers.admin.billing_service", new=billing):
+            res = await async_client.post(
+                "/api/v1/admin/users/user_123/billing/issue-credit",
+                json={"amount_cents": 500, "reason": "incident_comp"},
+            )
+        assert res.status_code == 200
+        billing.issue_credit_for_owner.assert_awaited_once_with(
+            "org_abc",
+            amount_cents=500,
+            reason="incident_comp",
+        )
+
+    @pytest.mark.asyncio
+    async def test_billing_mark_invoice_resolved_uses_org_owner_id(self, async_client, admin_env, org_mode):
+        billing = MagicMock()
+        billing.mark_invoice_resolved = AsyncMock(return_value={"status": "resolved"})
+        with patch("routers.admin.billing_service", new=billing):
+            res = await async_client.post(
+                "/api/v1/admin/users/user_123/billing/mark-invoice-resolved",
+                json={"invoice_id": "in_1"},
+            )
+        assert res.status_code == 200
+        billing.mark_invoice_resolved.assert_awaited_once_with("org_abc", "in_1")
+
+    # -- Config + agent mutations -------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_config_patch_uses_org_owner_id(self, async_client, admin_env, org_mode):
+        with patch(
+            "routers.admin.patch_openclaw_config",
+            new=AsyncMock(return_value=None),
+        ) as mock_patch:
+            res = await async_client.patch(
+                "/api/v1/admin/users/user_123/config",
+                json={"patch": {"agents": {"defaults": {}}}},
+            )
+        assert res.status_code == 200
+        mock_patch.assert_awaited_once()
+        # owner_id keyword — patch_openclaw_config is called with kwargs.
+        assert mock_patch.await_args.kwargs.get("owner_id") == "org_abc"
+
+    @pytest.mark.asyncio
+    async def test_agent_delete_uses_org_owner_id_and_unique_req_id(self, async_client, admin_env, org_mode):
+        """Dispatch targets org_id AND the req_id carries a uuid4 nonce so
+        concurrent deletes on the same shared agent don't collide in the
+        gateway pending-RPC dict."""
+        import re
+
+        pool = MagicMock()
+        pool.send_rpc = AsyncMock(return_value={"deleted": True})
+        ecs = MagicMock()
+        ecs.resolve_running_container = AsyncMock(return_value=({"gateway_token": "tok"}, "10.0.0.1"))
+        with (
+            patch("routers.admin.get_gateway_pool", return_value=pool),
+            patch("routers.admin.get_ecs_manager", return_value=ecs),
+        ):
+            res = await async_client.post("/api/v1/admin/users/user_123/agents/agt_42/delete")
+
+        assert res.status_code == 200
+        # ECS container lookup uses org_id.
+        ecs.resolve_running_container.assert_awaited_once_with("org_abc")
+        # RPC user_id is org_id; req_id carries an 8-hex-char uuid nonce.
+        kwargs = pool.send_rpc.await_args.kwargs
+        assert kwargs["user_id"] == "org_abc"
+        assert re.fullmatch(r"admin-agent-delete-agt_42-[0-9a-f]{8}", kwargs["req_id"])
+
+    @pytest.mark.asyncio
+    async def test_agent_delete_req_ids_are_unique_across_calls(self, async_client, admin_env, org_mode):
+        """P1: two concurrent delete calls on the same agent must produce
+        different req_ids so the gateway's pending-RPC dict keyed by req_id
+        doesn't clobber one future with another."""
+        pool = MagicMock()
+        pool.send_rpc = AsyncMock(return_value={"deleted": True})
+        ecs = MagicMock()
+        ecs.resolve_running_container = AsyncMock(return_value=({"gateway_token": "tok"}, "10.0.0.1"))
+        with (
+            patch("routers.admin.get_gateway_pool", return_value=pool),
+            patch("routers.admin.get_ecs_manager", return_value=ecs),
+        ):
+            r1 = await async_client.post("/api/v1/admin/users/user_123/agents/agt_42/delete")
+            r2 = await async_client.post("/api/v1/admin/users/user_123/agents/agt_42/delete")
+        assert r1.status_code == r2.status_code == 200
+        req_ids = [c.kwargs["req_id"] for c in pool.send_rpc.await_args_list]
+        assert len(req_ids) == 2
+        assert req_ids[0] != req_ids[1]
+
+    @pytest.mark.asyncio
+    async def test_agent_clear_sessions_uses_org_owner_id_and_unique_req_id(self, async_client, admin_env, org_mode):
+        import re
+
+        pool = MagicMock()
+        pool.send_rpc = AsyncMock(return_value={"cleared": 3})
+        ecs = MagicMock()
+        ecs.resolve_running_container = AsyncMock(return_value=({"gateway_token": "tok"}, "10.0.0.1"))
+        with (
+            patch("routers.admin.get_gateway_pool", return_value=pool),
+            patch("routers.admin.get_ecs_manager", return_value=ecs),
+        ):
+            res = await async_client.post("/api/v1/admin/users/user_123/agents/agt_42/clear-sessions")
+
+        assert res.status_code == 200
+        ecs.resolve_running_container.assert_awaited_once_with("org_abc")
+        kwargs = pool.send_rpc.await_args.kwargs
+        assert kwargs["user_id"] == "org_abc"
+        assert re.fullmatch(r"admin-agent-clear-agt_42-[0-9a-f]{8}", kwargs["req_id"])
+
+    # -- Account mutations MUST NOT resolve (regression guard) ---------------
+
+    @pytest.mark.asyncio
+    async def test_account_suspend_uses_raw_user_id_not_org(self, async_client, admin_env):
+        """Regression guard: account/* endpoints target the Clerk user
+        directly, not the org. If these ever start calling
+        resolve_admin_owner_id an admin would end up banning "org_abc" (which
+        Clerk would 404) instead of the actual misbehaving user.
+
+        We patch resolve_admin_owner_id so, if the handler DID call it, we'd
+        see ``org_abc`` land in the ban payload and fail the assertion.
+        """
+        with (
+            patch(
+                "routers.admin.resolve_admin_owner_id",
+                new=AsyncMock(return_value=("org_abc", ORG_FIXTURE)),
+            ) as mock_resolve,
+            patch(
+                "routers.admin.clerk_admin.ban_user",
+                new=AsyncMock(return_value={"banned": True}),
+            ) as mock_ban,
+        ):
+            res = await async_client.post("/api/v1/admin/users/user_123/account/suspend")
+
+        assert res.status_code == 200
+        mock_ban.assert_awaited_once_with("user_123")
+        mock_resolve.assert_not_awaited()

--- a/apps/backend/tests/unit/test_admin_org_resolution.py
+++ b/apps/backend/tests/unit/test_admin_org_resolution.py
@@ -15,6 +15,8 @@ These tests pin:
   personal-mode payload (fail-open) rather than 500 the whole dashboard.
 """
 
+import asyncio
+import logging
 import os
 from unittest.mock import AsyncMock, patch
 
@@ -229,3 +231,140 @@ async def test_get_agent_detail_uses_org_id_for_container_lookup():
     mock_container.assert_awaited_once_with("org_abc")
     assert result["error"] == "container_not_running"
     assert result["org"] == org
+
+
+# -----------------------------------------------------------------------------
+# Codex P1+P1+P2 (PR #376) regression tests
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_user_agents_uses_unique_req_ids_per_call():
+    """P1: concurrent admin agents.list calls on the same org must NOT
+    overwrite each other in the gateway's pending-RPC dict. The deterministic
+    req_id (admin-agents-list-{owner_id}) collided; add uuid4 entropy."""
+    from core.services import admin_service
+
+    org = {"id": "org_abc", "slug": "acme", "name": "Acme", "role": "org:admin"}
+
+    captured_req_ids: list[str] = []
+
+    async def fake_send_rpc(*, user_id, req_id, method, params, ip, token):  # noqa: ARG001
+        captured_req_ids.append(req_id)
+        return {"agents": [], "cursor": None}
+
+    fake_pool = type("FakePool", (), {"send_rpc": staticmethod(fake_send_rpc)})()
+    fake_ecs = type(
+        "FakeECS",
+        (),
+        {"resolve_running_container": AsyncMock(return_value=({"gateway_token": "tok"}, "1.2.3.4"))},
+    )()
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[org]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=fake_ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=fake_pool),
+    ):
+        results = await asyncio.gather(
+            admin_service.list_user_agents("user_abc"),
+            admin_service.list_user_agents("user_abc"),
+        )
+
+    assert len(results) == 2
+    assert len(captured_req_ids) == 2
+    # Both req_ids must share the admin-agents-list-{owner_id} prefix but
+    # differ in the trailing uuid4 slug.
+    for rid in captured_req_ids:
+        assert rid.startswith("admin-agents-list-org_abc-")
+    assert captured_req_ids[0] != captured_req_ids[1]
+
+
+@pytest.mark.asyncio
+async def test_get_agent_detail_uses_unique_req_ids_per_call():
+    """P1: _rpc in get_agent_detail issued 4 RPCs with deterministic
+    admin-{suffix}-{agent_id} ids. Concurrent detail loads on the same agent
+    would clobber each other. Each call must carry uuid4 entropy."""
+    from core.services import admin_service
+
+    org = {"id": "org_abc", "slug": "acme", "name": "Acme", "role": "org:admin"}
+
+    captured_req_ids: list[str] = []
+
+    async def fake_send_rpc(*, user_id, req_id, method, params, ip, token):  # noqa: ARG001
+        captured_req_ids.append(req_id)
+        # Return a plausibly-shaped dict so get_agent_detail doesn't error.
+        return {"agent": {}, "sessions": [], "skills": [], "config": {}}
+
+    fake_pool = type("FakePool", (), {"send_rpc": staticmethod(fake_send_rpc)})()
+    fake_ecs = type(
+        "FakeECS",
+        (),
+        {"resolve_running_container": AsyncMock(return_value=({"gateway_token": "tok"}, "1.2.3.4"))},
+    )()
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[org]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=fake_ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=fake_pool),
+        patch(
+            "core.services.admin_service.redact_openclaw_config",
+            side_effect=lambda x: x,
+        ),
+    ):
+        await asyncio.gather(
+            admin_service.get_agent_detail("user_abc", "agt_1"),
+            admin_service.get_agent_detail("user_abc", "agt_1"),
+        )
+
+    # 4 RPCs per detail call * 2 concurrent calls = 8 unique ids.
+    assert len(captured_req_ids) == 8
+    assert len(set(captured_req_ids)) == 8, f"req_ids collided: {captured_req_ids}"
+    # All still carry the admin-{suffix}-{agent_id} prefix.
+    for rid in captured_req_ids:
+        assert rid.startswith("admin-") and "-agt_1-" in rid
+
+
+@pytest.mark.asyncio
+async def test_resolve_owner_falls_back_to_personal_mode_on_clerk_timeout(caplog):
+    """P2: _resolve_owner_for_admin must bound the Clerk call with the same
+    per-panel timeout budget. When Clerk is slow/unreachable, fall back to
+    personal-mode (user_id, None) and log a warning — don't block the
+    dashboard on upstream latency before _with_timeout-wrapped reads."""
+    from core.services import admin_service
+
+    async def never_returns(user_id: str):  # noqa: ARG001
+        # Sleep far longer than the patched timeout to force asyncio.TimeoutError.
+        await asyncio.sleep(10)
+        return [{"id": "org_never"}]
+
+    with (
+        patch(
+            "core.services.admin_service._PARALLEL_TIMEOUT_S",
+            0.05,  # 50ms — enough time for wait_for to trip, too short for the sleep.
+        ),
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            side_effect=never_returns,
+        ),
+        caplog.at_level(logging.WARNING, logger="core.services.admin_service"),
+    ):
+        owner_id, org_context = await admin_service._resolve_owner_for_admin("user_slow")
+
+    assert owner_id == "user_slow"
+    assert org_context is None
+    # Warning must mention timeout so operators know Clerk is slow.
+    assert any("timeout" in rec.message.lower() for rec in caplog.records)

--- a/apps/backend/tests/unit/test_admin_org_resolution.py
+++ b/apps/backend/tests/unit/test_admin_org_resolution.py
@@ -1,0 +1,231 @@
+"""Tests for admin_service org-aware owner_id resolution.
+
+Background: the DDB partition key ``owner_id`` equals Clerk ``org_id`` for
+org-member resources and ``user_id`` for personal-mode resources. The admin
+dashboard receives the target user_id from the URL, so it must resolve the
+effective owner_id via Clerk before querying container_repo / billing_repo /
+usage_repo — otherwise org-member users render as "no container provisioned".
+
+These tests pin:
+- get_overview queries DDB with org_id (not user_id) when Clerk reports org
+  membership, and returns org_context in the ``org`` response field.
+- get_overview falls back to user_id when Clerk reports no orgs, and returns
+  ``org: None``.
+- get_overview is defensive: when Clerk itself errors, we still render the
+  personal-mode payload (fail-open) rather than 500 the whole dashboard.
+"""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+@pytest.mark.asyncio
+async def test_get_overview_uses_org_id_as_owner_when_user_is_in_org():
+    """User in an org → repos queried with org_id, response includes org."""
+    from core.services import admin_service
+
+    org = {
+        "id": "org_abc",
+        "slug": "acme",
+        "name": "Acme Co.",
+        "role": "org:admin",
+    }
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[org]),
+        ),
+        patch(
+            "core.services.admin_service.clerk_admin.get_user",
+            new=AsyncMock(return_value={"id": "user_abc", "email_addresses": []}),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running", "plan_tier": "pro"}),
+        ) as mock_container,
+        patch(
+            "core.services.admin_service.billing_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"plan_tier": "pro"}),
+        ) as mock_billing,
+        patch(
+            "core.services.admin_service.usage_repo.get_period_usage",
+            new=AsyncMock(return_value={"total_spend_microdollars": 0}),
+        ) as mock_usage,
+    ):
+        result = await admin_service.get_overview("user_abc")
+
+    # Repos must be queried with the ORG id, not the USER id.
+    mock_container.assert_awaited_once_with("org_abc")
+    mock_billing.assert_awaited_once_with("org_abc")
+    # usage_repo.get_period_usage takes (owner_id, period)
+    assert mock_usage.await_args.args[0] == "org_abc"
+
+    # Response carries org context.
+    assert result["org"] == org
+    assert result["identity"]["id"] == "user_abc"
+    assert result["container"]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_get_overview_uses_user_id_when_personal_mode():
+    """User in no orgs → repos queried with user_id, ``org`` is None."""
+    from core.services import admin_service
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "core.services.admin_service.clerk_admin.get_user",
+            new=AsyncMock(return_value={"id": "user_solo"}),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ) as mock_container,
+        patch(
+            "core.services.admin_service.billing_repo.get_by_owner_id",
+            new=AsyncMock(return_value=None),
+        ) as mock_billing,
+        patch(
+            "core.services.admin_service.usage_repo.get_period_usage",
+            new=AsyncMock(return_value={}),
+        ) as mock_usage,
+    ):
+        result = await admin_service.get_overview("user_solo")
+
+    mock_container.assert_awaited_once_with("user_solo")
+    mock_billing.assert_awaited_once_with("user_solo")
+    assert mock_usage.await_args.args[0] == "user_solo"
+
+    assert result["org"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_overview_falls_back_to_user_id_when_clerk_errors():
+    """Clerk org lookup raising must NOT 500 the dashboard — fall back to
+    personal-mode lookup so the admin can still see something."""
+    from core.services import admin_service
+
+    async def raising_clerk(user_id: str):  # noqa: ARG001
+        raise RuntimeError("clerk 503")
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            side_effect=raising_clerk,
+        ),
+        patch(
+            "core.services.admin_service.clerk_admin.get_user",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value=None),
+        ) as mock_container,
+        patch(
+            "core.services.admin_service.billing_repo.get_by_owner_id",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "core.services.admin_service.usage_repo.get_period_usage",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        result = await admin_service.get_overview("user_flaky")
+
+    mock_container.assert_awaited_once_with("user_flaky")
+    assert result["org"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_overview_picks_first_org_when_clerk_returns_multiple():
+    """project_single_org_per_user: one org per user. If Clerk returns
+    multiple (shouldn't happen) we use the first and log a warning."""
+    from core.services import admin_service
+
+    orgs = [
+        {"id": "org_first", "slug": "first", "name": "First", "role": "org:admin"},
+        {"id": "org_second", "slug": "second", "name": "Second", "role": "org:member"},
+    ]
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=orgs),
+        ),
+        patch(
+            "core.services.admin_service.clerk_admin.get_user",
+            new=AsyncMock(return_value={"id": "user_multi"}),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value=None),
+        ) as mock_container,
+        patch(
+            "core.services.admin_service.billing_repo.get_by_owner_id",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "core.services.admin_service.usage_repo.get_period_usage",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        result = await admin_service.get_overview("user_multi")
+
+    mock_container.assert_awaited_once_with("org_first")
+    assert result["org"]["id"] == "org_first"
+
+
+@pytest.mark.asyncio
+async def test_list_user_agents_uses_org_id_for_container_lookup():
+    """Agents-list container lookup must hit org_id when user is in an org."""
+    from core.services import admin_service
+
+    org = {"id": "org_abc", "slug": "acme", "name": "Acme", "role": "org:admin"}
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[org]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value=None),
+        ) as mock_container,
+    ):
+        result = await admin_service.list_user_agents("user_abc")
+
+    mock_container.assert_awaited_once_with("org_abc")
+    assert result["org"] == org
+    assert result["container_status"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_detail_uses_org_id_for_container_lookup():
+    """Agent detail container lookup must hit org_id when user is in an org."""
+    from core.services import admin_service
+
+    org = {"id": "org_abc", "slug": "acme", "name": "Acme", "role": "org:admin"}
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[org]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "stopped"}),
+        ) as mock_container,
+    ):
+        result = await admin_service.get_agent_detail("user_abc", "agt_1")
+
+    mock_container.assert_awaited_once_with("org_abc")
+    assert result["error"] == "container_not_running"
+    assert result["org"] == org

--- a/apps/frontend/src/app/admin/_lib/api.ts
+++ b/apps/frontend/src/app/admin/_lib/api.ts
@@ -63,11 +63,25 @@ export interface UsersPage {
   stubbed: boolean;
 }
 
+export interface AdminOrgContext {
+  id: string;
+  slug: string;
+  name: string;
+  role: string;
+}
+
 export interface UserOverview {
   identity: unknown;
   container: unknown;
   billing: unknown;
   usage: unknown;
+  /**
+   * Populated when the target user belongs to a Clerk org. The DDB rows in
+   * container/billing/usage are keyed by ``owner_id == org_id`` in that case,
+   * so the dashboard surfaces this as an indigo banner making the provenance
+   * explicit to the admin.
+   */
+  org?: AdminOrgContext | null;
 }
 
 export interface AgentSummary {
@@ -82,6 +96,7 @@ export interface AgentsPage {
   cursor: string | null;
   container_status: string;
   error?: string;
+  org?: AdminOrgContext | null;
 }
 
 export interface AgentDetail {

--- a/apps/frontend/src/app/admin/users/[id]/agents/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/agents/page.tsx
@@ -3,7 +3,11 @@ import { auth } from "@clerk/nextjs/server";
 
 import { EmptyState } from "@/components/admin/EmptyState";
 import { ErrorBanner } from "@/components/admin/ErrorBanner";
-import { listAgents, type AgentSummary } from "@/app/admin/_lib/api";
+import {
+  listAgents,
+  type AdminOrgContext,
+  type AgentSummary,
+} from "@/app/admin/_lib/api";
 
 export const metadata = { title: "Agents \u00b7 Admin" };
 
@@ -63,7 +67,14 @@ export default async function AdminUserAgentsPage({ params, searchParams }: Page
   const token = await getToken();
   const result = token
     ? await listAgents(token, id, cursor, 50)
-    : { agents: [], cursor: null, container_status: "unknown" as string };
+    : {
+        agents: [],
+        cursor: null,
+        container_status: "unknown" as string,
+        org: null as AdminOrgContext | null,
+      };
+
+  const orgBanner = result.org ? <OrgBanner org={result.org} /> : null;
 
   // Container in a non-running state — render explanatory empty/error states
   // rather than an empty table (CEO U1).
@@ -71,6 +82,7 @@ export default async function AdminUserAgentsPage({ params, searchParams }: Page
     return (
       <div className="space-y-6">
         <Header />
+        {orgBanner}
         <EmptyState
           title="Container is stopped"
           body="The user's container is not running. Start it first to see their agents."
@@ -87,6 +99,7 @@ export default async function AdminUserAgentsPage({ params, searchParams }: Page
     return (
       <div className="space-y-6">
         <Header />
+        {orgBanner}
         <EmptyState
           title="No container provisioned"
           body="This user hasn't provisioned a container yet."
@@ -99,6 +112,7 @@ export default async function AdminUserAgentsPage({ params, searchParams }: Page
     return (
       <div className="space-y-6">
         <Header />
+        {orgBanner}
         <ErrorBanner
           error={result.error || "Gateway RPC failed"}
           source="OpenClaw"
@@ -112,6 +126,7 @@ export default async function AdminUserAgentsPage({ params, searchParams }: Page
     return (
       <div className="space-y-6">
         <Header />
+        {orgBanner}
         <EmptyState title="No agents yet" body="The user hasn't created any agents." />
       </div>
     );
@@ -122,6 +137,7 @@ export default async function AdminUserAgentsPage({ params, searchParams }: Page
   return (
     <div className="space-y-6">
       <Header />
+      {orgBanner}
       <div className="overflow-hidden rounded-md border border-white/10">
         <table className="w-full table-fixed text-sm">
           <thead className="bg-zinc-900 text-left text-xs uppercase tracking-wide text-zinc-400">
@@ -187,4 +203,32 @@ export default async function AdminUserAgentsPage({ params, searchParams }: Page
 // section heading here so the title doesn't duplicate.
 function Header() {
   return <h1 className="text-xl font-semibold text-zinc-100">Agents</h1>;
+}
+
+/**
+ * Indigo banner rendered when the target user belongs to a Clerk org.
+ * Mirrors the overview page so admins get the same provenance hint
+ * regardless of which tab they land on. Container/agents below are the
+ * org's resources (owner_id == org_id).
+ */
+function OrgBanner({ org }: { org: AdminOrgContext }) {
+  const role = org.role ? org.role.replace("org:", "") : "member";
+  const displayName = org.name || org.slug || org.id;
+  return (
+    <div className="rounded-md border border-indigo-800 bg-indigo-950/30 px-4 py-3 text-sm">
+      <div className="text-xs uppercase tracking-wide text-indigo-400">
+        Org member
+      </div>
+      <div className="mt-1 text-indigo-200">
+        {displayName}
+        {org.slug ? (
+          <span className="text-indigo-500"> ({org.slug})</span>
+        ) : null}
+      </div>
+      <div className="mt-1 text-xs text-indigo-400">
+        Role: {role} &mdash; container, billing, and agents below are the
+        org&apos;s resources.
+      </div>
+    </div>
+  );
 }

--- a/apps/frontend/src/app/admin/users/[id]/container/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/container/page.tsx
@@ -2,7 +2,7 @@ import { auth } from "@clerk/nextjs/server";
 
 import { EmptyState } from "@/components/admin/EmptyState";
 import { ErrorBanner } from "@/components/admin/ErrorBanner";
-import { getOverview } from "@/app/admin/_lib/api";
+import { getOverview, type AdminOrgContext } from "@/app/admin/_lib/api";
 
 import { ContainerActionsPanel } from "./ContainerActionsPanel";
 
@@ -114,12 +114,15 @@ export default async function AdminUserContainerPage({ params }: PageProps) {
     );
   }
 
+  const orgBanner = overview.org ? <OrgBanner org={overview.org} /> : null;
+
   const { container } = pickContainer(overview.container);
 
   if (!container) {
     return (
       <div className="space-y-6">
         <Header />
+        {orgBanner}
         <EmptyState
           title="No container"
           body="This user has no provisioned container."
@@ -133,6 +136,7 @@ export default async function AdminUserContainerPage({ params }: PageProps) {
   return (
     <div className="space-y-6">
       <Header />
+      {orgBanner}
 
       {container.error ? (
         <ErrorBanner
@@ -183,6 +187,32 @@ export default async function AdminUserContainerPage({ params }: PageProps) {
 // section heading here so the title doesn't duplicate.
 function Header() {
   return <h1 className="text-xl font-semibold text-zinc-100">Container</h1>;
+}
+
+/**
+ * Indigo banner rendered when the target user belongs to a Clerk org.
+ * Mirrors the overview page so admins know this container is the org's
+ * shared resource (owner_id == org_id), not the individual user's.
+ */
+function OrgBanner({ org }: { org: AdminOrgContext }) {
+  const role = org.role ? org.role.replace("org:", "") : "member";
+  const displayName = org.name || org.slug || org.id;
+  return (
+    <div className="rounded-md border border-indigo-800 bg-indigo-950/30 px-4 py-3 text-sm">
+      <div className="text-xs uppercase tracking-wide text-indigo-400">
+        Org member
+      </div>
+      <div className="mt-1 text-indigo-200">
+        {displayName}
+        {org.slug ? (
+          <span className="text-indigo-500"> ({org.slug})</span>
+        ) : null}
+      </div>
+      <div className="mt-1 text-xs text-indigo-400">
+        Role: {role} &mdash; this container is the org&apos;s shared resource.
+      </div>
+    </div>
+  );
 }
 
 function DefRow({

--- a/apps/frontend/src/app/admin/users/[id]/page.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/page.tsx
@@ -121,11 +121,47 @@ export default async function UserOverviewPage({ params }: UserOverviewPageProps
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-      <IdentityCard identity={overview.identity} />
-      <BillingCard billing={overview.billing} />
-      <ContainerCard container={overview.container} />
-      <UsageCard usage={overview.usage} />
+    <div className="space-y-4">
+      {overview.org ? <OrgBanner org={overview.org} /> : null}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <IdentityCard identity={overview.identity} />
+        <BillingCard billing={overview.billing} />
+        <ContainerCard container={overview.container} />
+        <UsageCard usage={overview.usage} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Indigo banner rendered at the top of the user-detail views when the target
+ * user is a member of a Clerk org. Container / billing / agents / usage rows
+ * in DDB are keyed by owner_id == org_id in that case, so the banner makes it
+ * explicit to the admin that the cards below are the org's resources — not
+ * the individual user's personal account.
+ */
+function OrgBanner({
+  org,
+}: {
+  org: { id: string; slug: string; name: string; role: string };
+}) {
+  const role = org.role ? org.role.replace("org:", "") : "member";
+  const displayName = org.name || org.slug || org.id;
+  return (
+    <div className="rounded-md border border-indigo-800 bg-indigo-950/30 px-4 py-3 text-sm">
+      <div className="text-xs uppercase tracking-wide text-indigo-400">
+        Org member
+      </div>
+      <div className="mt-1 text-indigo-200">
+        {displayName}
+        {org.slug ? (
+          <span className="text-indigo-500"> ({org.slug})</span>
+        ) : null}
+      </div>
+      <div className="mt-1 text-xs text-indigo-400">
+        Role: {role} &mdash; container, billing, and agents below are the
+        org&apos;s resources.
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The admin dashboard passed the target user's `user_id` directly to `container_repo.get_by_owner_id` etc., which only matches personal-mode records. For users in a Clerk org, `container` / `billing` / `usage_counters` are keyed by `owner_id == org_id`, so the admin UI rendered empty cards ("no container provisioned") when viewing an org-member's detail page.

## Fix

- **`clerk_admin.list_user_organizations(user_id)`** — new helper that calls `GET /v1/users/{user_id}/organization_memberships` on the Clerk Backend API and normalizes the envelope to `[{id, slug, name, role}]`. Defensive against missing `CLERK_SECRET_KEY`, 404, network errors — all return `[]` with a warning log.
- **`admin_service._resolve_owner_for_admin(user_id)`** — derives `(effective_owner_id, org_context)`. Returns `(org_id, org_dict)` when the user is in an org, `(user_id, None)` otherwise. Per `project_single_org_per_user` memory, picks the first org and logs a warning if Clerk returns multiple. Fail-open on Clerk errors: falls back to personal-mode lookup rather than 500ing the dashboard.
- **`get_overview`, `list_user_agents`, `get_agent_detail`** — resolve the owner first, then thread `effective_owner_id` into every `container_repo` / `billing_repo` / `usage_repo` / `ecs.resolve_running_container` / `pool.send_rpc` call. `get_logs` is left alone — CloudWatch filters by the authenticated user_id emitting log entries, which is correct.
- **Response shape** — overview / agents / agent-detail responses gain an additive `org: {id, slug, name, role} | null` field. Existing fields are unchanged.
- **Frontend** — new `UserOverview.org` + `AgentsPage.org` types, and an indigo "Org member" banner at the top of the overview / agents / container pages when the target user belongs to an org. Makes it unambiguous to the admin that the container/billing/agents shown are the org's shared resources.

## Test plan

- [x] Unit: `apps/backend/tests/unit/test_admin_org_resolution.py` — 5 new tests covering org-id owner routing, personal-mode fallback, fail-open on Clerk error, single-org-per-user enforcement, and `list_user_agents` / `get_agent_detail` flows.
- [x] Regression: `apps/backend/tests/unit/routers/test_admin_users_reads.py` — 31 existing tests still pass (the new `org` field is additive, and existing tests don't assert on full-dict equality).
- [x] Frontend `tsc --noEmit` clean.
- [x] Frontend `pnpm run lint` — no new errors (15 pre-existing warnings unchanged).

## Out of scope

The users-list view (`/admin/users`) shows container status in its own column which is still computed against `user_id` rather than the resolved org owner — that's a separate issue flagged by the user and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)