### PR TITLE
fix(admin): users-list container column resolves owner_id

### DIFF
--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -130,6 +130,17 @@ async def list_users(*, q: str = "", limit: int = 50, cursor: str | None = None)
     cursor is opaque — pass back to fetch next page. Internally a string
     representation of Clerk's offset (since Clerk uses int offsets, we
     stringify them so the frontend treats cursor uniformly).
+
+    For each Clerk user we resolve the effective owner_id via
+    ``resolve_admin_owner_id`` before looking up the container row — org
+    members' containers are keyed by ``owner_id == org_id`` in DDB, so using
+    the raw Clerk user_id would render every org member as "no container
+    provisioned" (admin-org-owner-id fix, list-view follow-up to PR #376).
+
+    Owner_ids are deduped before the container fetch so two org members sharing
+    the same owner_id cost one DDB call, not two. Each row also carries an
+    ``org`` field (``{id, slug, name, role}`` for org members, ``None`` for
+    personal-mode) so the UI can badge org members inline.
     """
     offset = int(cursor) if cursor and cursor.isdigit() else 0
     page = await clerk_admin.list_users(query=q, limit=limit, offset=offset)
@@ -137,28 +148,54 @@ async def list_users(*, q: str = "", limit: int = 50, cursor: str | None = None)
     clerk_users = page.get("users", [])
     user_ids = [u["id"] for u in clerk_users]
 
-    # Per-user container lookup. Parallel since container_repo.get_by_owner_id
-    # makes one DDB call each.
-    containers = await asyncio.gather(
-        *(container_repo.get_by_owner_id(uid) for uid in user_ids),
+    # Per-user owner resolution. resolve_admin_owner_id already bounds each
+    # Clerk call with _PARALLEL_TIMEOUT_S and fails open to (user_id, None), so
+    # a slow/down Clerk doesn't take the page down.
+    resolutions = await asyncio.gather(
+        *(resolve_admin_owner_id(uid) for uid in user_ids),
         return_exceptions=True,
     )
-    container_by_uid = {uid: (c if not isinstance(c, BaseException) else None) for uid, c in zip(user_ids, containers)}
+    owner_by_uid: dict[str, str] = {}
+    org_by_uid: dict[str, dict | None] = {}
+    for uid, res in zip(user_ids, resolutions):
+        if isinstance(res, BaseException):
+            # Defensive: resolve_admin_owner_id already catches internally, but
+            # if gather surfaces something unexpected fall back to personal mode.
+            owner_by_uid[uid] = uid
+            org_by_uid[uid] = None
+        else:
+            owner_id, org_context = res
+            owner_by_uid[uid] = owner_id
+            org_by_uid[uid] = org_context
+
+    # Dedupe owner_ids — two members of the same org share one owner_id and
+    # therefore one container row.
+    unique_owner_ids = list({oid for oid in owner_by_uid.values()})
+    containers = await asyncio.gather(
+        *(container_repo.get_by_owner_id(oid) for oid in unique_owner_ids),
+        return_exceptions=True,
+    )
+    container_by_oid: dict[str, dict | None] = {
+        oid: (c if not isinstance(c, BaseException) else None) for oid, c in zip(unique_owner_ids, containers)
+    }
 
     rows = []
     for u in clerk_users:
-        container = container_by_uid.get(u["id"]) or {}
+        uid = u["id"]
+        owner_id = owner_by_uid.get(uid, uid)
+        container = container_by_oid.get(owner_id) or {}
         emails = u.get("email_addresses", [])
         primary_email = emails[0].get("email_address") if emails else None
         rows.append(
             {
-                "clerk_id": u["id"],
+                "clerk_id": uid,
                 "email": primary_email,
                 "created_at": u.get("created_at"),
                 "last_sign_in_at": u.get("last_sign_in_at"),
                 "banned": u.get("banned", False),
                 "container_status": container.get("status", "none"),
                 "plan_tier": container.get("plan_tier", "free"),
+                "org": org_by_uid.get(uid),
             }
         )
 

--- a/apps/backend/tests/unit/test_admin_users_list_owner_id.py
+++ b/apps/backend/tests/unit/test_admin_users_list_owner_id.py
@@ -1,0 +1,212 @@
+"""Tests for admin_service.list_users owner_id resolution (PR #376 follow-up).
+
+Background: the DDB partition key ``owner_id`` equals Clerk ``org_id`` for
+org-member resources and ``user_id`` for personal-mode resources. PR #376
+fixed this for the admin detail views (Overview, Agents, Agent Detail) but
+explicitly deferred the list view at ``/admin/users``. That view fell back to
+``container_repo.get_by_owner_id(user_id)`` using the raw Clerk id, so every
+org member showed "no container" even when their org had one.
+
+These tests pin the list-view fix:
+
+1. Two Clerk users in the same org → container_repo is called once for the
+   org_id (dedupe by owner_id), not twice.
+2. Personal-mode user → container_repo is called with the user_id unchanged.
+3. Mixed page (1 org member + 1 personal) → both rows carry correct
+   container_status; the org member row has ``org`` populated, the personal
+   row has ``org: None``.
+4. Clerk throws for one user → that row falls back to personal mode; other
+   rows are unaffected.
+"""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("CLERK_ISSUER", "https://test.clerk.accounts.dev")
+
+
+ORG_FIXTURE = {
+    "id": "org_abc",
+    "slug": "acme",
+    "name": "Acme Co.",
+    "role": "org:admin",
+}
+
+
+@pytest.mark.asyncio
+async def test_list_users_dedupes_container_lookup_for_same_org_members():
+    """Two Clerk users in the same org share one owner_id → one DDB call."""
+    from core.services import admin_service
+
+    async def fake_clerk_list(*, query, limit, offset):  # noqa: ARG001
+        return {
+            "users": [
+                {"id": "user_alice", "email_addresses": [{"email_address": "alice@acme.com"}]},
+                {"id": "user_bob", "email_addresses": [{"email_address": "bob@acme.com"}]},
+            ],
+            "next_offset": None,
+            "stubbed": False,
+        }
+
+    # Both users are in the same org → both resolve to owner_id "org_abc".
+    async def fake_list_orgs(user_id, *, limit=25):  # noqa: ARG001
+        return [ORG_FIXTURE]
+
+    container_mock = AsyncMock(return_value={"status": "running", "plan_tier": "pro"})
+
+    with (
+        patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
+        patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
+        patch("core.services.admin_service.container_repo.get_by_owner_id", new=container_mock),
+    ):
+        result = await admin_service.list_users()
+
+    # Exactly one container lookup for the shared org_id — NOT two for each user.
+    assert container_mock.await_count == 1
+    assert container_mock.await_args.args[0] == "org_abc"
+
+    # Both rows report the org's container status.
+    assert len(result["users"]) == 2
+    for row in result["users"]:
+        assert row["container_status"] == "running"
+        assert row["plan_tier"] == "pro"
+        assert row["org"] == ORG_FIXTURE
+
+
+@pytest.mark.asyncio
+async def test_list_users_personal_mode_looks_up_container_by_user_id():
+    """Personal-mode user → container lookup key equals user_id (unchanged)."""
+    from core.services import admin_service
+
+    async def fake_clerk_list(*, query, limit, offset):  # noqa: ARG001
+        return {
+            "users": [
+                {"id": "user_solo", "email_addresses": [{"email_address": "solo@example.com"}]},
+            ],
+            "next_offset": None,
+            "stubbed": False,
+        }
+
+    async def fake_list_orgs(user_id, *, limit=25):  # noqa: ARG001
+        return []
+
+    container_mock = AsyncMock(return_value={"status": "running", "plan_tier": "starter"})
+
+    with (
+        patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
+        patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
+        patch("core.services.admin_service.container_repo.get_by_owner_id", new=container_mock),
+    ):
+        result = await admin_service.list_users()
+
+    container_mock.assert_awaited_once_with("user_solo")
+    assert len(result["users"]) == 1
+    assert result["users"][0]["container_status"] == "running"
+    assert result["users"][0]["plan_tier"] == "starter"
+    assert result["users"][0]["org"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_users_mixed_page_resolves_each_row_correctly():
+    """Mixed page: one org member + one personal user. Each row's
+    container_status reflects its own owner_id; ``org`` is populated for the
+    member and None for the personal user."""
+    from core.services import admin_service
+
+    async def fake_clerk_list(*, query, limit, offset):  # noqa: ARG001
+        return {
+            "users": [
+                {"id": "user_member", "email_addresses": [{"email_address": "member@acme.com"}]},
+                {"id": "user_solo", "email_addresses": [{"email_address": "solo@example.com"}]},
+            ],
+            "next_offset": None,
+            "stubbed": False,
+        }
+
+    async def fake_list_orgs(user_id, *, limit=25):  # noqa: ARG001
+        if user_id == "user_member":
+            return [ORG_FIXTURE]
+        return []
+
+    async def fake_container_lookup(owner_id):
+        return {
+            "org_abc": {"status": "running", "plan_tier": "pro"},
+            "user_solo": {"status": "stopped", "plan_tier": "free"},
+        }.get(owner_id)
+
+    with (
+        patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
+        patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
+        patch("core.services.admin_service.container_repo.get_by_owner_id", new=fake_container_lookup),
+    ):
+        result = await admin_service.list_users()
+
+    assert len(result["users"]) == 2
+    member_row = next(r for r in result["users"] if r["clerk_id"] == "user_member")
+    solo_row = next(r for r in result["users"] if r["clerk_id"] == "user_solo")
+
+    assert member_row["container_status"] == "running"
+    assert member_row["plan_tier"] == "pro"
+    assert member_row["org"] == ORG_FIXTURE
+
+    assert solo_row["container_status"] == "stopped"
+    assert solo_row["plan_tier"] == "free"
+    assert solo_row["org"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_users_falls_back_to_personal_mode_when_clerk_errors_for_one_user():
+    """Clerk raising for one user in the page must not take the whole page
+    down — that row falls back to personal mode (owner_id == user_id, org None)
+    and other rows resolve normally.
+
+    ``resolve_admin_owner_id`` already catches its own exceptions internally,
+    but we still gather with ``return_exceptions=True`` as a defense-in-depth
+    check. Here we simulate Clerk flakiness by returning a *different* org for
+    one user and raising for the other — the raising row must land in
+    personal-mode (user_id as owner, org=None), and the healthy row must still
+    see the org_id-backed container.
+    """
+    from core.services import admin_service
+
+    async def fake_clerk_list(*, query, limit, offset):  # noqa: ARG001
+        return {
+            "users": [
+                {"id": "user_ok", "email_addresses": [{"email_address": "ok@acme.com"}]},
+                {"id": "user_flaky", "email_addresses": [{"email_address": "flaky@example.com"}]},
+            ],
+            "next_offset": None,
+            "stubbed": False,
+        }
+
+    async def fake_list_orgs(user_id, *, limit=25):  # noqa: ARG001
+        if user_id == "user_flaky":
+            raise RuntimeError("clerk 503")
+        return [ORG_FIXTURE]
+
+    async def fake_container_lookup(owner_id):
+        return {
+            "org_abc": {"status": "running", "plan_tier": "pro"},
+            "user_flaky": {"status": "stopped", "plan_tier": "free"},
+        }.get(owner_id)
+
+    with (
+        patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
+        patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
+        patch("core.services.admin_service.container_repo.get_by_owner_id", new=fake_container_lookup),
+    ):
+        result = await admin_service.list_users()
+
+    assert len(result["users"]) == 2
+    ok_row = next(r for r in result["users"] if r["clerk_id"] == "user_ok")
+    flaky_row = next(r for r in result["users"] if r["clerk_id"] == "user_flaky")
+
+    # Healthy row picks up the org-scoped container.
+    assert ok_row["container_status"] == "running"
+    assert ok_row["org"] == ORG_FIXTURE
+
+    # Flaky row fails open to personal mode: user_id used as owner_id, org None.
+    assert flaky_row["container_status"] == "stopped"
+    assert flaky_row["org"] is None

--- a/apps/frontend/src/app/admin/_lib/api.ts
+++ b/apps/frontend/src/app/admin/_lib/api.ts
@@ -55,6 +55,14 @@ export interface UserDirectoryRow {
   banned: boolean;
   container_status: string;
   plan_tier: string;
+  /**
+   * Populated when the user belongs to a Clerk org. The list-view
+   * container_status is now resolved via owner_id (== org_id for org members)
+   * so org rows surface the real container state; this field lets the table
+   * render an inline `[org:slug]` hint next to the email so admins can tell
+   * at a glance which rows are organizational.
+   */
+  org?: AdminOrgContext | null;
 }
 
 export interface UsersPage {

--- a/apps/frontend/src/app/admin/users/page.tsx
+++ b/apps/frontend/src/app/admin/users/page.tsx
@@ -134,6 +134,14 @@ function UsersTable({ users }: { users: UserDirectoryRow[] }) {
                 >
                   {u.email ?? <span className="text-zinc-500">(no email)</span>}
                 </Link>
+                {u.org ? (
+                  <span
+                    className="ml-2 font-mono text-[10px] text-indigo-300/80"
+                    title={`Org: ${u.org.name} (${u.org.role})`}
+                  >
+                    [org:{u.org.slug}]
+                  </span>
+                ) : null}
               </td>
               <td className="px-3 py-2 font-mono text-xs text-zinc-300" title={u.clerk_id}>
                 {truncateId(u.clerk_id)}


### PR DESCRIPTION
## Summary
Follow-up to #376. The `/admin/users` list-view container-status column still used the raw Clerk user_id, so every org member rendered as "no container" even when their org's resource existed.

- Backend: `list_users` now resolves each Clerk user's effective owner_id in parallel via the existing public `resolve_admin_owner_id` helper (bounded by the same `_PARALLEL_TIMEOUT_S` timeout), dedupes by owner_id before container fetches (two users in the same org → one DDB call), and emits an `org: {id, slug, name, role} | null` field per row.
- Frontend: `UserDirectoryRow` gains `org?`; row renderer shows an inline `[org:slug]` badge next to the email (muted indigo, tooltip carries full org name + role).
- 4 new backend unit tests covering dedupe, personal-mode, mixed-page, and Clerk-flake fallback. 98-test admin suite still green.