### PR TITLE
fix(catalog): skip non-dict entries in openclaw.json agents list

### DIFF
--- a/apps/backend/core/services/catalog_service.py
+++ b/apps/backend/core/services/catalog_service.py
@@ -246,7 +246,9 @@ class CatalogService:
             raise FileNotFoundError(f"admin {admin_user_id} (owner {owner_id}) has no openclaw.json")
 
         slice_ = extract_agent_slice(config, agent_id)
-        agent_entry_raw = next(a for a in config["agents"] if a.get("id") == agent_id)
+        # Same non-dict tolerance as extract_agent_slice() — if we got past
+        # that, the dict entry exists; just mirror its filter here too.
+        agent_entry_raw = next(a for a in config["agents"] if isinstance(a, dict) and a.get("id") == agent_id)
 
         name = agent_entry_raw.get("name") or agent_id
         slug = (slug_override or name).strip().lower().replace(" ", "-")

--- a/apps/backend/core/services/catalog_slice.py
+++ b/apps/backend/core/services/catalog_slice.py
@@ -29,9 +29,15 @@ def strip_user_specific_fields(agent_entry: dict[str, Any]) -> dict[str, Any]:
 def extract_agent_slice(openclaw_json: dict[str, Any], agent_id: str) -> dict[str, Any]:
     """Return a dict with the sliced agent entry plus the required plugins/tools
     from the publisher's config. Raises KeyError if the agent_id isn't present.
+
+    Tolerates malformed entries in ``agents``. Live prod configs have been
+    observed with non-dict entries (e.g. bare strings) mixed in with the
+    full dict entries — probably from hand-editing or an OpenClaw runtime
+    write pattern we don't fully mirror. Skip anything that isn't a dict
+    rather than crashing the whole publish with AttributeError.
     """
     agents = openclaw_json.get("agents") or []
-    matching = [a for a in agents if a.get("id") == agent_id]
+    matching = [a for a in agents if isinstance(a, dict) and a.get("id") == agent_id]
     if not matching:
         raise KeyError(f"agent {agent_id!r} not found in openclaw.json")
     agent_entry = matching[0]

--- a/apps/backend/tests/unit/test_catalog_slice.py
+++ b/apps/backend/tests/unit/test_catalog_slice.py
@@ -42,6 +42,31 @@ def test_extract_agent_slice_missing_agent_raises():
         extract_agent_slice(FULL_OPENCLAW_JSON, "agent_does_not_exist")
 
 
+def test_extract_agent_slice_tolerates_non_dict_entries_in_agents():
+    """Live prod regression: publish crashed with AttributeError when openclaw.json's
+    agents list had a bare string alongside the dict entries. Skip non-dicts
+    rather than calling .get() on them."""
+    cfg = {
+        "agents": [
+            "some-stray-string",  # malformed entry — should be skipped, not crash
+            {"id": "agent_abc", "name": "Pitch", "skills": ["web-search"]},
+            None,  # another malformed variant
+        ],
+        "plugins": {},
+        "tools": {},
+    }
+    slice_ = extract_agent_slice(cfg, "agent_abc")
+    assert slice_["agent"]["name"] == "Pitch"
+
+
+def test_extract_agent_slice_missing_raises_when_only_non_dicts_match():
+    """If the only 'matching' entries are non-dict strings, still raise KeyError —
+    the behavior should match 'agent not found' rather than silently succeeding."""
+    cfg = {"agents": ["agent_abc", None], "plugins": {}, "tools": {}}
+    with pytest.raises(KeyError):
+        extract_agent_slice(cfg, "agent_abc")
+
+
 def test_strip_user_specific_fields_removes_model():
     agent = dict(FULL_OPENCLAW_JSON["agents"][0])
     cleaned = strip_user_specific_fields(agent)


### PR DESCRIPTION
## Root cause — live prod 500 after PR #386 landed

\`\`\`
File "/app/core/services/catalog_service.py", line 248, in publish
File "/app/core/services/catalog_slice.py", line 34, in extract_agent_slice
AttributeError: 'str' object has no attribute 'get'
\`\`\`

The first end-to-end publish attempt after PR #386 got past the owner_id gate (org EFS read succeeded), then crashed in `extract_agent_slice` because the org's openclaw.json has at least one non-dict entry in the `agents` list — probably a bare string from hand-editing or an OpenClaw runtime write pattern. `a.get("id")` on a string raises AttributeError, which blows up the whole publish.

## Fix

Filter with `isinstance(a, dict)` before calling `.get()` in both `extract_agent_slice()` and the mirrored `next()` in `catalog_service.publish()`. If the only 'matching' entries are non-dicts, we still raise `KeyError("agent not found")` rather than silently succeeding.

## Tests

- `test_extract_agent_slice_tolerates_non_dict_entries_in_agents` — mixed list of a stray string, a valid dict, a `None` → publishes fine.
- `test_extract_agent_slice_missing_raises_when_only_non_dicts_match` — list of only non-dicts → raises KeyError as before.

## Verification
- 54 tests pass (catalog_slice + catalog_service + routers_catalog)
- ruff check + format clean