### PR TITLE
fix(admin): agent-detail uses correct OpenClaw RPC names + camelCase params

### DIFF
--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -401,10 +401,21 @@ async def get_agent_detail(user_id: str, agent_id: str) -> dict:
         if isinstance(s, dict) and (s.get("agentId") == agent_id or s.get("agent_id") == agent_id)
     ]
 
+    # OpenClaw's skills.status response is either {skills: [...]} or a raw
+    # array depending on version (the main-app SkillsPanel handles both
+    # shapes). Normalize so the admin detail page doesn't silently show "no
+    # skills" on array-returning environments.
+    if isinstance(skills, dict):
+        skills_list = skills.get("skills", [])
+    elif isinstance(skills, list):
+        skills_list = skills
+    else:
+        skills_list = []
+
     return {
         "agent": identity,
         "sessions": agent_sessions,
-        "skills": skills.get("skills", []) if isinstance(skills, dict) else [],
+        "skills": skills_list,
         "config_redacted": redact_openclaw_config(config),
         "org": org_context,
     }

--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -391,10 +391,19 @@ async def get_agent_detail(user_id: str, agent_id: str) -> dict:
         logger.warning("admin_service.get_agent_detail gateway error: %s", e)
         return {"error": str(e), "org": org_context}
 
-    # sessions.list is not agent-filterable; narrow client-side. The agent
-    # key on a session may be "agentId" (OpenClaw canonical) or "agent_id"
-    # (older payload shapes) — accept either defensively.
-    all_sessions = sessions_raw.get("sessions", []) if isinstance(sessions_raw, dict) else []
+    # sessions.list is not agent-filterable; narrow client-side.
+    #
+    # Two shape normalizations, both mirroring main-app SessionsPanel:
+    # - envelope: response is either {sessions: [...]} or a raw array
+    #   (Session[] | {sessions: Session[]}) depending on OpenClaw version.
+    # - agent key: sessions may carry "agentId" (canonical) or "agent_id"
+    #   (older payload shapes) — accept either.
+    if isinstance(sessions_raw, dict):
+        all_sessions = sessions_raw.get("sessions", [])
+    elif isinstance(sessions_raw, list):
+        all_sessions = sessions_raw
+    else:
+        all_sessions = []
     agent_sessions = [
         s
         for s in all_sessions

--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -353,13 +353,35 @@ async def get_agent_detail(user_id: str, agent_id: str) -> dict:
             token=token,
         )
 
+    # RPC method names + param shapes are anchored to the main-app call sites
+    # so admin and main-app always speak the same wire contract to OpenClaw.
+    # Two gotchas that bit us in prod (OpenClaw returned
+    # `{"code":"INVALID_REQUEST","message":"unknown method: agents.get"}`):
+    #   1. Method names: the correct RPCs are `agent.identity.get` (NOT
+    #      `agents.get`) and `skills.status` (NOT `skills.list`). See
+    #      AgentOverviewTab.tsx:27 and SkillsPanel.tsx:219.
+    #   2. Wire format: OpenClaw's schemas use camelCase (`agentId`), not
+    #      snake_case. Main app always sends camelCase — we must too.
+    #   3. `sessions.list` isn't filterable by agent server-side; main app
+    #      fetches the full list and narrows client-side (SessionsPanel.tsx
+    #      :123-137). We replicate that below. `config.get` takes no params
+    #      (ConfigPanel.tsx:14).
     try:
-        agent, sessions, skills, config = await asyncio.wait_for(
+        identity, sessions_raw, skills, config = await asyncio.wait_for(
             asyncio.gather(
-                _rpc("agents.get", {"agent_id": agent_id}, "agent-get"),
-                _rpc("sessions.list", {"agent_id": agent_id, "limit": 20}, "sessions"),
-                _rpc("skills.list", {"agent_id": agent_id}, "skills"),
-                _rpc("config.get", {"agent_id": agent_id}, "config"),
+                _rpc("agent.identity.get", {"agentId": agent_id}, "identity"),
+                _rpc(
+                    "sessions.list",
+                    {
+                        "includeGlobal": True,
+                        "includeUnknown": True,
+                        "includeDerivedTitles": True,
+                        "includeLastMessage": True,
+                    },
+                    "sessions",
+                ),
+                _rpc("skills.status", {"agentId": agent_id}, "skills"),
+                _rpc("config.get", {}, "config"),
             ),
             timeout=_GATEWAY_RPC_TIMEOUT_S,  # read at call time so tests can monkeypatch
         )
@@ -369,9 +391,19 @@ async def get_agent_detail(user_id: str, agent_id: str) -> dict:
         logger.warning("admin_service.get_agent_detail gateway error: %s", e)
         return {"error": str(e), "org": org_context}
 
+    # sessions.list is not agent-filterable; narrow client-side. The agent
+    # key on a session may be "agentId" (OpenClaw canonical) or "agent_id"
+    # (older payload shapes) — accept either defensively.
+    all_sessions = sessions_raw.get("sessions", []) if isinstance(sessions_raw, dict) else []
+    agent_sessions = [
+        s
+        for s in all_sessions
+        if isinstance(s, dict) and (s.get("agentId") == agent_id or s.get("agent_id") == agent_id)
+    ]
+
     return {
-        "agent": agent,
-        "sessions": sessions.get("sessions", []) if isinstance(sessions, dict) else [],
+        "agent": identity,
+        "sessions": agent_sessions,
         "skills": skills.get("skills", []) if isinstance(skills, dict) else [],
         "config_redacted": redact_openclaw_config(config),
         "org": org_context,

--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -19,6 +19,7 @@ timeout via _with_timeout. Slow Stripe doesn't starve other panels.
 """
 
 import asyncio
+import json
 import logging
 import uuid
 from typing import Any
@@ -421,11 +422,26 @@ async def get_agent_detail(user_id: str, agent_id: str) -> dict:
     else:
         skills_list = []
 
+    # config.get returns either a plain config dict OR the envelope
+    # {raw: "<openclaw.json as string>", hash} used by ConfigPanel (see
+    # ConfigPanel.tsx lines 21-26). redact_openclaw_config only walks
+    # dict/list nodes and passes strings through, so a raw-envelope
+    # response would leak BYOK secrets verbatim in config_redacted.raw
+    # (Codex P1 on PR #379). Parse+redact the envelope before returning.
+    if isinstance(config, dict) and isinstance(config.get("raw"), str):
+        try:
+            config_to_redact = json.loads(config["raw"])
+        except json.JSONDecodeError:
+            # Malformed raw — drop rather than leak the unparseable blob.
+            config_to_redact = {"error": "malformed_config_raw"}
+    else:
+        config_to_redact = config
+
     return {
         "agent": identity,
         "sessions": agent_sessions,
         "skills": skills_list,
-        "config_redacted": redact_openclaw_config(config),
+        "config_redacted": redact_openclaw_config(config_to_redact),
         "org": org_context,
     }
 

--- a/apps/backend/tests/unit/services/test_admin_service.py
+++ b/apps/backend/tests/unit/services/test_admin_service.py
@@ -272,10 +272,14 @@ async def test_get_agent_detail_redacts_config_secrets():
     """CEO S3: openclaw.json secrets stripped before return."""
     from core.services import admin_service
 
+    # RPC names match the main-app call sites (see get_agent_detail in
+    # admin_service.py): agent.identity.get / sessions.list / skills.status /
+    # config.get. sessions.list is unfiltered; the service filters by agentId
+    # client-side — seed s1 with a matching agentId so it survives the filter.
     rpc_results = {
-        "agents.get": {"agent_id": "a", "name": "Agent A"},
-        "sessions.list": {"sessions": [{"id": "s1"}]},
-        "skills.list": {"skills": [{"id": "x"}]},
+        "agent.identity.get": {"agent_id": "a", "name": "Agent A"},
+        "sessions.list": {"sessions": [{"id": "s1", "agentId": "a"}]},
+        "skills.status": {"skills": [{"id": "x"}]},
         "config.get": {"providers": {"anthropic_api_key": "sk-secret-shh"}},
     }
 

--- a/apps/backend/tests/unit/test_admin_org_resolution.py
+++ b/apps/backend/tests/unit/test_admin_org_resolution.py
@@ -704,3 +704,189 @@ class TestAdminMutationOwnerResolution:
         assert res.status_code == 200
         mock_ban.assert_awaited_once_with("user_123")
         mock_resolve.assert_not_awaited()
+
+
+# =============================================================================
+# PR #379: get_agent_detail RPC method names + camelCase params
+# =============================================================================
+#
+# Background: prod returned `{"code":"INVALID_REQUEST","message":"unknown
+# method: agents.get"}` — admin_service was calling non-existent RPCs with
+# snake_case params. The correct OpenClaw RPCs, anchored to the main-app
+# call sites:
+#   agent.identity.get {agentId}            (AgentOverviewTab.tsx:27)
+#   sessions.list     {includeGlobal, ...} (SessionsPanel.tsx:123-137)
+#   skills.status     {agentId}            (SkillsPanel.tsx:219)
+#   config.get        {}                    (ConfigPanel.tsx:14)
+#
+# sessions.list isn't agent-filterable server-side — main app narrows
+# client-side and we must too.
+
+
+@pytest.mark.asyncio
+async def test_get_agent_detail_uses_correct_rpc_methods():
+    """Regression: the four RPC method names must match OpenClaw's actual
+    handlers. `agents.get` and `skills.list` DO NOT EXIST — OpenClaw exposes
+    `agent.identity.get` and `skills.status`. This guards against a silent
+    rename regression in admin_service.get_agent_detail."""
+    from core.services import admin_service
+
+    captured_methods: list[str] = []
+
+    async def fake_send_rpc(*, user_id, req_id, method, params, ip, token):  # noqa: ARG001
+        captured_methods.append(method)
+        return {"sessions": [], "skills": []}
+
+    fake_pool = type("FakePool", (), {"send_rpc": staticmethod(fake_send_rpc)})()
+    fake_ecs = type(
+        "FakeECS",
+        (),
+        {"resolve_running_container": AsyncMock(return_value=({"gateway_token": "tok"}, "1.2.3.4"))},
+    )()
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=fake_ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=fake_pool),
+        patch(
+            "core.services.admin_service.redact_openclaw_config",
+            side_effect=lambda x: x,
+        ),
+    ):
+        await admin_service.get_agent_detail("user_abc", "agt_1")
+
+    # Order is gather-dependent but the set must be exact.
+    assert set(captured_methods) == {
+        "agent.identity.get",
+        "sessions.list",
+        "skills.status",
+        "config.get",
+    }, f"wrong RPC methods: {captured_methods}"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_detail_uses_camelcase_params():
+    """Regression: OpenClaw schemas use camelCase. Admin was sending
+    snake_case (`agent_id`) so every call 400'd. Each RPC's params shape
+    must match the main-app call site exactly."""
+    from core.services import admin_service
+
+    # method -> params, captured per-call.
+    captured: dict[str, dict] = {}
+
+    async def fake_send_rpc(*, user_id, req_id, method, params, ip, token):  # noqa: ARG001
+        captured[method] = params
+        return {"sessions": [], "skills": []}
+
+    fake_pool = type("FakePool", (), {"send_rpc": staticmethod(fake_send_rpc)})()
+    fake_ecs = type(
+        "FakeECS",
+        (),
+        {"resolve_running_container": AsyncMock(return_value=({"gateway_token": "tok"}, "1.2.3.4"))},
+    )()
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=fake_ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=fake_pool),
+        patch(
+            "core.services.admin_service.redact_openclaw_config",
+            side_effect=lambda x: x,
+        ),
+    ):
+        await admin_service.get_agent_detail("user_abc", "agt_1")
+
+    # agent.identity.get: only {agentId}.
+    assert captured["agent.identity.get"] == {"agentId": "agt_1"}
+    # skills.status: only {agentId}.
+    assert captured["skills.status"] == {"agentId": "agt_1"}
+    # config.get: no params (matches ConfigPanel.tsx:14).
+    assert captured["config.get"] == {}
+    # sessions.list: include-* flags, and NO agent filter of any form (main
+    # app filters client-side — OpenClaw's schema would reject agentId here).
+    sessions_params = captured["sessions.list"]
+    assert sessions_params.get("includeGlobal") is True
+    assert sessions_params.get("includeUnknown") is True
+    assert sessions_params.get("includeDerivedTitles") is True
+    assert sessions_params.get("includeLastMessage") is True
+    assert "agentId" not in sessions_params
+    assert "agent_id" not in sessions_params
+    assert "limit" not in sessions_params
+
+    # Blanket camelCase audit across ALL params: no snake_case agent key
+    # should have leaked through anywhere.
+    for method, params in captured.items():
+        assert "agent_id" not in params, f"{method} sent snake_case agent_id: {params}"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_detail_filters_sessions_by_agent_client_side():
+    """OpenClaw's sessions.list returns all sessions regardless of agent;
+    admin_service must narrow to the target agent client-side. Both
+    `agentId` (canonical) and `agent_id` (legacy payloads) are accepted."""
+    from core.services import admin_service
+
+    seeded_sessions = {
+        "sessions": [
+            {"id": "s1", "agentId": "agt_1"},
+            {"id": "s2", "agentId": "agt_OTHER"},
+            {"id": "s3", "agent_id": "agt_1"},
+            {"id": "s4"},  # no agent key at all — must be filtered out
+        ]
+    }
+
+    async def fake_send_rpc(*, user_id, req_id, method, params, ip, token):  # noqa: ARG001
+        if method == "sessions.list":
+            return seeded_sessions
+        if method == "skills.status":
+            return {"skills": []}
+        if method == "config.get":
+            return {"raw": "{}"}
+        if method == "agent.identity.get":
+            return {"id": "agt_1", "name": "Test Agent"}
+        return {}
+
+    fake_pool = type("FakePool", (), {"send_rpc": staticmethod(fake_send_rpc)})()
+    fake_ecs = type(
+        "FakeECS",
+        (),
+        {"resolve_running_container": AsyncMock(return_value=({"gateway_token": "tok"}, "1.2.3.4"))},
+    )()
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=fake_ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=fake_pool),
+        patch(
+            "core.services.admin_service.redact_openclaw_config",
+            side_effect=lambda x: x,
+        ),
+    ):
+        result = await admin_service.get_agent_detail("user_abc", "agt_1")
+
+    ids = [s["id"] for s in result["sessions"]]
+    assert ids == ["s1", "s3"], f"expected only s1+s3 (both match forms); got {ids}"
+    # Sanity: the other payloads survived the filter pipeline.
+    assert result["agent"] == {"id": "agt_1", "name": "Test Agent"}
+    assert result["skills"] == []

--- a/apps/backend/tests/unit/test_admin_org_resolution.py
+++ b/apps/backend/tests/unit/test_admin_org_resolution.py
@@ -341,6 +341,56 @@ async def test_list_user_agents_sends_empty_params_to_openclaw():
 
 
 @pytest.mark.asyncio
+async def test_get_agent_detail_normalizes_sessions_list_array_response():
+    """Codex P2 (PR #379 follow-up): sessions.list returns either
+    {sessions: [...]} or a raw array depending on OpenClaw version, same as
+    skills.status. Admin must surface both; previously only the dict form
+    was handled and array responses silently rendered 'no recent sessions'.
+    """
+    from core.services import admin_service
+
+    rpc_results = {
+        "agent.identity.get": {"name": "A"},
+        "sessions.list": [  # array form — the bug path
+            {"id": "s_keep", "agentId": "agt_1"},
+            {"id": "s_drop", "agentId": "agt_OTHER"},
+            {"id": "s_keep2", "agent_id": "agt_1"},
+        ],
+        "skills.status": {"skills": []},
+        "config.get": {},
+    }
+
+    async def fake_send_rpc(*, user_id, req_id, method, params, ip, token):  # noqa: ARG001
+        return rpc_results[method]
+
+    fake_pool = type("FakePool", (), {"send_rpc": staticmethod(fake_send_rpc)})()
+    fake_ecs = type(
+        "FakeECS",
+        (),
+        {"resolve_running_container": AsyncMock(return_value=({"gateway_token": "tok"}, "1.2.3.4"))},
+    )()
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=fake_ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=fake_pool),
+    ):
+        result = await admin_service.get_agent_detail("user_abc", "agt_1")
+
+    ids = [s["id"] for s in result["sessions"]]
+    assert ids == ["s_keep", "s_keep2"], (
+        f"array-shape sessions.list + agent filter must yield only agt_1 sessions; got {ids}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_agent_detail_normalizes_skills_status_array_response():
     """Codex P2 (PR #379): skills.status returns either {skills: [...]} or a
     raw array depending on OpenClaw version. Admin must surface both shapes;

--- a/apps/backend/tests/unit/test_admin_org_resolution.py
+++ b/apps/backend/tests/unit/test_admin_org_resolution.py
@@ -341,6 +341,109 @@ async def test_list_user_agents_sends_empty_params_to_openclaw():
 
 
 @pytest.mark.asyncio
+async def test_get_agent_detail_redacts_secrets_in_config_raw_envelope():
+    """Codex P1 on PR #379: config.get returns either a plain dict or the
+    ConfigPanel envelope {raw: "<openclaw.json as string>", hash}. The
+    redactor only walks dict/list nodes; strings pass through unchanged.
+    If we redact the envelope directly, config_redacted.raw still
+    contains BYOK secrets verbatim. Parse+redact the raw envelope.
+    """
+    import json as _json
+
+    from core.services import admin_service
+
+    secret_config = {
+        "providers": {
+            "anthropic_api_key": "sk-ant-REAL-SECRET-DO-NOT-LEAK",
+            "openai_api_key": "sk-openai-ALSO-SECRET",
+        },
+        "agents": {"list": [{"id": "agt_1", "name": "A"}]},
+    }
+    raw_envelope = {"raw": _json.dumps(secret_config), "hash": "abc123"}
+
+    rpc_results = {
+        "agent.identity.get": {"name": "A"},
+        "sessions.list": {"sessions": []},
+        "skills.status": {"skills": []},
+        "config.get": raw_envelope,  # envelope form — the bug path
+    }
+
+    async def fake_send_rpc(*, user_id, req_id, method, params, ip, token):  # noqa: ARG001
+        return rpc_results[method]
+
+    fake_pool = type("FakePool", (), {"send_rpc": staticmethod(fake_send_rpc)})()
+    fake_ecs = type(
+        "FakeECS",
+        (),
+        {"resolve_running_container": AsyncMock(return_value=({"gateway_token": "tok"}, "1.2.3.4"))},
+    )()
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=fake_ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=fake_pool),
+    ):
+        result = await admin_service.get_agent_detail("user_abc", "agt_1")
+
+    # Belt-and-suspenders: secrets must not appear anywhere in the response.
+    response_str = _json.dumps(result)
+    assert "sk-ant-REAL-SECRET-DO-NOT-LEAK" not in response_str, "anthropic key leaked"
+    assert "sk-openai-ALSO-SECRET" not in response_str, "openai key leaked"
+
+    # Structural check: envelope was parsed, so config_redacted is the parsed
+    # + redacted config (not a wrapper containing the raw string).
+    assert result["config_redacted"]["providers"]["anthropic_api_key"] == "***redacted***"
+    assert result["config_redacted"]["providers"]["openai_api_key"] == "***redacted***"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_detail_handles_malformed_config_raw_envelope():
+    """If config.get returns {raw: "not-json"}, don't crash and don't leak
+    the unparseable blob. Return an error marker instead."""
+    from core.services import admin_service
+
+    rpc_results = {
+        "agent.identity.get": {"name": "A"},
+        "sessions.list": {"sessions": []},
+        "skills.status": {"skills": []},
+        "config.get": {"raw": "not valid json {{{", "hash": "abc"},
+    }
+
+    async def fake_send_rpc(*, user_id, req_id, method, params, ip, token):  # noqa: ARG001
+        return rpc_results[method]
+
+    fake_pool = type("FakePool", (), {"send_rpc": staticmethod(fake_send_rpc)})()
+    fake_ecs = type(
+        "FakeECS",
+        (),
+        {"resolve_running_container": AsyncMock(return_value=({"gateway_token": "tok"}, "1.2.3.4"))},
+    )()
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=fake_ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=fake_pool),
+    ):
+        result = await admin_service.get_agent_detail("user_abc", "agt_1")
+
+    assert result["config_redacted"] == {"error": "malformed_config_raw"}
+
+
+@pytest.mark.asyncio
 async def test_get_agent_detail_normalizes_sessions_list_array_response():
     """Codex P2 (PR #379 follow-up): sessions.list returns either
     {sessions: [...]} or a raw array depending on OpenClaw version, same as

--- a/apps/backend/tests/unit/test_admin_org_resolution.py
+++ b/apps/backend/tests/unit/test_admin_org_resolution.py
@@ -341,6 +341,52 @@ async def test_list_user_agents_sends_empty_params_to_openclaw():
 
 
 @pytest.mark.asyncio
+async def test_get_agent_detail_normalizes_skills_status_array_response():
+    """Codex P2 (PR #379): skills.status returns either {skills: [...]} or a
+    raw array depending on OpenClaw version. Admin must surface both shapes;
+    previously `skills.get("skills", [])` returned [] for array responses,
+    silently showing "no skills" on environments returning the array form."""
+    from core.services import admin_service
+
+    rpc_results = {
+        "agent.identity.get": {"name": "A"},
+        "sessions.list": {"sessions": []},
+        "skills.status": [  # array form — the bug path
+            {"id": "skill_shell", "enabled": True},
+            {"id": "skill_browser", "enabled": False},
+        ],
+        "config.get": {},
+    }
+
+    async def fake_send_rpc(*, user_id, req_id, method, params, ip, token):  # noqa: ARG001
+        return rpc_results[method]
+
+    fake_pool = type("FakePool", (), {"send_rpc": staticmethod(fake_send_rpc)})()
+    fake_ecs = type(
+        "FakeECS",
+        (),
+        {"resolve_running_container": AsyncMock(return_value=({"gateway_token": "tok"}, "1.2.3.4"))},
+    )()
+
+    with (
+        patch(
+            "core.services.admin_service.clerk_admin.list_user_organizations",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "core.services.admin_service.container_repo.get_by_owner_id",
+            new=AsyncMock(return_value={"status": "running"}),
+        ),
+        patch("core.services.admin_service.get_ecs_manager", return_value=fake_ecs),
+        patch("core.services.admin_service.get_gateway_pool", return_value=fake_pool),
+    ):
+        result = await admin_service.get_agent_detail("user_abc", "agt_1")
+
+    assert len(result["skills"]) == 2, f"array-shape skills.status must surface; got {result['skills']}"
+    assert result["skills"][0]["id"] == "skill_shell"
+
+
+@pytest.mark.asyncio
 async def test_get_agent_detail_uses_unique_req_ids_per_call():
     """P1: _rpc in get_agent_detail issued 4 RPCs with deterministic
     admin-{suffix}-{agent_id} ids. Concurrent detail loads on the same agent


### PR DESCRIPTION
## Summary
The admin agent-detail page (`/admin/users/{user_id}/agents/{agent_id}`) was calling 3 nonexistent / wrong-shape OpenClaw RPCs, blocking the entire view with `{"code":"INVALID_REQUEST","message":"unknown method: agents.get"}`.

Also blocks the Publish-to-catalog flow, since the footer with that button lives on this same page.

## Fixes
| Before (broken) | After (main-app pattern) | Main-app call site |
|---|---|---|
| `agents.get { agent_id }` | `agent.identity.get { agentId }` | `AgentOverviewTab.tsx:29` |
| `sessions.list { agent_id, limit: 20 }` | `sessions.list { includeGlobal, includeUnknown, includeDerivedTitles, includeLastMessage }` + client-side filter by agent | `SessionsPanel.tsx:123` |
| `skills.list { agent_id }` | `skills.status { agentId }` | `SkillsPanel.tsx:217` |
| `config.get { agent_id }` | `config.get {}` | `ConfigPanel.tsx:14` |

Key transformation: OpenClaw wire format is **camelCase** (`agentId`), not `agent_id`.

## Tests
3 new regression tests in `test_admin_org_resolution.py`:
- Method names are exactly the 4 listed above
- Params use camelCase and don't leak `agent_id`/`limit`
- Client-side session filter narrows to this agent (accepts both `agentId` and `agent_id` session keys)

57 admin tests green.