### PR TITLE
fix(admin): remove `export type` from "use server" files (publish-500 root cause)

### DIFF
--- a/apps/frontend/src/app/admin/_actions/agent.ts
+++ b/apps/frontend/src/app/admin/_actions/agent.ts
@@ -91,4 +91,6 @@ export async function clearAgentSessions(
   );
 }
 
-export type { ActionResult };
+// NOTE: see catalog.ts — "use server" files must export ONLY async functions.
+// Turbopack turns `export type { ActionResult }` into a runtime ReferenceError
+// at SSR chunk load. No consumer imports ActionResult today.

--- a/apps/frontend/src/app/admin/_actions/billing.ts
+++ b/apps/frontend/src/app/admin/_actions/billing.ts
@@ -101,4 +101,6 @@ export async function markInvoiceResolved(
   );
 }
 
-export type { ActionResult };
+// NOTE: see catalog.ts — "use server" files must export ONLY async functions.
+// Turbopack turns `export type { ActionResult }` into a runtime ReferenceError
+// at SSR chunk load. No consumer imports ActionResult today.

--- a/apps/frontend/src/app/admin/_actions/catalog.ts
+++ b/apps/frontend/src/app/admin/_actions/catalog.ts
@@ -100,4 +100,12 @@ export async function unpublishSlug(slug: string): Promise<ActionResult> {
   return adminPost(`/admin/catalog/${encodeURIComponent(slug)}/unpublish`);
 }
 
-export type { ActionResult };
+// NOTE: Do NOT add `export type { ActionResult }` (or any non-async-function
+// export) here. Next.js `"use server"` files may export ONLY async server
+// functions; anything else is invalid. Turbopack emits the type re-export
+// as a runtime value reference in the SSR chunk, which fails at module
+// evaluation with `ReferenceError: ActionResult is not defined` the first
+// time the Server Action runs — manifesting as a 500 on the first publish
+// click. No consumer currently imports ActionResult; if you ever need the
+// type, move the `interface ActionResult` declaration to a non-"use server"
+// module (e.g. `_actions/_types.ts`).

--- a/apps/frontend/src/app/admin/_actions/container.ts
+++ b/apps/frontend/src/app/admin/_actions/container.ts
@@ -93,4 +93,6 @@ export async function resizeContainer(userId: string, tier: string): Promise<Act
   );
 }
 
-export type { ActionResult };
+// NOTE: see catalog.ts — "use server" files must export ONLY async functions.
+// Turbopack turns `export type { ActionResult }` into a runtime ReferenceError
+// at SSR chunk load. No consumer imports ActionResult today.


### PR DESCRIPTION
## Root cause

**Vercel prod digest** `1060549929`:
\`\`\`
ReferenceError: ActionResult is not defined
    at module evaluation (.next/server/chunks/ssr/[root-of-the-server]__0c4be624._.js:1:2918)
\`\`\`

Next.js `"use server"` files may export **only async server functions**. Any non-function export (including `export type { ... }`) is invalid. Turbopack compiled `export type { ActionResult };` at the bottom of `catalog.ts` into a runtime **value** reference in the SSR chunk, so the first invocation of any action in that chunk failed module evaluation with the ReferenceError above. The user saw it as a 500 + "An error occurred in the Server Components render" on the first Publish-to-catalog click.

## Why it surfaced on catalog publish specifically
`catalog.ts`'s `publishAgent` was the first action the user triggered on the agent detail page. The same latent bug exists in `agent.ts`, `billing.ts`, `container.ts` — the action mutations (deleteAgent, startContainer, issueCredit, etc.) would have hit the same ReferenceError as soon as they were invoked in prod.

## Fix
Remove `export type { ActionResult };` from all 4 affected files and add a comment warning against re-adding it. `ActionResult` is not imported anywhere — pure dead-code removal.

\`_actions/account.ts\` and \`_actions/config.ts\` were already clean.

## Verification
- `pnpm exec tsc --noEmit`: clean
- `pnpm lint`: 0 errors (15 pre-existing warnings, none in touched files)
- Full grep confirms no consumer imports `ActionResult`

## Follow-up (not in this PR)
If `ActionResult` is ever needed by a consumer, move the `interface ActionResult` declaration to `_actions/_types.ts` (a non-"use server" module) and import from there.