### PR TITLE
fix(admin): scope .dark + adopt design tokens

### DIFF
--- a/apps/frontend/src/app/admin/layout.tsx
+++ b/apps/frontend/src/app/admin/layout.tsx
@@ -37,7 +37,7 @@ export default async function AdminLayout({
   }
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+    <div className="dark min-h-screen bg-background text-foreground">
       <header className="border-b border-zinc-800 bg-zinc-900">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
           <div className="flex items-center gap-8">

--- a/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/AgentActionsFooter.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/AgentActionsFooter.tsx
@@ -78,7 +78,7 @@ export function AgentActionsFooter({
   }
 
   return (
-    <div className="space-y-3 rounded-md border border-white/10 bg-white/[0.02] p-4">
+    <div className="space-y-3 rounded-md border border-border bg-card p-4">
       <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-400">
         Destructive actions
       </h2>


### PR DESCRIPTION
## Summary
The admin layout wrapped content in `bg-zinc-950 text-zinc-100` but never added the `.dark` class, so shadcn CSS vars (`--background`, `--input`, `--border`, etc.) resolved from `:root` (light values in `globals.css:56-87`). Every shadcn primitive rendered for a light surface while the visual palette was black.

**Live evidence (Chrome MCP):**
- `/admin/users` search input: `bg: lab(100 0 0)` (white) + `color: lab(96.16 ...)` (near-white). **Typed query was invisible.**
- Agent detail page "Clear sessions" / "Publish to catalog" (outline variant): white bg + near-white text.

## Fix
- `apps/frontend/src/app/admin/layout.tsx:40` — wrapper class `"min-h-screen bg-zinc-950 text-zinc-100"` → `"dark min-h-screen bg-background text-foreground"`. `.dark` flips the token block at `globals.css:89-129`; swapping to `bg-background text-foreground` makes admin a first-class design-token consumer.
- `AgentActionsFooter.tsx:81` — `border-white/10 bg-white/[0.02]` → `border-border bg-card`. Only spot in admin using alpha-white tokens; now consistent with the rest.

Scoped to the admin wrapper, not `<html>`, so `/chat` and marketing keep their existing styling.

## Deferred
- `ConfirmActionDialog.tsx:130-133` hand-rolled destructive class on `AlertDialogAction` (Radix Slot, not raw `<button>`) — swap would require broader signature changes. Independent of this fix.

## Verification
- `pnpm lint`: 0 errors (15 pre-existing warnings, none in touched files)
- `pnpm exec tsc --noEmit`: clean
- Chrome MCP runtime injection confirmed outline buttons jump from 1.0 → ~20:1 contrast, search input becomes readable.