### PR TITLE
fix(admin): read plan_tier from billing_accounts in users list

### DIFF
--- a/apps/backend/core/services/admin_service.py
+++ b/apps/backend/core/services/admin_service.py
@@ -170,14 +170,27 @@ async def list_users(*, q: str = "", limit: int = 50, cursor: str | None = None)
             org_by_uid[uid] = org_context
 
     # Dedupe owner_ids — two members of the same org share one owner_id and
-    # therefore one container row.
+    # therefore one container + billing row.
     unique_owner_ids = list({oid for oid in owner_by_uid.values()})
-    containers = await asyncio.gather(
-        *(container_repo.get_by_owner_id(oid) for oid in unique_owner_ids),
-        return_exceptions=True,
+    # plan_tier lives on the billing_accounts row (see billing_repo.put_billing
+    # line 62), NOT on the container row. Reading from the container row meant
+    # plan_tier was always the default "free" in the list view, misrepresenting
+    # every paid user. Fetch container + billing in parallel per owner.
+    containers, billings = await asyncio.gather(
+        asyncio.gather(
+            *(container_repo.get_by_owner_id(oid) for oid in unique_owner_ids),
+            return_exceptions=True,
+        ),
+        asyncio.gather(
+            *(billing_repo.get_by_owner_id(oid) for oid in unique_owner_ids),
+            return_exceptions=True,
+        ),
     )
     container_by_oid: dict[str, dict | None] = {
         oid: (c if not isinstance(c, BaseException) else None) for oid, c in zip(unique_owner_ids, containers)
+    }
+    billing_by_oid: dict[str, dict | None] = {
+        oid: (b if not isinstance(b, BaseException) else None) for oid, b in zip(unique_owner_ids, billings)
     }
 
     rows = []
@@ -185,6 +198,7 @@ async def list_users(*, q: str = "", limit: int = 50, cursor: str | None = None)
         uid = u["id"]
         owner_id = owner_by_uid.get(uid, uid)
         container = container_by_oid.get(owner_id) or {}
+        billing = billing_by_oid.get(owner_id) or {}
         emails = u.get("email_addresses", [])
         primary_email = emails[0].get("email_address") if emails else None
         rows.append(
@@ -195,7 +209,7 @@ async def list_users(*, q: str = "", limit: int = 50, cursor: str | None = None)
                 "last_sign_in_at": u.get("last_sign_in_at"),
                 "banned": u.get("banned", False),
                 "container_status": container.get("status", "none"),
-                "plan_tier": container.get("plan_tier", "free"),
+                "plan_tier": billing.get("plan_tier", "free"),
                 "org": org_by_uid.get(uid),
             }
         )

--- a/apps/backend/tests/unit/services/test_admin_service.py
+++ b/apps/backend/tests/unit/services/test_admin_service.py
@@ -31,11 +31,16 @@ async def test_list_users_joins_clerk_with_container_status():
         }
 
     async def fake_container_lookup(uid):
-        return {"user_a": {"status": "running", "plan_tier": "starter"}}.get(uid)
+        return {"user_a": {"status": "running"}}.get(uid)
+
+    # plan_tier lives on billing_accounts, not containers.
+    async def fake_billing_lookup(uid):
+        return {"user_a": {"plan_tier": "starter"}}.get(uid)
 
     with (
         patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
         patch("core.services.admin_service.container_repo.get_by_owner_id", new=fake_container_lookup),
+        patch("core.services.admin_service.billing_repo.get_by_owner_id", new=fake_billing_lookup),
     ):
         result = await admin_service.list_users(q="", limit=10)
 

--- a/apps/backend/tests/unit/test_admin_users_list_owner_id.py
+++ b/apps/backend/tests/unit/test_admin_users_list_owner_id.py
@@ -54,20 +54,25 @@ async def test_list_users_dedupes_container_lookup_for_same_org_members():
     async def fake_list_orgs(user_id, *, limit=25):  # noqa: ARG001
         return [ORG_FIXTURE]
 
-    container_mock = AsyncMock(return_value={"status": "running", "plan_tier": "pro"})
+    container_mock = AsyncMock(return_value={"status": "running"})
+    # plan_tier lives on billing_accounts, not containers (see fix-plan-tier PR).
+    billing_mock = AsyncMock(return_value={"plan_tier": "pro"})
 
     with (
         patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
         patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
         patch("core.services.admin_service.container_repo.get_by_owner_id", new=container_mock),
+        patch("core.services.admin_service.billing_repo.get_by_owner_id", new=billing_mock),
     ):
         result = await admin_service.list_users()
 
-    # Exactly one container lookup for the shared org_id — NOT two for each user.
+    # Exactly one container + one billing lookup for the shared org_id.
     assert container_mock.await_count == 1
     assert container_mock.await_args.args[0] == "org_abc"
+    assert billing_mock.await_count == 1
+    assert billing_mock.await_args.args[0] == "org_abc"
 
-    # Both rows report the org's container status.
+    # Both rows report the org's container status + plan tier.
     assert len(result["users"]) == 2
     for row in result["users"]:
         assert row["container_status"] == "running"
@@ -92,16 +97,19 @@ async def test_list_users_personal_mode_looks_up_container_by_user_id():
     async def fake_list_orgs(user_id, *, limit=25):  # noqa: ARG001
         return []
 
-    container_mock = AsyncMock(return_value={"status": "running", "plan_tier": "starter"})
+    container_mock = AsyncMock(return_value={"status": "running"})
+    billing_mock = AsyncMock(return_value={"plan_tier": "starter"})
 
     with (
         patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
         patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
         patch("core.services.admin_service.container_repo.get_by_owner_id", new=container_mock),
+        patch("core.services.admin_service.billing_repo.get_by_owner_id", new=billing_mock),
     ):
         result = await admin_service.list_users()
 
     container_mock.assert_awaited_once_with("user_solo")
+    billing_mock.assert_awaited_once_with("user_solo")
     assert len(result["users"]) == 1
     assert result["users"][0]["container_status"] == "running"
     assert result["users"][0]["plan_tier"] == "starter"
@@ -132,14 +140,21 @@ async def test_list_users_mixed_page_resolves_each_row_correctly():
 
     async def fake_container_lookup(owner_id):
         return {
-            "org_abc": {"status": "running", "plan_tier": "pro"},
-            "user_solo": {"status": "stopped", "plan_tier": "free"},
+            "org_abc": {"status": "running"},
+            "user_solo": {"status": "stopped"},
+        }.get(owner_id)
+
+    async def fake_billing_lookup(owner_id):
+        return {
+            "org_abc": {"plan_tier": "pro"},
+            "user_solo": {"plan_tier": "free"},
         }.get(owner_id)
 
     with (
         patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
         patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
         patch("core.services.admin_service.container_repo.get_by_owner_id", new=fake_container_lookup),
+        patch("core.services.admin_service.billing_repo.get_by_owner_id", new=fake_billing_lookup),
     ):
         result = await admin_service.list_users()
 
@@ -188,14 +203,21 @@ async def test_list_users_falls_back_to_personal_mode_when_clerk_errors_for_one_
 
     async def fake_container_lookup(owner_id):
         return {
-            "org_abc": {"status": "running", "plan_tier": "pro"},
-            "user_flaky": {"status": "stopped", "plan_tier": "free"},
+            "org_abc": {"status": "running"},
+            "user_flaky": {"status": "stopped"},
+        }.get(owner_id)
+
+    async def fake_billing_lookup(owner_id):
+        return {
+            "org_abc": {"plan_tier": "pro"},
+            "user_flaky": {"plan_tier": "free"},
         }.get(owner_id)
 
     with (
         patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
         patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
         patch("core.services.admin_service.container_repo.get_by_owner_id", new=fake_container_lookup),
+        patch("core.services.admin_service.billing_repo.get_by_owner_id", new=fake_billing_lookup),
     ):
         result = await admin_service.list_users()
 
@@ -210,3 +232,81 @@ async def test_list_users_falls_back_to_personal_mode_when_clerk_errors_for_one_
     # Flaky row fails open to personal mode: user_id used as owner_id, org None.
     assert flaky_row["container_status"] == "stopped"
     assert flaky_row["org"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_users_reads_plan_tier_from_billing_not_container():
+    """Regression: plan_tier lives on the billing_accounts row (see
+    billing_repo.put_billing), NOT on the container row. Reading it from the
+    container row (the previous bug) caused every user in the list view to
+    render as "free" tier regardless of actual subscription, because container
+    rows never carry a plan_tier field.
+    """
+    from core.services import admin_service
+
+    async def fake_clerk_list(*, query, limit, offset):  # noqa: ARG001
+        return {
+            "users": [
+                {"id": "user_paying", "email_addresses": [{"email_address": "pay@example.com"}]},
+            ],
+            "next_offset": None,
+            "stubbed": False,
+        }
+
+    async def fake_list_orgs(user_id, *, limit=25):  # noqa: ARG001
+        return []
+
+    # Container row is deliberately WITHOUT plan_tier — which matches reality,
+    # since plan_tier is not a field on the containers table.
+    container_mock = AsyncMock(return_value={"status": "running", "service_name": "openclaw-x"})
+    # Billing row is the authoritative source for plan_tier.
+    billing_mock = AsyncMock(return_value={"plan_tier": "enterprise"})
+
+    with (
+        patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
+        patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
+        patch("core.services.admin_service.container_repo.get_by_owner_id", new=container_mock),
+        patch("core.services.admin_service.billing_repo.get_by_owner_id", new=billing_mock),
+    ):
+        result = await admin_service.list_users()
+
+    assert len(result["users"]) == 1
+    assert result["users"][0]["plan_tier"] == "enterprise", (
+        "plan_tier must come from billing_repo, not container_repo; "
+        "previously returned 'free' because containers never have plan_tier"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_users_plan_tier_defaults_to_free_when_no_billing_row():
+    """Users with no billing row (never subscribed, pre-provisioning, etc.)
+    should render as 'free' — the sensible default. Guards against the fix
+    regressing in the opposite direction (KeyError on missing billing row).
+    """
+    from core.services import admin_service
+
+    async def fake_clerk_list(*, query, limit, offset):  # noqa: ARG001
+        return {
+            "users": [
+                {"id": "user_new", "email_addresses": [{"email_address": "new@example.com"}]},
+            ],
+            "next_offset": None,
+            "stubbed": False,
+        }
+
+    async def fake_list_orgs(user_id, *, limit=25):  # noqa: ARG001
+        return []
+
+    container_mock = AsyncMock(return_value=None)
+    billing_mock = AsyncMock(return_value=None)  # no billing row
+
+    with (
+        patch("core.services.admin_service.clerk_admin.list_users", new=fake_clerk_list),
+        patch("core.services.admin_service.clerk_admin.list_user_organizations", new=fake_list_orgs),
+        patch("core.services.admin_service.container_repo.get_by_owner_id", new=container_mock),
+        patch("core.services.admin_service.billing_repo.get_by_owner_id", new=billing_mock),
+    ):
+        result = await admin_service.list_users()
+
+    assert result["users"][0]["plan_tier"] == "free"
+    assert result["users"][0]["container_status"] == "none"


### PR DESCRIPTION
## Summary
Users list at \`/admin/users\` was rendering every user as \"free\" tier regardless of their actual subscription.

## Root cause
\`admin_service.list_users\` was reading \`plan_tier\` from the container row:
\`\`\`python
\"plan_tier\": container.get(\"plan_tier\", \"free\"),
\`\`\`
but \`plan_tier\` lives on the **billing_accounts** row (see \`billing_repo.put_billing\` line 62; \`usage_service\` already reads it correctly from the billing account). Container rows never carry \`plan_tier\`, so \`.get(\"plan_tier\", \"free\")\` always fell through to the default.

## Fix
Fetch billing accounts in parallel with container rows (same dedupe-by-owner_id pattern) and source \`plan_tier\` from billing.

## Tests
- Regression: reads plan_tier from billing mock, not container — fails if we flip the source back
- Default: plan_tier is 'free' when billing row is missing
- Existing 4 tests updated to mock billing_repo alongside container_repo

85 admin tests green.