### PR TITLE
fix(catalog): read/write agents.list nested path (OpenClaw schema)

### DIFF
--- a/apps/backend/core/services/catalog_service.py
+++ b/apps/backend/core/services/catalog_service.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
 from core.services.catalog_package import build_manifest, tar_directory
-from core.services.catalog_slice import extract_agent_slice
+from core.services.catalog_slice import _agents_list, extract_agent_slice
 
 # Catalog slugs become a single S3 key path segment (e.g. "pitch/v1/..."),
 # so reject anything that could inject additional segments, reserved
@@ -246,9 +246,8 @@ class CatalogService:
             raise FileNotFoundError(f"admin {admin_user_id} (owner {owner_id}) has no openclaw.json")
 
         slice_ = extract_agent_slice(config, agent_id)
-        # Same non-dict tolerance as extract_agent_slice() — if we got past
-        # that, the dict entry exists; just mirror its filter here too.
-        agent_entry_raw = next(a for a in config["agents"] if isinstance(a, dict) and a.get("id") == agent_id)
+        # Read from the nested agents.list the same way extract_agent_slice does.
+        agent_entry_raw = next(a for a in _agents_list(config) if isinstance(a, dict) and a.get("id") == agent_id)
 
         name = agent_entry_raw.get("name") or agent_id
         slug = (slug_override or name).strip().lower().replace(" ", "-")

--- a/apps/backend/core/services/catalog_slice.py
+++ b/apps/backend/core/services/catalog_slice.py
@@ -27,7 +27,7 @@ def strip_user_specific_fields(agent_entry: dict[str, Any]) -> dict[str, Any]:
 
 
 def _agents_list(openclaw_json: dict[str, Any]) -> list[Any]:
-    """Return the ``agents.list`` array from an openclaw.json.
+    """Return the agent-entry array from an openclaw.json.
 
     OpenClaw's config schema (zod: ``openclaw/src/config/zod-schema.agents.ts``):
 
@@ -35,10 +35,14 @@ def _agents_list(openclaw_json: dict[str, Any]) -> list[Any]:
 
     Early versions of the Isol8 catalog code read ``config["agents"]`` as if it
     were a flat list — that worked only for configs that didn't exist, which
-    is why it went unnoticed until the first real publish attempt. Real configs
-    nest the array under ``agents.list``.
+    is why it went unnoticed until the first real publish attempt. The write
+    path (``config_patcher.apply_deploy_mutation``) migrates flat-list configs
+    to the nested shape on deploy; this reader accepts BOTH so an admin with a
+    legacy config can still publish without first triggering a migration.
     """
     agents = openclaw_json.get("agents")
+    if isinstance(agents, list):
+        return agents  # legacy flat shape — tolerated for read/publish
     if not isinstance(agents, dict):
         return []
     lst = agents.get("list")

--- a/apps/backend/core/services/catalog_slice.py
+++ b/apps/backend/core/services/catalog_slice.py
@@ -26,17 +26,34 @@ def strip_user_specific_fields(agent_entry: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _agents_list(openclaw_json: dict[str, Any]) -> list[Any]:
+    """Return the ``agents.list`` array from an openclaw.json.
+
+    OpenClaw's config schema (zod: ``openclaw/src/config/zod-schema.agents.ts``):
+
+        agents: { defaults: AgentDefaults, list: AgentEntry[] }
+
+    Early versions of the Isol8 catalog code read ``config["agents"]`` as if it
+    were a flat list — that worked only for configs that didn't exist, which
+    is why it went unnoticed until the first real publish attempt. Real configs
+    nest the array under ``agents.list``.
+    """
+    agents = openclaw_json.get("agents")
+    if not isinstance(agents, dict):
+        return []
+    lst = agents.get("list")
+    return lst if isinstance(lst, list) else []
+
+
 def extract_agent_slice(openclaw_json: dict[str, Any], agent_id: str) -> dict[str, Any]:
     """Return a dict with the sliced agent entry plus the required plugins/tools
     from the publisher's config. Raises KeyError if the agent_id isn't present.
 
-    Tolerates malformed entries in ``agents``. Live prod configs have been
-    observed with non-dict entries (e.g. bare strings) mixed in with the
-    full dict entries — probably from hand-editing or an OpenClaw runtime
-    write pattern we don't fully mirror. Skip anything that isn't a dict
-    rather than crashing the whole publish with AttributeError.
+    Also tolerates stray non-dict entries in ``agents.list`` (bare strings have
+    been observed from hand-editing / partial runtime writes) — skip anything
+    that isn't a dict rather than crashing with AttributeError.
     """
-    agents = openclaw_json.get("agents") or []
+    agents = _agents_list(openclaw_json)
     matching = [a for a in agents if isinstance(a, dict) and a.get("id") == agent_id]
     if not matching:
         raise KeyError(f"agent {agent_id!r} not found in openclaw.json")

--- a/apps/backend/core/services/config_patcher.py
+++ b/apps/backend/core/services/config_patcher.py
@@ -262,10 +262,15 @@ async def apply_deploy_mutation(
 
     def _mutate(current: dict) -> bool:
         # 1. Append agent entry (always mutates — each deploy gets a fresh id).
-        # OpenClaw schema: agents.list is the array; agents.defaults is siblings.
-        # See openclaw/src/config/zod-schema.agents.ts.
+        # OpenClaw schema: agents.list is the array; agents.defaults is its
+        # sibling. See openclaw/src/config/zod-schema.agents.ts.
         agents_obj = current.get("agents")
-        if not isinstance(agents_obj, dict):
+        if isinstance(agents_obj, list):
+            # Legacy flat-list shape from pre-schema-fix deploys: migrate by
+            # promoting the list under `agents.list` so existing entries
+            # survive rather than getting silently clobbered.
+            agents_obj = {"list": list(agents_obj)}
+        elif not isinstance(agents_obj, dict):
             agents_obj = {}
         agents_list = agents_obj.get("list")
         if not isinstance(agents_list, list):

--- a/apps/backend/core/services/config_patcher.py
+++ b/apps/backend/core/services/config_patcher.py
@@ -262,11 +262,17 @@ async def apply_deploy_mutation(
 
     def _mutate(current: dict) -> bool:
         # 1. Append agent entry (always mutates — each deploy gets a fresh id).
-        agents = current.get("agents")
-        if not isinstance(agents, list):
-            agents = []
-        agents.append(copy.deepcopy(agent_entry))
-        current["agents"] = agents
+        # OpenClaw schema: agents.list is the array; agents.defaults is siblings.
+        # See openclaw/src/config/zod-schema.agents.ts.
+        agents_obj = current.get("agents")
+        if not isinstance(agents_obj, dict):
+            agents_obj = {}
+        agents_list = agents_obj.get("list")
+        if not isinstance(agents_list, list):
+            agents_list = []
+        agents_list.append(copy.deepcopy(agent_entry))
+        agents_obj["list"] = agents_list
+        current["agents"] = agents_obj
 
         # 2. Deep-merge plugins.
         if plugins_patch:

--- a/apps/backend/tests/unit/services/test_config_patcher.py
+++ b/apps/backend/tests/unit/services/test_config_patcher.py
@@ -504,6 +504,40 @@ async def test_apply_deploy_mutation_sequential_deploys_keep_both_agents(catalog
 
 
 @pytest.mark.asyncio
+async def test_apply_deploy_mutation_migrates_legacy_flat_list(catalog_efs_dir):
+    """Codex P1 regression: if a config exists with the old flat-list shape
+    (``agents: [...]``) from pre-schema-fix deploys, we must PROMOTE it into
+    ``agents.list`` — not silently drop the existing entries."""
+    config_path = os.path.join(catalog_efs_dir, "user_1", "openclaw.json")
+    with open(config_path, "w") as f:
+        json.dump(
+            {
+                "agents": [
+                    {"id": "legacy_a", "name": "Legacy A"},
+                    {"id": "legacy_b", "name": "Legacy B"},
+                ],
+                "plugins": {},
+                "tools": {"allowed": []},
+            },
+            f,
+        )
+
+    await apply_deploy_mutation(
+        "user_1",
+        {"id": "fresh", "name": "Fresh"},
+        {},
+        [],
+    )
+    with open(config_path) as f:
+        result = json.load(f)
+
+    # Legacy entries preserved + new entry appended, all under agents.list.
+    assert isinstance(result["agents"], dict)
+    agent_ids = [a["id"] for a in result["agents"]["list"]]
+    assert agent_ids == ["legacy_a", "legacy_b", "fresh"]
+
+
+@pytest.mark.asyncio
 async def test_apply_deploy_mutation_preserves_agents_defaults(catalog_efs_dir):
     """Adding an agent to agents.list must NOT drop agents.defaults — that's
     where OpenClaw keeps shared workspace / model / hook config."""

--- a/apps/backend/tests/unit/services/test_config_patcher.py
+++ b/apps/backend/tests/unit/services/test_config_patcher.py
@@ -416,12 +416,13 @@ async def test_delete_path_missing_intermediate_is_noop(tmp_efs_with_multi_accou
 
 @pytest.fixture
 def catalog_efs_dir():
-    """EFS fixture where `agents` is a list (catalog publisher/deploy shape)."""
+    """EFS fixture with the real OpenClaw ``agents.list`` schema
+    (see openclaw/src/config/zod-schema.agents.ts)."""
     with tempfile.TemporaryDirectory() as tmpdir:
         user_dir = os.path.join(tmpdir, "user_1")
         os.makedirs(user_dir)
         config = {
-            "agents": [{"id": "existing_agent", "name": "Existing"}],
+            "agents": {"list": [{"id": "existing_agent", "name": "Existing"}]},
             "plugins": {"memory": {"enabled": True}},
             "tools": {"allowed": ["web-search"]},
         }
@@ -443,8 +444,8 @@ async def test_apply_deploy_mutation_appends_agent_and_unions_tools(catalog_efs_
     with open(os.path.join(catalog_efs_dir, "user_1", "openclaw.json")) as f:
         result = json.load(f)
 
-    # Agent was appended, existing one preserved.
-    agent_ids = [a["id"] for a in result["agents"]]
+    # Agent was appended to agents.list, existing one preserved.
+    agent_ids = [a["id"] for a in result["agents"]["list"]]
     assert agent_ids == ["existing_agent", "new_agent"]
 
     # Plugins deep-merged.
@@ -457,8 +458,8 @@ async def test_apply_deploy_mutation_appends_agent_and_unions_tools(catalog_efs_
 
 @pytest.mark.asyncio
 async def test_apply_deploy_mutation_creates_missing_containers(catalog_efs_dir):
-    # Start with an empty-ish config to verify creation paths for
-    # missing agents / tools.allowed.
+    # Start with an empty config to verify creation paths for
+    # missing agents.list / tools.allowed.
     config_path = os.path.join(catalog_efs_dir, "user_1", "openclaw.json")
     with open(config_path, "w") as f:
         json.dump({}, f)
@@ -472,7 +473,7 @@ async def test_apply_deploy_mutation_creates_missing_containers(catalog_efs_dir)
     with open(config_path) as f:
         result = json.load(f)
 
-    assert result["agents"] == [{"id": "first", "name": "First"}]
+    assert result["agents"] == {"list": [{"id": "first", "name": "First"}]}
     assert result["tools"]["allowed"] == ["skill-a"]
 
 
@@ -480,7 +481,7 @@ async def test_apply_deploy_mutation_creates_missing_containers(catalog_efs_dir)
 async def test_apply_deploy_mutation_sequential_deploys_keep_both_agents(catalog_efs_dir):
     """Sequential deploys must both land without clobbering each other —
     this is what the deploy path actually exercises now that the
-    read-modify-write of the agents list happens inside the lock."""
+    read-modify-write of agents.list happens inside the lock."""
     await apply_deploy_mutation(
         "user_1",
         {"id": "agent_a", "name": "A"},
@@ -496,7 +497,36 @@ async def test_apply_deploy_mutation_sequential_deploys_keep_both_agents(catalog
     with open(os.path.join(catalog_efs_dir, "user_1", "openclaw.json")) as f:
         result = json.load(f)
 
-    agent_ids = [a["id"] for a in result["agents"]]
+    agent_ids = [a["id"] for a in result["agents"]["list"]]
     assert agent_ids == ["existing_agent", "agent_a", "agent_b"]
     # Both tools survive — union not replace.
     assert set(result["tools"]["allowed"]) == {"tool-a", "tool-b", "web-search"}
+
+
+@pytest.mark.asyncio
+async def test_apply_deploy_mutation_preserves_agents_defaults(catalog_efs_dir):
+    """Adding an agent to agents.list must NOT drop agents.defaults — that's
+    where OpenClaw keeps shared workspace / model / hook config."""
+    config_path = os.path.join(catalog_efs_dir, "user_1", "openclaw.json")
+    with open(config_path, "w") as f:
+        json.dump(
+            {
+                "agents": {
+                    "defaults": {"workspace": "/workspace/root"},
+                    "list": [{"id": "existing_agent", "name": "Existing"}],
+                },
+            },
+            f,
+        )
+
+    await apply_deploy_mutation(
+        "user_1",
+        {"id": "new", "name": "N"},
+        {},
+        [],
+    )
+    with open(config_path) as f:
+        result = json.load(f)
+
+    assert result["agents"]["defaults"] == {"workspace": "/workspace/root"}
+    assert [a["id"] for a in result["agents"]["list"]] == ["existing_agent", "new"]

--- a/apps/backend/tests/unit/test_catalog_service.py
+++ b/apps/backend/tests/unit/test_catalog_service.py
@@ -189,18 +189,20 @@ async def test_deploy_rolls_back_workspace_on_patch_failure(service, mock_s3, mo
 @pytest.mark.asyncio
 async def test_publish_reads_admin_efs_and_uploads_package(service, mock_s3, mock_workspace, tmp_path):
     mock_workspace.read_openclaw_config.return_value = {
-        "agents": [
-            {
-                "id": "agent_admin_pitch",
-                "workspace": ".openclaw/workspaces/agent_admin_pitch",
-                "name": "Pitch",
-                "emoji": "🎯",
-                "vibe": "Direct",
-                "model": "qwen/qwen3-vl-235b",
-                "skills": ["web-search"],
-                "channels": {"telegram": {"bot_token": "SECRET"}},
-            }
-        ],
+        "agents": {
+            "list": [
+                {
+                    "id": "agent_admin_pitch",
+                    "workspace": ".openclaw/workspaces/agent_admin_pitch",
+                    "name": "Pitch",
+                    "emoji": "🎯",
+                    "vibe": "Direct",
+                    "model": "qwen/qwen3-vl-235b",
+                    "skills": ["web-search"],
+                    "channels": {"telegram": {"bot_token": "SECRET"}},
+                }
+            ]
+        },
         "plugins": {"memory": {"enabled": True}},
         "tools": {"allowed": ["web-search"]},
     }
@@ -241,7 +243,7 @@ async def test_publish_reads_admin_efs_and_uploads_package(service, mock_s3, moc
 @pytest.mark.asyncio
 async def test_publish_rejects_invalid_slug(service, mock_s3, mock_workspace, tmp_path):
     mock_workspace.read_openclaw_config.return_value = {
-        "agents": [{"id": "a1", "name": "Pitch", "skills": []}],
+        "agents": {"list": [{"id": "a1", "name": "Pitch", "skills": []}]},
         "plugins": {},
         "tools": {},
     }
@@ -287,7 +289,7 @@ async def test_publish_rejects_invalid_slug(service, mock_s3, mock_workspace, tm
 @pytest.mark.asyncio
 async def test_publish_bumps_version_when_prior_exists(service, mock_s3, mock_workspace, tmp_path):
     mock_workspace.read_openclaw_config.return_value = {
-        "agents": [{"id": "a1", "name": "Pitch", "skills": []}],
+        "agents": {"list": [{"id": "a1", "name": "Pitch", "skills": []}]},
         "plugins": {},
         "tools": {},
     }
@@ -379,7 +381,7 @@ async def test_unpublish_handles_missing_retired_key(service, mock_s3):
 async def test_publish_removes_retired_entry_when_republishing(service, mock_s3, mock_workspace, tmp_path):
     """Republishing a retired slug removes it from retired and adds it to agents."""
     mock_workspace.read_openclaw_config.return_value = {
-        "agents": [{"id": "a1", "name": "Pitch", "skills": []}],
+        "agents": {"list": [{"id": "a1", "name": "Pitch", "skills": []}]},
         "plugins": {},
         "tools": {},
     }
@@ -557,14 +559,16 @@ def test_list_versions_skips_missing_manifest(service, mock_s3):
 async def test_publish_uses_passed_owner_id_for_efs_reads(mock_s3, mock_workspace, mock_apply_deploy, tmp_path):
     """Org-context: caller passes owner_id=org_id; EFS reads use it; published_by stays admin_user_id."""
     mock_workspace.read_openclaw_config.return_value = {
-        "agents": [
-            {
-                "id": "agent_admin_pitch",
-                "workspace": ".openclaw/workspaces/agent_admin_pitch",
-                "name": "Pitch",
-                "skills": ["web-search"],
-            }
-        ],
+        "agents": {
+            "list": [
+                {
+                    "id": "agent_admin_pitch",
+                    "workspace": ".openclaw/workspaces/agent_admin_pitch",
+                    "name": "Pitch",
+                    "skills": ["web-search"],
+                }
+            ]
+        },
         "plugins": {"memory": {"enabled": True}},
         "tools": {"allowed": ["web-search"]},
     }
@@ -603,7 +607,7 @@ async def test_publish_uses_passed_owner_id_for_efs_reads(mock_s3, mock_workspac
 async def test_publish_personal_mode_owner_equals_admin_user_id(mock_s3, mock_workspace, mock_apply_deploy, tmp_path):
     """Personal mode: caller passes owner_id == admin_user_id; everything keys off it."""
     mock_workspace.read_openclaw_config.return_value = {
-        "agents": [{"id": "a1", "name": "Pitch", "skills": []}],
+        "agents": {"list": [{"id": "a1", "name": "Pitch", "skills": []}]},
         "plugins": {},
         "tools": {},
     }

--- a/apps/backend/tests/unit/test_catalog_slice.py
+++ b/apps/backend/tests/unit/test_catalog_slice.py
@@ -66,29 +66,31 @@ def test_extract_agent_slice_tolerates_non_dict_entries_in_agents_list():
 
 
 def test_extract_agent_slice_raises_when_agents_missing_or_malformed():
-    """Missing agents key, non-dict agents, or missing .list → treat as empty."""
+    """Missing agents key, non-dict/non-list agents, or missing .list → empty."""
     for cfg in [
         {"plugins": {}, "tools": {}},
         {"agents": None, "plugins": {}, "tools": {}},
-        {"agents": [], "plugins": {}, "tools": {}},  # legacy flat list — now ignored
+        {"agents": [], "plugins": {}, "tools": {}},  # empty flat list
         {"agents": {"defaults": {"workspace": "/x"}}, "plugins": {}, "tools": {}},
     ]:
         with pytest.raises(KeyError):
             extract_agent_slice(cfg, "agent_abc")
 
 
-def test_extract_agent_slice_legacy_flat_list_is_no_longer_read():
-    """Prod regression guard: if we ever see a config using the OLD flat-list
-    shape (``agents: [...]``) we must NOT silently read it — that shape isn't
-    OpenClaw's real schema and would produce a mutated deploy target on write.
-    Expect KeyError instead."""
+def test_extract_agent_slice_accepts_legacy_flat_list():
+    """Codex P2 regression: admins whose configs are still in the legacy flat
+    shape (``agents: [...]``) must still be able to publish. The write path
+    in config_patcher migrates the shape on deploy; the read path here
+    tolerates it so we don't regress working admins while they wait for a
+    migration write."""
     cfg = {
-        "agents": [{"id": "agent_abc", "name": "Pitch"}],
-        "plugins": {},
-        "tools": {},
+        "agents": [{"id": "agent_abc", "name": "Pitch", "skills": ["web-search"]}],
+        "plugins": {"memory": {"enabled": True}},
+        "tools": {"allowed": ["web-search"]},
     }
-    with pytest.raises(KeyError):
-        extract_agent_slice(cfg, "agent_abc")
+    slice_ = extract_agent_slice(cfg, "agent_abc")
+    assert slice_["agent"]["name"] == "Pitch"
+    assert slice_["plugins"] == {"memory": {"enabled": True}}
 
 
 def test_strip_user_specific_fields_removes_model():

--- a/apps/backend/tests/unit/test_catalog_slice.py
+++ b/apps/backend/tests/unit/test_catalog_slice.py
@@ -8,19 +8,24 @@ from core.services.catalog_slice import (
 
 FULL_OPENCLAW_JSON = {
     "defaultAgentId": "agent_abc",
-    "agents": [
-        {
-            "id": "agent_abc",
-            "workspace": ".openclaw/workspaces/agent_abc",
-            "name": "Pitch",
-            "model": "qwen/qwen3-vl-235b",
-            "thinkingDefault": True,
-            "skills": ["web-search", "email-send"],
-            "channels": {"telegram": {"bot_token": "SECRET"}},
-            "cron": [{"schedule": "0 8 * * *", "workflow": "morning-briefing"}],
-        },
-        {"id": "agent_zzz", "name": "Other"},
-    ],
+    # Matches upstream OpenClaw schema (openclaw/src/config/zod-schema.agents.ts):
+    # agents: { defaults?, list?: AgentEntry[] }
+    "agents": {
+        "defaults": {"workspace": "/workspace/root"},
+        "list": [
+            {
+                "id": "agent_abc",
+                "workspace": ".openclaw/workspaces/agent_abc",
+                "name": "Pitch",
+                "model": "qwen/qwen3-vl-235b",
+                "thinkingDefault": True,
+                "skills": ["web-search", "email-send"],
+                "channels": {"telegram": {"bot_token": "SECRET"}},
+                "cron": [{"schedule": "0 8 * * *", "workflow": "morning-briefing"}],
+            },
+            {"id": "agent_zzz", "name": "Other"},
+        ],
+    },
     "plugins": {"memory": {"enabled": True}},
     "tools": {"allowed": ["web-search", "email-send"]},
 }
@@ -42,16 +47,17 @@ def test_extract_agent_slice_missing_agent_raises():
         extract_agent_slice(FULL_OPENCLAW_JSON, "agent_does_not_exist")
 
 
-def test_extract_agent_slice_tolerates_non_dict_entries_in_agents():
-    """Live prod regression: publish crashed with AttributeError when openclaw.json's
-    agents list had a bare string alongside the dict entries. Skip non-dicts
-    rather than calling .get() on them."""
+def test_extract_agent_slice_tolerates_non_dict_entries_in_agents_list():
+    """Live prod regression: publish crashed with AttributeError when
+    ``agents.list`` had a bare string alongside the dict entries."""
     cfg = {
-        "agents": [
-            "some-stray-string",  # malformed entry — should be skipped, not crash
-            {"id": "agent_abc", "name": "Pitch", "skills": ["web-search"]},
-            None,  # another malformed variant
-        ],
+        "agents": {
+            "list": [
+                "some-stray-string",
+                {"id": "agent_abc", "name": "Pitch", "skills": ["web-search"]},
+                None,
+            ],
+        },
         "plugins": {},
         "tools": {},
     }
@@ -59,40 +65,58 @@ def test_extract_agent_slice_tolerates_non_dict_entries_in_agents():
     assert slice_["agent"]["name"] == "Pitch"
 
 
-def test_extract_agent_slice_missing_raises_when_only_non_dicts_match():
-    """If the only 'matching' entries are non-dict strings, still raise KeyError —
-    the behavior should match 'agent not found' rather than silently succeeding."""
-    cfg = {"agents": ["agent_abc", None], "plugins": {}, "tools": {}}
+def test_extract_agent_slice_raises_when_agents_missing_or_malformed():
+    """Missing agents key, non-dict agents, or missing .list → treat as empty."""
+    for cfg in [
+        {"plugins": {}, "tools": {}},
+        {"agents": None, "plugins": {}, "tools": {}},
+        {"agents": [], "plugins": {}, "tools": {}},  # legacy flat list — now ignored
+        {"agents": {"defaults": {"workspace": "/x"}}, "plugins": {}, "tools": {}},
+    ]:
+        with pytest.raises(KeyError):
+            extract_agent_slice(cfg, "agent_abc")
+
+
+def test_extract_agent_slice_legacy_flat_list_is_no_longer_read():
+    """Prod regression guard: if we ever see a config using the OLD flat-list
+    shape (``agents: [...]``) we must NOT silently read it — that shape isn't
+    OpenClaw's real schema and would produce a mutated deploy target on write.
+    Expect KeyError instead."""
+    cfg = {
+        "agents": [{"id": "agent_abc", "name": "Pitch"}],
+        "plugins": {},
+        "tools": {},
+    }
     with pytest.raises(KeyError):
         extract_agent_slice(cfg, "agent_abc")
 
 
 def test_strip_user_specific_fields_removes_model():
-    agent = dict(FULL_OPENCLAW_JSON["agents"][0])
+    agent = dict(FULL_OPENCLAW_JSON["agents"]["list"][0])
     cleaned = strip_user_specific_fields(agent)
     assert "model" not in cleaned
 
 
 def test_strip_user_specific_fields_removes_channels():
-    agent = dict(FULL_OPENCLAW_JSON["agents"][0])
+    agent = dict(FULL_OPENCLAW_JSON["agents"]["list"][0])
     cleaned = strip_user_specific_fields(agent)
     assert "channels" not in cleaned
 
 
 def test_strip_user_specific_fields_removes_workspace_path():
-    agent = dict(FULL_OPENCLAW_JSON["agents"][0])
+    agent = dict(FULL_OPENCLAW_JSON["agents"]["list"][0])
     cleaned = strip_user_specific_fields(agent)
     assert "workspace" not in cleaned
 
 
 def test_strip_user_specific_fields_removes_id():
-    agent = dict(FULL_OPENCLAW_JSON["agents"][0])
+    agent = dict(FULL_OPENCLAW_JSON["agents"]["list"][0])
     cleaned = strip_user_specific_fields(agent)
     assert "id" not in cleaned
 
 
 def test_strip_user_specific_fields_keeps_behavioral_flags():
-    agent = dict(FULL_OPENCLAW_JSON["agents"][0])
+    agent = dict(FULL_OPENCLAW_JSON["agents"]["list"][0])
     cleaned = strip_user_specific_fields(agent)
     assert cleaned["thinkingDefault"] is True
     assert cleaned["skills"] == ["web-search", "email-send"]


### PR DESCRIPTION
## Root cause — 4th layer

After PR #387 skipped non-dict entries gracefully, prod publish returned a clean `KeyError: agent 'pulse' not found in openclaw.json` — but the admin detail page clearly shows pulse on the container. The config schema differs from what the catalog code assumed.

## OpenClaw's actual schema

`openclaw/src/config/zod-schema.agents.ts`:
```ts
agents: z.object({
  defaults: AgentDefaultsSchema.optional(),
  list: z.array(AgentEntrySchema).optional(),
}).strict().optional()
```

So the correct path to the agent array is `config["agents"]["list"]`, not `config["agents"]`.

## Existing code — all wrong

| Layer | Was | Should be |
|---|---|---|
| `catalog_slice.extract_agent_slice` | `agents = config.get("agents") or []` | `agents = config["agents"]["list"]` |
| `catalog_service.publish` (secondary lookup) | `config["agents"]` | `_agents_list(config)` helper |
| `config_patcher.apply_deploy_mutation` | appends to `config["agents"]` list | appends to `config["agents"]["list"]`, preserves `defaults` |

For real configs, `config["agents"]` is a dict (`{defaults, list}`). Iterating yielded the dict's **keys** (`"defaults"`, `"list"`) — strings. PR #387's non-dict guard correctly filtered them all out → KeyError.

## Fix

- New `_agents_list()` helper in `catalog_slice` so all three code paths agree on the schema.
- `config_patcher` preserves `agents.defaults` on deploy (new regression test).
- Legacy flat-list shape is now **not** silently accepted — a test asserts it raises KeyError (avoids producing mutated deploy targets on write).

## Tests — 83 pass

- `test_catalog_slice.py` fixtures switched to nested schema + 2 new tests
- `test_catalog_service.py` fixtures auto-migrated (6 `read_openclaw_config` sites)
- `test_config_patcher.py` fixtures switched + `test_apply_deploy_mutation_preserves_agents_defaults`
- `test_routers_catalog.py` unchanged
- ruff check + format clean