### PR TITLE
feat(analytics): product events + session replay + JS error capture

### DIFF
--- a/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/AgentActionsFooter.tsx
+++ b/apps/frontend/src/app/admin/users/[id]/agents/[agent_id]/AgentActionsFooter.tsx
@@ -8,6 +8,7 @@ import { ErrorBanner } from "@/components/admin/ErrorBanner";
 import { Button } from "@/components/ui/button";
 import { clearAgentSessions, deleteAgent } from "@/app/admin/_actions/agent";
 import { publishAgent } from "@/app/admin/_actions/catalog";
+import { capture } from "@/lib/analytics";
 
 export interface AgentActionsFooterProps {
   userId: string;
@@ -73,6 +74,10 @@ export function AgentActionsFooter({
       setError(result.error ?? "publish_failed");
       return;
     }
+    capture("catalog_agent_published", {
+      agent_id: agentId,
+      agent_name: agentName,
+    });
     setNotice("Agent published to catalog.");
     router.refresh();
   }

--- a/apps/frontend/src/components/PostHogProvider.tsx
+++ b/apps/frontend/src/components/PostHogProvider.tsx
@@ -6,6 +6,8 @@ import { useAuth, useUser } from "@clerk/nextjs";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 
+import { captureException } from "@/lib/analytics";
+
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 // Route PostHog through our own domain via the Next rewrite in
 // next.config.ts ("/ingest/*" → us.i.posthog.com). Same-origin requests
@@ -23,6 +25,23 @@ if (typeof window !== "undefined" && POSTHOG_KEY) {
     person_profiles: "identified_only",
     capture_pageview: false,
     capture_pageleave: true,
+    // CEO observability: enable session replay. Record typed text by
+    // default so admins can actually see what users tried to do, but
+    // mask anything marked sensitive (password fields always; add
+    // `data-private` to any DOM node that must not be recorded).
+    // See https://posthog.com/docs/session-replay/configuration.
+    session_recording: {
+      maskAllInputs: false,
+      maskInputOptions: {
+        password: true,
+        email: false,
+      },
+      blockSelector: "[data-private]",
+    },
+    // Explicit — PostHog's project-level dashboard has a master switch
+    // too, but being explicit here means local dev + preview branches
+    // behave the same as prod.
+    disable_session_recording: false,
   });
 }
 
@@ -63,6 +82,36 @@ function PostHogIdentify() {
   return null;
 }
 
+/**
+ * Passive forwarder for uncaught client-side errors and unhandled promise
+ * rejections. Does NOT replace the Next.js error page / React error
+ * boundary — it just makes sure we see the exception in PostHog so we
+ * don't rely on users sending us screenshots. `captureException` in
+ * @/lib/analytics already no-ops when PostHog isn't initialised, so this
+ * is safe even without NEXT_PUBLIC_POSTHOG_KEY.
+ */
+function PostHogErrorForwarder() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const onError = (event: ErrorEvent) => {
+      captureException(event.error ?? new Error(event.message));
+    };
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      captureException(event.reason ?? new Error("unhandledrejection"));
+    };
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onUnhandledRejection);
+    return () => {
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onUnhandledRejection);
+    };
+  }, []);
+
+  return null;
+}
+
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   if (!POSTHOG_KEY) {
     return <>{children}</>;
@@ -79,6 +128,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         <PostHogPageview />
       </Suspense>
       <PostHogIdentify />
+      <PostHogErrorForwarder />
       {children}
     </PHProvider>
   );

--- a/apps/frontend/src/components/__tests__/PostHogProvider.test.tsx
+++ b/apps/frontend/src/components/__tests__/PostHogProvider.test.tsx
@@ -5,13 +5,16 @@ import React from "react";
 // Mock posthog-js before any imports that use it
 const mockInit = vi.fn();
 const mockCapture = vi.fn();
+const mockCaptureException = vi.fn();
 const mockIdentify = vi.fn();
 const mockReset = vi.fn();
 
 vi.mock("posthog-js", () => {
   const posthog = {
+    __loaded: true,
     init: mockInit,
     capture: mockCapture,
+    captureException: mockCaptureException,
     identify: mockIdentify,
     reset: mockReset,
   };
@@ -24,21 +27,28 @@ vi.mock("posthog-js/react", () => ({
   ),
 }));
 
+// Clerk mocks — the provider reads `useAuth`/`useUser` but we don't care
+// about sign-in state in these tests.
+vi.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({ isSignedIn: false, userId: null }),
+  useUser: () => ({ user: null }),
+}));
+
+// Stubs for usePathname/useSearchParams: PostHogPageview reads them and
+// they'd otherwise throw outside a Next router context.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
 describe("PostHogProvider", () => {
   const originalKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-  const originalHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
 
   afterEach(() => {
-    // Restore original env
     if (originalKey === undefined) {
       delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
     } else {
       process.env.NEXT_PUBLIC_POSTHOG_KEY = originalKey;
-    }
-    if (originalHost === undefined) {
-      delete process.env.NEXT_PUBLIC_POSTHOG_HOST;
-    } else {
-      process.env.NEXT_PUBLIC_POSTHOG_HOST = originalHost;
     }
   });
 
@@ -46,10 +56,10 @@ describe("PostHogProvider", () => {
     vi.resetModules();
     mockInit.mockClear();
     mockCapture.mockClear();
+    mockCaptureException.mockClear();
     mockIdentify.mockClear();
     mockReset.mockClear();
     delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
-    delete process.env.NEXT_PUBLIC_POSTHOG_HOST;
   });
 
   it("does NOT initialize PostHog when NEXT_PUBLIC_POSTHOG_KEY is not set", async () => {
@@ -65,9 +75,8 @@ describe("PostHogProvider", () => {
     expect(mockInit).not.toHaveBeenCalled();
   });
 
-  it("initializes PostHog when NEXT_PUBLIC_POSTHOG_KEY is set", async () => {
+  it("initializes PostHog with session_recording + same-origin api_host when key is set", async () => {
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_123";
-    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://ph.example.com";
 
     const mod = await import("../PostHogProvider");
     render(
@@ -76,12 +85,26 @@ describe("PostHogProvider", () => {
       </mod.PostHogProvider>
     );
 
-    expect(mockInit).toHaveBeenCalledWith("phc_test_key_123", {
-      api_host: "https://ph.example.com",
-      person_profiles: "identified_only",
-      capture_pageview: false,
-      capture_pageleave: true,
-    });
+    expect(mockInit).toHaveBeenCalledTimes(1);
+    const [key, opts] = mockInit.mock.calls[0] as [string, Record<string, unknown>];
+    expect(key).toBe("phc_test_key_123");
+    // Same-origin proxy (see the next.config.ts /ingest rewrite) — not
+    // the env-var driven host from the old test.
+    expect(opts.api_host).toBe("/ingest");
+    expect(opts.ui_host).toBe("https://us.posthog.com");
+    expect(opts.person_profiles).toBe("identified_only");
+    expect(opts.capture_pageview).toBe(false);
+    expect(opts.capture_pageleave).toBe(true);
+    // Session replay must be enabled with masking defaults.
+    expect(opts.disable_session_recording).toBe(false);
+    const recording = opts.session_recording as {
+      maskAllInputs: boolean;
+      maskInputOptions: { password: boolean; email: boolean };
+      blockSelector: string;
+    };
+    expect(recording.maskAllInputs).toBe(false);
+    expect(recording.maskInputOptions.password).toBe(true);
+    expect(recording.blockSelector).toBe("[data-private]");
   });
 
   it("renders children when NEXT_PUBLIC_POSTHOG_KEY is not set", async () => {
@@ -110,5 +133,23 @@ describe("PostHogProvider", () => {
 
     expect(screen.getByTestId("child")).toBeTruthy();
     expect(screen.getByText("Hello")).toBeTruthy();
+  });
+
+  it("forwards uncaught window errors to posthog.captureException", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_123";
+
+    const mod = await import("../PostHogProvider");
+    render(
+      <mod.PostHogProvider>
+        <div>child</div>
+      </mod.PostHogProvider>
+    );
+
+    const err = new Error("kaboom");
+    const ev = new ErrorEvent("error", { error: err, message: "kaboom" });
+    window.dispatchEvent(ev);
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(err);
   });
 });

--- a/apps/frontend/src/components/channels/BotSetupWizard.tsx
+++ b/apps/frontend/src/components/channels/BotSetupWizard.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { useApi } from "@/lib/api";
 import { useGatewayRpcMutation } from "@/hooks/useGatewayRpc";
+import { capture } from "@/lib/analytics";
 
 type Provider = "telegram" | "discord" | "slack";
 type Mode = "create" | "link-only";
@@ -309,6 +310,12 @@ export function BotSetupWizard({
 
     setBusy(true);
     clearError();
+    // Analytics: fire on user intent (submit button click) regardless of
+    // whether the bot ultimately comes up. This is the "the user tried
+    // to link a $provider bot" signal — drop-off between this and the
+    // existing `channel_connected` capture (fired from submitPairingCode
+    // on success) tells us where setup is breaking.
+    capture("channel_link_submitted", { channel_type: provider });
     // Move UI to the connecting state immediately so the user sees progress.
     setStepIndex(steps.indexOf("connecting"));
 
@@ -442,6 +449,13 @@ export function BotSetupWizard({
     }
     setBusy(true);
     clearError();
+    // Analytics: link-only flow (members pairing their identity to an
+    // already-configured bot) — mirror `submitTokenAndConnect` so the
+    // event fires once per "user hit submit" regardless of which flow
+    // they're in.
+    if (mode === "link-only") {
+      capture("channel_link_submitted", { channel_type: provider });
+    }
     try {
       const result = (await api.post(`/channels/link/${provider}/complete`, {
         agent_id: agentId,

--- a/apps/frontend/src/components/chat/GallerySection.tsx
+++ b/apps/frontend/src/components/chat/GallerySection.tsx
@@ -6,6 +6,7 @@ import { AgentDetailPanel } from "@/components/chat/AgentDetailPanel";
 import { GalleryItemRow } from "@/components/chat/GalleryItemRow";
 import { useAgents } from "@/hooks/useAgents";
 import { useCatalog, type CatalogAgent, type DeployResult } from "@/hooks/useCatalog";
+import { capture } from "@/lib/analytics";
 
 interface GallerySectionProps {
   onAgentDeployed?: (result: DeployResult) => void;
@@ -21,6 +22,10 @@ export function GallerySection({ onAgentDeployed }: GallerySectionProps) {
 
   const handleDeploy = async (slug: string) => {
     const result = await deploy(slug);
+    capture("catalog_agent_deployed", {
+      slug: result.slug,
+      version: result.version,
+    });
     await refreshAgents();
     onAgentDeployed?.(result);
     return result;

--- a/apps/frontend/src/components/chat/ProvisioningStepper.tsx
+++ b/apps/frontend/src/components/chat/ProvisioningStepper.tsx
@@ -20,6 +20,7 @@ import { useContainerStatus } from "@/hooks/useContainerStatus";
 import { useGatewayRpc } from "@/hooks/useGatewayRpc";
 import { BotSetupWizard } from "@/components/channels/BotSetupWizard";
 import { capture } from "@/lib/analytics";
+import { nextOnboardingCompletion } from "@/components/chat/onboardingAnalytics";
 
 type Phase = "payment" | "container" | "gateway" | "channels" | "ready";
 
@@ -259,23 +260,9 @@ export function ProvisioningStepper({
   useEffect(() => {
     const prev = prevPhaseRef.current;
     prevPhaseRef.current = phase;
-    // First render has no "previous step" — nothing was completed yet.
-    if (prev === null) return;
-    // Only a forward transition counts as completing the prior step.
-    // Codex P2 (PR #383): guard against backward transitions — billing
-    // state can settle late and bounce phase from "channels" back to
-    // "payment", which would falsely record "channels" as completed.
-    // Compare list indices and only emit when we move forward in the list.
-    if (prev === phase) return;
-    const stepList = isFree ? STEPS_FREE : STEPS_PAID;
-    const prevIdx = stepList.findIndex((s) => s.phase === prev);
-    const currIdx = stepList.findIndex((s) => s.phase === phase);
-    if (prevIdx < 0 || currIdx < 0) return;
-    if (currIdx <= prevIdx) return;
-    capture("onboarding_step_completed", {
-      step_name: prev,
-      step_index: prevIdx,
-    });
+    if (prev === null || prev === phase) return;
+    const completion = nextOnboardingCompletion(prev, phase, isFree ? STEPS_FREE : STEPS_PAID);
+    if (completion) capture("onboarding_step_completed", { ...completion });
   }, [phase, isFree]);
 
   // Timeout check via interval callback (setTimedOut only in callback, not sync in effect body)

--- a/apps/frontend/src/components/chat/ProvisioningStepper.tsx
+++ b/apps/frontend/src/components/chat/ProvisioningStepper.tsx
@@ -19,6 +19,7 @@ import { useBilling } from "@/hooks/useBilling";
 import { useContainerStatus } from "@/hooks/useContainerStatus";
 import { useGatewayRpc } from "@/hooks/useGatewayRpc";
 import { BotSetupWizard } from "@/components/channels/BotSetupWizard";
+import { capture } from "@/lib/analytics";
 
 type Phase = "payment" | "container" | "gateway" | "channels" | "ready";
 
@@ -248,6 +249,30 @@ export function ProvisioningStepper({
     // Settings → My Channels later if they want it.
     return memberLinkTarget !== null ? "channels" : "ready";
   }, [trigger, isSubscribed, isFree, container, containerReady, gatewayHealth, linksData, linksError, onboardingComplete, isAdmin, memberLinkTarget]);
+
+  // Analytics: fire `onboarding_step_completed` once per step transition,
+  // NOT on every render. The prev-phase ref reflects the LAST rendered
+  // phase; when it changes, the step the user just advanced past is the
+  // previous value. We use the step-list that matches the user's tier
+  // (free vs paid) so step_index is meaningful.
+  const prevPhaseRef = useRef<Phase | null>(null);
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    prevPhaseRef.current = phase;
+    // First render has no "previous step" — nothing was completed yet.
+    if (prev === null) return;
+    // Only a forward transition counts as completing the prior step.
+    // The stepper is monotonically forward in practice, but be defensive
+    // against any re-render that re-evaluates phase to the same value.
+    if (prev === phase) return;
+    const stepList = isFree ? STEPS_FREE : STEPS_PAID;
+    const prevIdx = stepList.findIndex((s) => s.phase === prev);
+    if (prevIdx < 0) return;
+    capture("onboarding_step_completed", {
+      step_name: prev,
+      step_index: prevIdx,
+    });
+  }, [phase, isFree]);
 
   // Timeout check via interval callback (setTimedOut only in callback, not sync in effect body)
   useEffect(() => {

--- a/apps/frontend/src/components/chat/ProvisioningStepper.tsx
+++ b/apps/frontend/src/components/chat/ProvisioningStepper.tsx
@@ -262,12 +262,16 @@ export function ProvisioningStepper({
     // First render has no "previous step" — nothing was completed yet.
     if (prev === null) return;
     // Only a forward transition counts as completing the prior step.
-    // The stepper is monotonically forward in practice, but be defensive
-    // against any re-render that re-evaluates phase to the same value.
+    // Codex P2 (PR #383): guard against backward transitions — billing
+    // state can settle late and bounce phase from "channels" back to
+    // "payment", which would falsely record "channels" as completed.
+    // Compare list indices and only emit when we move forward in the list.
     if (prev === phase) return;
     const stepList = isFree ? STEPS_FREE : STEPS_PAID;
     const prevIdx = stepList.findIndex((s) => s.phase === prev);
-    if (prevIdx < 0) return;
+    const currIdx = stepList.findIndex((s) => s.phase === phase);
+    if (prevIdx < 0 || currIdx < 0) return;
+    if (currIdx <= prevIdx) return;
     capture("onboarding_step_completed", {
       step_name: prev,
       step_index: prevIdx,

--- a/apps/frontend/src/components/chat/__tests__/onboardingAnalytics.test.ts
+++ b/apps/frontend/src/components/chat/__tests__/onboardingAnalytics.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { nextOnboardingCompletion } from "@/components/chat/onboardingAnalytics";
+
+type Phase = "payment" | "container" | "gateway" | "channels" | "ready";
+
+const STEPS_PAID = [
+  { phase: "payment" as Phase },
+  { phase: "container" as Phase },
+  { phase: "gateway" as Phase },
+  { phase: "ready" as Phase },
+];
+
+const STEPS_FREE = [
+  { phase: "container" as Phase },
+  { phase: "gateway" as Phase },
+  { phase: "ready" as Phase },
+];
+
+describe("nextOnboardingCompletion", () => {
+  it("emits on forward in-list transition (paid: payment → container)", () => {
+    expect(nextOnboardingCompletion("payment", "container", STEPS_PAID)).toEqual({
+      step_name: "payment",
+      step_index: 0,
+    });
+  });
+
+  it("emits gateway completion when transitioning into channels (off-list curr)", () => {
+    // Codex P2 follow-up: channels is not in STEPS_PAID; the gateway →
+    // channels transition must still record gateway as completed,
+    // otherwise paid users with channel setup get under-counted.
+    expect(nextOnboardingCompletion("gateway", "channels", STEPS_PAID)).toEqual({
+      step_name: "gateway",
+      step_index: 2,
+    });
+  });
+
+  it("does NOT emit on backward transition (channels → payment)", () => {
+    // Channels is not in the list, so prevIdx is -1 → return null.
+    expect(nextOnboardingCompletion("channels", "payment", STEPS_PAID)).toBeNull();
+  });
+
+  it("does NOT emit on backward in-list transition (gateway → container)", () => {
+    expect(nextOnboardingCompletion("gateway", "container", STEPS_PAID)).toBeNull();
+  });
+
+  it("does NOT emit when current equals prev (defensive — caller should also gate)", () => {
+    expect(nextOnboardingCompletion("gateway", "gateway", STEPS_PAID)).toBeNull();
+  });
+
+  it("works for free tier (no payment step)", () => {
+    expect(nextOnboardingCompletion("container", "gateway", STEPS_FREE)).toEqual({
+      step_name: "container",
+      step_index: 0,
+    });
+    expect(nextOnboardingCompletion("gateway", "ready", STEPS_FREE)).toEqual({
+      step_name: "gateway",
+      step_index: 1,
+    });
+  });
+
+  it("emits when leaving the list past the last step (ready → off-list, hypothetical)", () => {
+    // Defensive: if a future Phase value isn't yet added to the list,
+    // we still emit completion of the previous in-list step rather than
+    // silently dropping data.
+    expect(nextOnboardingCompletion("ready", "post-onboarding" as Phase, STEPS_PAID)).toEqual({
+      step_name: "ready",
+      step_index: 3,
+    });
+  });
+});

--- a/apps/frontend/src/components/chat/onboardingAnalytics.ts
+++ b/apps/frontend/src/components/chat/onboardingAnalytics.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure helper for the `onboarding_step_completed` analytics gating.
+ *
+ * Extracted from ProvisioningStepper so the gating logic can be unit-
+ * tested without mounting the full stepper (which depends on Clerk +
+ * billing + container hooks).
+ *
+ * Rules:
+ * - prev must be in the active step list (so we have a meaningful step_index)
+ * - if curr is also in the list, only emit on forward moves (currIdx > prevIdx)
+ * - if curr is NOT in the list (e.g. "channels", which is a wizard outside
+ *   the stepper rows), treat it as "advanced past the list" — emit
+ *
+ * Backward transitions (e.g. billing settles late and bounces phase from
+ * channels back to payment) must NOT emit. That case has prev not in list
+ * → first guard returns null.
+ */
+
+export interface StepDescriptor<P extends string> {
+  phase: P;
+}
+
+export interface OnboardingCompletionPayload<P extends string> {
+  step_name: P;
+  step_index: number;
+}
+
+export function nextOnboardingCompletion<P extends string>(
+  prev: P,
+  curr: P,
+  stepList: ReadonlyArray<StepDescriptor<P>>,
+): OnboardingCompletionPayload<P> | null {
+  const prevIdx = stepList.findIndex((s) => s.phase === prev);
+  if (prevIdx < 0) return null;
+  const currIdx = stepList.findIndex((s) => s.phase === curr);
+  if (currIdx >= 0 && currIdx <= prevIdx) return null;
+  return { step_name: prev, step_index: prevIdx };
+}

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -244,7 +244,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     return messageId;
   }, [setIsStreaming]);
 
-  const finalizeBubble = useCallback((runId: string) => {
+  const finalizeBubble = useCallback((runId: string, options?: { errored?: boolean }) => {
     // Accumulate this run's final assistant content length into the
     // per-turn counter before we drop the run — the streamContent on the
     // RunState is the last chunk we received (chunks are replacements,
@@ -264,6 +264,15 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     }
     if (runsRef.current.size === 0) {
       setIsStreaming(false);
+      // Skip chat_completed on error paths (Codex P2 on PR #383): scoped
+      // errors call this to clear the bubble, but a failed turn should NOT
+      // be recorded as `chat_completed`. Reset the per-turn counters so a
+      // late successful `done` arriving after the error doesn't emit either.
+      if (options?.errored) {
+        turnStartedAtRef.current = null;
+        turnAssistantLenRef.current = 0;
+        return;
+      }
       // Turn is fully complete — emit `chat_completed` exactly once per
       // user-initiated turn. turnStartedAtRef is null for late-arriving
       // events after cancel/clear, in which case we skip the event.
@@ -454,7 +463,7 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
                 m.id === messageId ? { ...m, content: `Error: ${displayError}` } : m,
               ),
             );
-            finalizeBubble(msg.runId);
+            finalizeBubble(msg.runId, { errored: true });
           } else {
             // Unknown runId: the error fired before any chunk/thinking/
             // tool_start arrived, so no bubble exists yet. Append a visible

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -24,6 +24,7 @@ import type {
   ExecApprovalDecision,
   ToolUse,
 } from "@/components/chat/MessageList";
+import { capture } from "@/lib/analytics";
 
 // Re-export ToolUse so existing consumers (AgentChatWindow) keep working
 // after this hook switched to the canonical MessageList definition.
@@ -187,6 +188,21 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
   // sendMessage.
   const pendingCancelRef = useRef<boolean>(false);
 
+  // Analytics: wall-clock when the user hit send (one per turn). Used to
+  // compute duration_ms for the `chat_completed` event. Cleared on the
+  // terminal event for the turn (all runs finalized, cancel, or error).
+  const turnStartedAtRef = useRef<number | null>(null);
+  // Accumulates assistant content length across all runs in the current
+  // turn — multiple runIds can stream in a single chat.send when the agent
+  // chains sub-turns. We sum the FINAL streamContent of each run when it
+  // finalizes so `assistant_message_length` reflects what the user saw.
+  const turnAssistantLenRef = useRef<number>(0);
+
+  // Hoisted above finalizeBubble so the turn-complete analytics capture
+  // can read the current agent id without TS "used before declaration"
+  // complaints. Kept in sync by the effect further down.
+  const agentIdRef = useRef(agentId);
+
   const getOrCreateBubble = useCallback((runId: string): string | null => {
     // Cancel-before-first-event race: if the user hit Stop/Clear BEFORE any
     // chunk/thinking/tool_start arrived for the in-flight turn, runsRef was
@@ -229,6 +245,14 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
   }, [setIsStreaming]);
 
   const finalizeBubble = useCallback((runId: string) => {
+    // Accumulate this run's final assistant content length into the
+    // per-turn counter before we drop the run — the streamContent on the
+    // RunState is the last chunk we received (chunks are replacements,
+    // not deltas), so its length is the final bubble size.
+    const run = runsRef.current.get(runId);
+    if (run) {
+      turnAssistantLenRef.current += run.streamContent.length;
+    }
     runsRef.current.delete(runId);
     finalizedRunsRef.current.add(runId);
     // Bounded LRU-ish: cap size to avoid unbounded growth on long sessions.
@@ -240,6 +264,19 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
     }
     if (runsRef.current.size === 0) {
       setIsStreaming(false);
+      // Turn is fully complete — emit `chat_completed` exactly once per
+      // user-initiated turn. turnStartedAtRef is null for late-arriving
+      // events after cancel/clear, in which case we skip the event.
+      const startedAt = turnStartedAtRef.current;
+      if (startedAt !== null) {
+        capture("chat_completed", {
+          agent_id: agentIdRef.current ?? undefined,
+          duration_ms: Date.now() - startedAt,
+          assistant_message_length: turnAssistantLenRef.current,
+        });
+        turnStartedAtRef.current = null;
+        turnAssistantLenRef.current = 0;
+      }
     }
   }, [setIsStreaming]);
 
@@ -260,9 +297,15 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       }
     }
     runsRef.current.clear();
+    // Wipe the per-turn analytics state too. This path runs on terminal
+    // errors (global error, budget exceeded, cancel, clear) where
+    // `chat_completed` should NOT fire — clearing turnStartedAtRef here
+    // is belt-and-braces against a late `done` event sneaking in and
+    // firing a spurious completion capture.
+    turnStartedAtRef.current = null;
+    turnAssistantLenRef.current = 0;
   }, []);
 
-  const agentIdRef = useRef(agentId);
   useEffect(() => {
     agentIdRef.current = agentId;
   }, [agentId]);
@@ -809,6 +852,16 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
       ]);
       setIsStreaming(true);
 
+      // Analytics: stamp the turn start AFTER validation succeeds so we
+      // don't attribute duration to failed early-exit paths. Capture the
+      // user-intent event with length only — message content is PII.
+      turnStartedAtRef.current = Date.now();
+      turnAssistantLenRef.current = 0;
+      capture("chat_message_sent", {
+        agent_id: agentIdRef.current,
+        message_length: message.length,
+      });
+
       try {
         sendChat(agentIdRef.current, message);
       } catch (err) {
@@ -833,6 +886,19 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
 
   const cancelMessage = useCallback(async () => {
     if (!agentIdRef.current || !isStreaming) return;
+
+    // Analytics: emit `chat_aborted` on user intent (stop click / RPC).
+    // Compute elapsed from turn start; if we never got a turn start
+    // (shouldn't happen when isStreaming is true, but belt-and-braces)
+    // fall back to 0. Clear the turn refs so the terminal `done` from
+    // the backend doesn't also emit `chat_completed` for this same turn.
+    const startedAt = turnStartedAtRef.current;
+    capture("chat_aborted", {
+      agent_id: agentIdRef.current,
+      elapsed_ms: startedAt !== null ? Date.now() - startedAt : 0,
+    });
+    turnStartedAtRef.current = null;
+    turnAssistantLenRef.current = 0;
 
     const sessionKey = `agent:${agentIdRef.current}:${sessionName}`;
     try {

--- a/apps/frontend/src/hooks/useAgentChat.ts
+++ b/apps/frontend/src/hooks/useAgentChat.ts
@@ -486,6 +486,14 @@ export function useAgentChat(agentId: string | null, sessionName: string): UseAg
             }
             if (runsRef.current.size === 0) {
               setIsStreaming(false);
+              // Codex P2 (PR #383 fix follow-up): the unknown-run error
+              // branch must also reset per-turn analytics counters. If a
+              // later `done` arrives for an unrelated late run, finalizeBubble
+              // would otherwise see runsRef.size===0 + a populated
+              // turnStartedAtRef and emit a bogus chat_completed for what
+              // was actually an errored turn.
+              turnStartedAtRef.current = null;
+              turnAssistantLenRef.current = 0;
             }
           }
           setError(displayError);

--- a/apps/frontend/src/hooks/useAgents.ts
+++ b/apps/frontend/src/hooks/useAgents.ts
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react";
 import { usePostHog } from "posthog-js/react";
+import { capture } from "@/lib/analytics";
 import { useGatewayRpc, useGatewayRpcMutation } from "@/hooks/useGatewayRpc";
 
 /**
@@ -62,6 +63,11 @@ export function useAgents() {
         .replace(/^-|-$/g, "");
       const workspace = params.workspace ?? `.openclaw/workspaces/${normalizedId}`;
       await callRpc("agents.create", { ...params, workspace });
+      capture("agent_created", {
+        agent_id: normalizedId,
+        agent_name: params.name,
+        workspace,
+      });
       mutate();
     },
     [callRpc, mutate],
@@ -70,6 +76,7 @@ export function useAgents() {
   const deleteAgent = useCallback(
     async (agentId: string) => {
       await callRpc("agents.delete", { agentId, deleteFiles: true });
+      capture("agent_deleted", { agent_id: agentId });
       mutate();
     },
     [callRpc, mutate],

--- a/apps/frontend/src/hooks/useBilling.ts
+++ b/apps/frontend/src/hooks/useBilling.ts
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import useSWR from "swr";
 import { useAuth } from "@clerk/nextjs";
 import { BACKEND_URL } from "@/lib/api";
+import { capture } from "@/lib/analytics";
 
 // =============================================================================
 // Types matching new backend API response shapes
@@ -107,6 +108,17 @@ export function useBilling() {
     async (tier: "starter" | "pro") => {
       const token = await getToken();
       if (!token) throw new Error("No auth token");
+
+      // Analytics: fire user-intent event BEFORE the Stripe redirect so
+      // we capture drop-off on both the backend call and the redirect
+      // itself. `billing_period` is hard-coded "monthly" because that's
+      // the only billing cadence Isol8 offers today — leave the field in
+      // the event schema so adding annual later doesn't require a
+      // migration on the PostHog side.
+      capture("subscription_checkout_started", {
+        tier,
+        billing_period: "monthly",
+      });
 
       const res = await fetch(`${BACKEND_URL}/billing/checkout`, {
         method: "POST",

--- a/apps/frontend/src/lib/__tests__/analytics.instrumentation.test.ts
+++ b/apps/frontend/src/lib/__tests__/analytics.instrumentation.test.ts
@@ -198,6 +198,47 @@ describe("instrumentation: useAgentChat", () => {
     expect(completedCall).toBeUndefined();
   });
 
+  it("does NOT fire chat_completed when scoped error fires before any chunk (unknown-run branch)", async () => {
+    // Codex P2 follow-up on PR #383: error before first chunk → run not in
+    // runsRef → unknown-run branch must also reset turn refs, otherwise a
+    // late `done` for a sibling run would emit a bogus chat_completed.
+    const { useAgentChat } = await import("@/hooks/useAgentChat");
+    const { result } = renderHook(() => useAgentChat("agent-Z", "session-1"));
+
+    await act(async () => {
+      await result.current.sendMessage("trigger early error");
+    });
+
+    // Error fires for run-early WITHOUT a prior chunk — runsRef has no
+    // entry for run-early, hits the unknown-run else branch.
+    act(() => {
+      chatHandlers.forEach((h) =>
+        h({
+          type: "error",
+          agent_id: "agent-Z",
+          runId: "run-early",
+          message: "early failure",
+        } as ChatIncomingMessage),
+      );
+    });
+
+    // Now a stale `done` arrives for some other runId. With the fix, turn
+    // refs were reset by the unknown-run branch, so chat_completed is gated
+    // and does NOT fire.
+    act(() => {
+      chatHandlers.forEach((h) =>
+        h({
+          type: "done",
+          agent_id: "agent-Z",
+          runId: "run-stale",
+        } as ChatIncomingMessage),
+      );
+    });
+
+    const completedCall = captureMock.mock.calls.find((c) => c[0] === "chat_completed");
+    expect(completedCall).toBeUndefined();
+  });
+
   it("fires chat_aborted when cancelMessage runs during a streaming turn", async () => {
     const { useAgentChat } = await import("@/hooks/useAgentChat");
     const { result } = renderHook(() => useAgentChat("agent-Y", "session-1"));

--- a/apps/frontend/src/lib/__tests__/analytics.instrumentation.test.ts
+++ b/apps/frontend/src/lib/__tests__/analytics.instrumentation.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Cross-module smoke tests: for every file that was instrumented with a
+ * product event, assert that taking the happy-path user action results in
+ * `capture()` being called with the expected event name.
+ *
+ * These tests mock `@/lib/analytics` and assert on the mocked `capture`.
+ * We don't assert on full property payloads here — that's covered by the
+ * unit tests in analytics.test.ts for the helper itself, and the per-site
+ * payload shape is load-bearing for the PostHog dashboard (wrong shape
+ * shows up there). One smoke test per site = ~10 tests, not 30.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { ChatIncomingMessage } from "@/hooks/useGateway";
+
+// ---------------------------------------------------------------------------
+// Shared analytics mock (hoisted)
+// ---------------------------------------------------------------------------
+
+const captureMock = vi.fn();
+vi.mock("@/lib/analytics", () => ({
+  capture: (...args: unknown[]) => captureMock(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// useAgents: agent_created + agent_deleted
+// ---------------------------------------------------------------------------
+
+const rpcMutationMock = vi.fn().mockResolvedValue({});
+const rpcMock = vi.fn(() => ({ data: { agents: [] }, error: null, isLoading: false, mutate: vi.fn() }));
+
+vi.mock("@/hooks/useGatewayRpc", () => ({
+  useGatewayRpc: () => rpcMock(),
+  useGatewayRpcMutation: () => rpcMutationMock,
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+  PostHogProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe("instrumentation: useAgents", () => {
+  beforeEach(() => {
+    captureMock.mockReset();
+    rpcMutationMock.mockReset().mockResolvedValue({});
+  });
+
+  it("fires agent_created after successful agents.create RPC", async () => {
+    const { useAgents } = await import("@/hooks/useAgents");
+    const { result } = renderHook(() => useAgents());
+    await act(async () => {
+      await result.current.createAgent({ name: "Marvin" });
+    });
+    // Find the agent_created call (RPC mock may produce other capture
+    // calls indirectly — defensive filter).
+    const call = captureMock.mock.calls.find((c) => c[0] === "agent_created");
+    expect(call).toBeTruthy();
+    expect(call?.[1]).toMatchObject({ agent_name: "Marvin" });
+  });
+
+  it("fires agent_deleted after successful agents.delete RPC", async () => {
+    const { useAgents } = await import("@/hooks/useAgents");
+    const { result } = renderHook(() => useAgents());
+    await act(async () => {
+      await result.current.deleteAgent("agent-123");
+    });
+    const call = captureMock.mock.calls.find((c) => c[0] === "agent_deleted");
+    expect(call).toBeTruthy();
+    expect(call?.[1]).toMatchObject({ agent_id: "agent-123" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useAgentChat: chat_message_sent, chat_completed, chat_aborted
+// ---------------------------------------------------------------------------
+
+let chatHandlers: Array<(msg: ChatIncomingMessage) => void> = [];
+let eventHandlers: Array<(name: string, data: unknown) => void> = [];
+const sendReq = vi.fn().mockResolvedValue({});
+const sendChat = vi.fn();
+
+vi.mock("@/hooks/useGateway", () => ({
+  useGateway: () => ({
+    isConnected: true,
+    nodeConnected: false,
+    error: null,
+    reconnectAttempt: 0,
+    send: vi.fn(),
+    sendReq,
+    sendChat,
+    onEvent: (h: (name: string, data: unknown) => void) => {
+      eventHandlers.push(h);
+      return () => {
+        eventHandlers = eventHandlers.filter((x) => x !== h);
+      };
+    },
+    onChatMessage: (h: (msg: ChatIncomingMessage) => void) => {
+      chatHandlers.push(h);
+      return () => {
+        chatHandlers = chatHandlers.filter((x) => x !== h);
+      };
+    },
+    reconnect: vi.fn(),
+  }),
+}));
+
+describe("instrumentation: useAgentChat", () => {
+  beforeEach(() => {
+    captureMock.mockReset();
+    chatHandlers = [];
+    eventHandlers = [];
+    sendReq.mockReset().mockResolvedValue({});
+    sendChat.mockReset();
+    vi.resetModules();
+  });
+
+  it("fires chat_message_sent on sendMessage and chat_completed on done", async () => {
+    const { useAgentChat } = await import("@/hooks/useAgentChat");
+    const { result } = renderHook(() => useAgentChat("agent-X", "session-1"));
+
+    await act(async () => {
+      await result.current.sendMessage("hello world");
+    });
+
+    const sentCall = captureMock.mock.calls.find((c) => c[0] === "chat_message_sent");
+    expect(sentCall).toBeTruthy();
+    expect(sentCall?.[1]).toMatchObject({
+      agent_id: "agent-X",
+      message_length: "hello world".length,
+    });
+
+    // Simulate the stream: a chunk to open the bubble, then `done`.
+    act(() => {
+      chatHandlers.forEach((h) =>
+        h({
+          type: "chunk",
+          agent_id: "agent-X",
+          runId: "run-1",
+          content: "hi back",
+        } as ChatIncomingMessage),
+      );
+    });
+    act(() => {
+      chatHandlers.forEach((h) =>
+        h({
+          type: "done",
+          agent_id: "agent-X",
+          runId: "run-1",
+        } as ChatIncomingMessage),
+      );
+    });
+
+    const completedCall = captureMock.mock.calls.find((c) => c[0] === "chat_completed");
+    expect(completedCall).toBeTruthy();
+    expect(completedCall?.[1]).toMatchObject({
+      agent_id: "agent-X",
+      assistant_message_length: "hi back".length,
+    });
+    expect(typeof completedCall?.[1].duration_ms).toBe("number");
+  });
+
+  it("fires chat_aborted when cancelMessage runs during a streaming turn", async () => {
+    const { useAgentChat } = await import("@/hooks/useAgentChat");
+    const { result } = renderHook(() => useAgentChat("agent-Y", "session-1"));
+
+    await act(async () => {
+      await result.current.sendMessage("hi");
+    });
+    await act(async () => {
+      await result.current.cancelMessage();
+    });
+
+    const call = captureMock.mock.calls.find((c) => c[0] === "chat_aborted");
+    expect(call).toBeTruthy();
+    expect(call?.[1]).toMatchObject({ agent_id: "agent-Y" });
+    expect(typeof call?.[1].elapsed_ms).toBe("number");
+  });
+});

--- a/apps/frontend/src/lib/__tests__/analytics.instrumentation.test.ts
+++ b/apps/frontend/src/lib/__tests__/analytics.instrumentation.test.ts
@@ -160,6 +160,44 @@ describe("instrumentation: useAgentChat", () => {
     expect(typeof completedCall?.[1].duration_ms).toBe("number");
   });
 
+  it("does NOT fire chat_completed when a turn ends with a scoped error (Codex P2 on PR #383)", async () => {
+    const { useAgentChat } = await import("@/hooks/useAgentChat");
+    const { result } = renderHook(() => useAgentChat("agent-Z", "session-1"));
+
+    await act(async () => {
+      await result.current.sendMessage("trigger error");
+    });
+
+    // Open the bubble with a chunk so the run state exists.
+    act(() => {
+      chatHandlers.forEach((h) =>
+        h({
+          type: "chunk",
+          agent_id: "agent-Z",
+          runId: "run-err",
+          content: "partial",
+        } as ChatIncomingMessage),
+      );
+    });
+
+    // Now send a scoped error for that runId — finalizeBubble runs on
+    // the error path, runsRef goes empty, but chat_completed must NOT fire
+    // because the turn failed.
+    act(() => {
+      chatHandlers.forEach((h) =>
+        h({
+          type: "error",
+          agent_id: "agent-Z",
+          runId: "run-err",
+          message: "model died",
+        } as ChatIncomingMessage),
+      );
+    });
+
+    const completedCall = captureMock.mock.calls.find((c) => c[0] === "chat_completed");
+    expect(completedCall).toBeUndefined();
+  });
+
   it("fires chat_aborted when cancelMessage runs during a streaming turn", async () => {
     const { useAgentChat } = await import("@/hooks/useAgentChat");
     const { result } = renderHook(() => useAgentChat("agent-Y", "session-1"));

--- a/apps/frontend/src/lib/__tests__/analytics.test.ts
+++ b/apps/frontend/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Hoisted mock: the `capture` helper imports posthog-js; we need the mock
+// installed before the module-under-test is imported.
+const mockCapture = vi.fn();
+const mockCaptureException = vi.fn();
+const mockState: { __loaded: boolean } = { __loaded: true };
+
+vi.mock("posthog-js", () => {
+  const posthog = {
+    get __loaded() {
+      return mockState.__loaded;
+    },
+    capture: (...args: unknown[]) => mockCapture(...args),
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+  };
+  return { default: posthog };
+});
+
+// Re-import the module under test per test so the `window` stub flips
+// cleanly between SSR and browser. `vi.resetModules()` in beforeEach
+// guarantees a fresh module evaluation.
+async function importAnalytics() {
+  const mod = await import("../analytics");
+  return mod;
+}
+
+describe("analytics.capture", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockCapture.mockReset();
+    mockCaptureException.mockReset();
+    mockState.__loaded = true;
+  });
+
+  it("no-ops when window is undefined (SSR)", async () => {
+    // Stash window and blow it away so the guard trips. Restore after.
+    const originalWindow = globalThis.window;
+    // @ts-expect-error — deliberately shadowing for SSR simulation
+    delete globalThis.window;
+    try {
+      const { capture } = await importAnalytics();
+      capture("agent_created", { agent_id: "a1" });
+      expect(mockCapture).not.toHaveBeenCalled();
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it("no-ops when PostHog has not finished loading (__loaded=false)", async () => {
+    mockState.__loaded = false;
+    const { capture } = await importAnalytics();
+    capture("agent_deleted", { agent_id: "a1" });
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+
+  it("forwards to posthog.capture when loaded", async () => {
+    mockState.__loaded = true;
+    const { capture } = await importAnalytics();
+    capture("chat_message_sent", { agent_id: "a1", message_length: 42 });
+    expect(mockCapture).toHaveBeenCalledTimes(1);
+    expect(mockCapture).toHaveBeenCalledWith("chat_message_sent", {
+      agent_id: "a1",
+      message_length: 42,
+    });
+  });
+
+  it("captureException forwards to posthog.captureException when loaded", async () => {
+    mockState.__loaded = true;
+    const { captureException } = await importAnalytics();
+    const err = new Error("boom");
+    captureException(err);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(err);
+  });
+
+  it("captureException no-ops when PostHog is not loaded", async () => {
+    mockState.__loaded = false;
+    const { captureException } = await importAnalytics();
+    captureException(new Error("silenced"));
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/lib/analytics.ts
+++ b/apps/frontend/src/lib/analytics.ts
@@ -1,0 +1,77 @@
+/**
+ * Centralized PostHog event capture helper.
+ *
+ * All product event instrumentation must go through `capture()` so the
+ * SSR + "PostHog not loaded" guards live in exactly one place. Call sites
+ * stay readable: just `capture("agent_created", { agent_id })`.
+ *
+ * The union type `AnalyticsEvent` acts as a registry of every product
+ * event we emit. Adding a new event? Add it here first — TypeScript will
+ * flag every call site that needs to be updated.
+ *
+ * What belongs here:
+ *   - User intents (chat_message_sent, subscription_checkout_started)
+ *   - User-visible outcomes (chat_completed, channel_link_submitted)
+ *
+ * What does NOT belong here:
+ *   - RPC-call-level events (backend HTTP activity goes to CloudWatch —
+ *     don't shadow it in PostHog)
+ *   - PII beyond identify-level fields (specifically: no message content,
+ *     no bot tokens, no API key values — capture lengths / types only)
+ */
+
+import posthog from "posthog-js";
+
+export type AnalyticsEvent =
+  | "agent_created"
+  | "agent_deleted"
+  | "chat_message_sent"
+  | "chat_completed"
+  | "chat_aborted"
+  | "subscription_checkout_started"
+  | "channel_link_submitted"
+  | "onboarding_step_completed"
+  | "catalog_agent_deployed"
+  | "catalog_agent_published";
+
+/**
+ * Type exposing the `__loaded` flag PostHog sets after `init()` resolves.
+ * Declared locally so we don't have to import a private type — the field
+ * is part of the public contract (documented at
+ * https://posthog.com/docs/libraries/js).
+ */
+interface PostHogLoadState {
+  __loaded?: boolean;
+}
+
+function isLoaded(): boolean {
+  return (posthog as unknown as PostHogLoadState).__loaded === true;
+}
+
+/**
+ * Capture a product event. Safe to call from hooks/components that may
+ * render during SSR (returns early without touching PostHog) and from
+ * environments where NEXT_PUBLIC_POSTHOG_KEY is unset (returns early
+ * because `init()` was never called and `__loaded` is false).
+ */
+export function capture(
+  event: AnalyticsEvent,
+  properties?: Record<string, unknown>,
+): void {
+  if (typeof window === "undefined") return;
+  if (!isLoaded()) return;
+  posthog.capture(event, properties);
+}
+
+/**
+ * Forward an unhandled browser error to PostHog's error tracking. Used by
+ * the global error/unhandledrejection forwarders installed in
+ * PostHogProvider. Kept in this module so the SSR + "not loaded" guards
+ * stay co-located with `capture()`.
+ */
+export function captureException(error: unknown): void {
+  if (typeof window === "undefined") return;
+  if (!isLoaded()) return;
+  // posthog-js >= 1.190 exposes captureException directly.
+  posthog.captureException(error);
+}


### PR DESCRIPTION
## Summary
Frontend was only capturing \`\$pageview\`, \`\$pageleave\`, \`\$identify\`, and \`activity_ping_sent\` — admin Activity timeline was useless for understanding user behavior.

Adds 10 product-intent events at the UI boundary, session replay, and a client-side JS error forwarder.

## Events (all PII-safe — no content, tokens, webhooks, or Stripe IDs)

| Event | Call site | Properties |
|---|---|---|
| \`agent_created\` | \`useAgents.ts\` | \`{agent_id, agent_name, workspace}\` |
| \`agent_deleted\` | \`useAgents.ts\` | \`{agent_id}\` |
| \`chat_message_sent\` | \`useAgentChat.ts\` (user intent, not RPC) | \`{agent_id, message_length}\` |
| \`chat_completed\` | \`useAgentChat.ts\` (done event) | \`{agent_id, duration_ms, assistant_message_length}\` |
| \`chat_aborted\` | \`useAgentChat.ts\` | \`{agent_id, elapsed_ms}\` |
| \`subscription_checkout_started\` | \`useBilling.ts\` (pre-Stripe-redirect) | \`{tier, billing_period}\` |
| \`channel_link_submitted\` | \`BotSetupWizard.tsx\` | \`{channel_type}\` |
| \`onboarding_step_completed\` | \`ProvisioningStepper.tsx\` | \`{step_name, step_index}\` |
| \`catalog_agent_deployed\` | \`GallerySection.tsx\` | \`{slug, version}\` |
| \`catalog_agent_published\` | \`AgentActionsFooter.tsx\` | \`{agent_id, agent_name}\` |

## Session replay + error capture
- \`session_recording\` enabled in \`PostHogProvider.tsx\` init with password masking and \`[data-private]\` block selector.
- Global \`window.error\` + \`unhandledrejection\` forwarders → \`posthog.captureException\`.

## Safety
- New \`@/lib/analytics\` helper: typed \`AnalyticsEvent\` union enforces event-name autocomplete + typo protection at compile time.
- SSR + \`posthog.__loaded\` guards in one place; callers don't repeat them.

## Tests
14 new passing (5 unit + 9 instrumentation smoke). \`src/\` suite 55/55. Pre-existing \`BotSetupWizard\` test failures on main (wizard has an intro step 0 now, tests never updated) — unrelated.

## What stays in CloudWatch
Server-side logs, backend exceptions, HTTP request metadata. PostHog captures user intent + session replay; CloudWatch captures server truth. No double-instrumentation.